### PR TITLE
feat: allow overriding marker storage directory for CI / commit sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,27 @@ git so CI sees it without any cache layer, skip to
 [Pattern B](#b-committed-files-hash) — that's a different shape, not
 a variant of this one.)
 
+> **⚠ Required for `hash: git-tree` + state dir inside the repo:
+> gitignore the state dir.** Not hygiene — *required*. The `git-tree`
+> digest includes untracked-not-ignored files, and the marker itself
+> is an untracked file. Without gitignore:
+>
+> 1. `markgate run` computes digest_1 (before the marker exists) and
+>    saves the marker with digest_1.
+> 2. The saved marker file now exists as untracked-not-ignored.
+> 3. The next `markgate verify` computes digest_2 — which *includes*
+>    the marker file — so digest_2 ≠ digest_1 → mismatch → the check
+>    re-runs every time. The feature is defeated on the first verify,
+>    before any commit.
+>
+> Gitignoring the state dir keeps the marker out of the digest.
+> Placing the state dir outside the repo (absolute path,
+> `$RUNNER_TEMP/...`, etc.) also works — untracked-not-ignored only
+> applies to files under the repo tree.
+>
+> `hash: files` sidesteps this: the marker is only in the digest if a
+> glob matches it. Gitignore is optional on `files` — pure hygiene.
+
 **Across runs of the same workflow** — `actions/cache`:
 
 ```yaml
@@ -424,17 +445,8 @@ jobs:
       - run: markgate run pre-image-push --state-dir .markgate-cache -- trivy fs .
 ```
 
-When the dir lives inside the repo, gitignore it **if you use
-`hash: git-tree`**. Why: an accidental `git add .` + commit pulls
-the marker into the commit, which changes HEAD, which stales the
-digest the marker just recorded — so the very next `verify` fails
-and the check runs again, defeating the whole point. Gitignoring the
-dir makes that accident impossible.
-
-With `hash: files` the marker survives being committed (it's outside
-the digest scope), so gitignoring is optional on that hash — treat
-it as hygiene (keeps `git status` clean, signals that these aren't
-tracked artifacts).
+Make sure `.markgate-cache/` is in `.gitignore` before the first run
+(see the warning above for why it's required on `git-tree`).
 
 **Across jobs within one workflow** — `actions/upload-artifact` →
 `actions/download-artifact`. A setup job runs the expensive check

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ command.)
 Your agent (or you) just ran `make check`. The commit hook runs it
 again. `gh pr create` runs it again. CI runs it again — four passes,
 one change. `markgate` lets the second / third / fourth of those exit
-instantly when the repo state hasn't moved.
+instantly when the repo state hasn't moved. (The CI pass needs a bit
+of extra wiring — see [Sharing markers](#sharing-markers-across-machines-ci--teammates).)
 
 Concrete gates you can build (see [Use cases](#use-cases) for full
 configs):
@@ -355,6 +356,166 @@ go test -cover && markgate set pre-push
 markgate verify pre-push || exit 1
 ```
 
+## Sharing markers across machines (CI / teammates)
+
+By default, markers live under `.git/markgate/` — strictly local. If
+that's all you need, skip this section; the [use cases above](#use-cases)
+all work with the default.
+
+Read on if you want a check to **skip in CI (or on a teammate's
+machine) based on a run that already happened elsewhere**. Typical
+wins: coverage, vulnerability scan, e2e, image build — expensive and
+deterministic, redundant to re-run. Don't use it for security
+boundaries (supply-chain audit, permission scan); those should stay
+fresh in CI.
+
+### Specifying a non-default location
+
+Three sources, in precedence order (flag beats env beats config):
+
+```text
+--state-dir <dir>           # per-invocation flag
+MARKGATE_STATE_DIR=<dir>    # environment variable
+state_dir: <dir>            # in .markgate.yml, per gate
+```
+
+The marker is written at `<dir>/<key>.json` (no extra `markgate/`
+subdirectory). Relative paths resolve against the repo top-level, so
+the location is stable regardless of cwd — identical on every machine
+that checks out the repo.
+
+### Two patterns at a glance
+
+Both use `--state-dir` / `state_dir`; the difference is whether the
+marker is **committed** to the repo.
+
+| aspect | **A. Not committed** (CI cache / artifact) | **B. Committed** |
+|---|---|---|
+| Marker in the repo? | No (typically gitignored, or outside the repo) | Yes, tracked in git |
+| Works with hash type | `git-tree` or `files` | **`files` only** — committing with `git-tree` breaks: the commit changes HEAD → digest is instantly stale |
+| Local → CI sharing | Needs CI cache / artifact / shared volume | Just `git push` |
+| Tamper surface | Whoever can write to the cache | Whoever has commit access |
+| Extra infra | CI cache provider (e.g. `actions/cache`, `actions/upload-artifact`) | None — git is enough |
+| Best for | CI-internal reuse across runs; teams already on remote cache infra | Zero-infra local→CI sharing for `files`-hash gates (coverage, scans) |
+
+### A. Not committed (CI cache / artifact)
+
+Store the marker somewhere CI can pick it up, but keep it out of git.
+`.markgate-cache/` at the repo root is a conventional choice; any
+path outside `.git/` works. (If you'd rather commit the marker into
+git so CI sees it without any cache layer, skip to
+[Pattern B](#b-committed-files-hash) — that's a different shape, not
+a variant of this one.)
+
+**Across runs of the same workflow** — `actions/cache`:
+
+```yaml
+# .github/workflows/scan.yml
+jobs:
+  scan:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: .markgate-cache
+          key: markgate-scan-${{ github.sha }}
+          restore-keys: |
+            markgate-scan-
+      - run: markgate run pre-image-push --state-dir .markgate-cache -- trivy fs .
+```
+
+When the dir lives inside the repo, gitignore it **if you use
+`hash: git-tree`**. Why: an accidental `git add .` + commit pulls
+the marker into the commit, which changes HEAD, which stales the
+digest the marker just recorded — so the very next `verify` fails
+and the check runs again, defeating the whole point. Gitignoring the
+dir makes that accident impossible.
+
+With `hash: files` the marker survives being committed (it's outside
+the digest scope), so gitignoring is optional on that hash — treat
+it as hygiene (keeps `git status` clean, signals that these aren't
+tracked artifacts).
+
+**Across jobs within one workflow** — `actions/upload-artifact` →
+`actions/download-artifact`. A setup job runs the expensive check
+once; matrix jobs on the same commit download the marker and skip:
+
+```yaml
+jobs:
+  verify:
+    steps:
+      - uses: actions/checkout@v4
+      - run: markgate run expensive --state-dir .markgate-cache -- make expensive-check
+      - uses: actions/upload-artifact@v4
+        with:
+          name: markgate-state
+          path: .markgate-cache
+
+  fan-out:
+    needs: verify
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: markgate-state
+          path: .markgate-cache
+      - run: markgate verify expensive --state-dir .markgate-cache || make expensive-check
+```
+
+### B. Committed (files hash)
+
+Keep the state directory **tracked in git** and commit the marker with
+the code. Works only with `hash: files`: `git-tree` would change HEAD
+on the commit and invalidate the marker it just wrote.
+
+Typical fit: coverage reports, image vulnerability scans — expensive,
+deterministic, and already re-running them on every push is waste
+when nothing in scope changed.
+
+Coverage example (extending the pre-push gate from
+[Use case 4](#4-pre-push-coverage-report-freshness)):
+
+```yaml
+# .markgate.yml
+gates:
+  coverage:
+    hash: files
+    include:
+      - "src/**"
+      - "tests/**"
+    state_dir: .markgate-state
+```
+
+```sh
+# Locally, after a successful coverage run:
+markgate run coverage -- go test -cover ./...
+git add .markgate-state/coverage.json
+git commit -m "bump coverage marker"
+git push
+
+# In CI (already sees the committed marker):
+markgate verify coverage || go test -cover ./...
+```
+
+Trust model: anyone with commit access can forge a skip. Use committed
+markers where commit-access already implies trust in the signal.
+
+### Notes
+
+- **Worktree isolation is lost** when the dir is shared across
+  worktrees pointing at the same location. The default `.git/`-based
+  layout preserves isolation; `--state-dir` does not.
+- **Relative paths** resolve from the repo top-level, not cwd, so
+  hook-invoked commands land in the same place regardless of where
+  they run from.
+- **Signing is not yet implemented** — markers are unsigned JSON.
+  Tamper resistance depends on who can write to the directory (cache /
+  repo).
+
 ## CLI reference
 
 ```text
@@ -376,6 +537,10 @@ so one-off scopes don't need a `.markgate.yml`:
 --hash git-tree|files    Override hash type for this call.
 --include <glob>         Repeatable. Override the gate's include list.
 --exclude <glob>         Repeatable. Override the gate's exclude list.
+--state-dir <path>       Directory to store marker files. Takes
+                         precedence over MARKGATE_STATE_DIR env and
+                         state_dir: in .markgate.yml. Default:
+                         <git-dir>/markgate. See "Sharing markers".
 ```
 
 Flag syntax is identical across hash types. With `--hash files`,
@@ -386,12 +551,30 @@ config file:
 markgate run --exclude 'vendor/**' -- make check
 ```
 
+### Environment variables
+
+```text
+MARKGATE_STATE_DIR       Marker storage directory. Same effect as
+                         --state-dir and state_dir: in config.
+                         Precedence: --state-dir > this env >
+                         state_dir: in .markgate.yml > default.
+```
+
 ## `.markgate.yml` (optional)
 
 Only needed for multiple gates, or for `files` hash, or to persist
-include/exclude. Looked up at
+include / exclude / state_dir. Looked up at
 `$(git rev-parse --show-toplevel)/.markgate.yml` (no parent-dir
 walking).
+
+Per-gate fields:
+
+| field | purpose |
+|---|---|
+| `hash` | `git-tree` (default) or `files` |
+| `include` | glob list; required for `hash: files` |
+| `exclude` | glob list |
+| `state_dir` | marker storage directory (override per gate). Prefer a **relative** path — it resolves against the repo top-level so it's identical on every machine. An absolute path committed here will point to nonexistent locations on other machines. CLI flag and `MARKGATE_STATE_DIR` still take precedence. |
 
 ### Generate a starter — `markgate init`
 
@@ -432,23 +615,36 @@ $(git rev-parse --git-dir)/markgate/<key>.json
 ```
 
 Inside `.git/`, so no gitignore entry is needed and worktrees stay
-isolated. The on-disk JSON layout is an implementation detail — the
-fields (including `version`, which is an internal schema marker) exist
-only for debugging and may change between releases without notice.
-Don't parse it.
+isolated. With `--state-dir <dir>`, `MARKGATE_STATE_DIR=<dir>`, or
+`state_dir:` in `.markgate.yml`, the location becomes `<dir>/<key>.json`
+instead — see
+[Sharing markers](#sharing-markers-across-machines-ci--teammates). The on-disk
+JSON layout is an implementation detail — the fields (including
+`version`, which is an internal schema marker) exist only for
+debugging and may change between releases without notice. Don't parse
+it.
 
 ## FAQ
 
 - **Does it work in git worktrees?** Yes. Markers live under each
   worktree's own `.git/` dir, so they don't leak across worktrees.
-- **Do I need to gitignore anything?** No — markers are under `.git/`.
+  (This isolation is lost if you point `--state-dir` at a shared
+  location.)
+- **Do I need to gitignore anything?** No for the default layout —
+  markers are under `.git/`. If you use `--state-dir` pointing inside
+  the repo, gitignore that directory.
 - **What if I don't want HEAD in the hash?** Use `hash: files` for
   that gate.
 - **Does `files` respect `.gitignore`?** No. `files` is explicit scope
   by design. Use `git-tree` when you want `.gitignore`-aware behavior.
-- **Can the marker be tampered with?** Locally, yes (it's a JSON file
-  under `.git/`). Signed / remote-shared markers are a future
-  consideration for CI-shared caches, not part of this release.
+- **Can markers be shared across machines / CI?** Yes, via
+  `--state-dir`, `MARKGATE_STATE_DIR`, or `state_dir:` in
+  `.markgate.yml`. See
+  [Sharing markers](#sharing-markers-across-machines-ci--teammates) for patterns
+  and trust considerations.
+- **Can the marker be tampered with?** Yes — it's a JSON file under
+  `.git/` (or wherever `--state-dir` points). Trust whoever can write
+  to that location. Signed markers are still a future consideration.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). It
 records that a check passed at the current repo state so the next hook
 can skip re-running it.
 
+**Especially useful in the AI-coding-agent era.** Two patterns hit
+hard when Claude Code / Cursor / Codex / Copilot CLI is the one
+running checks:
+
+- **Redundancy** — the agent runs your `/check`, then the commit
+  hook runs it, then `gh pr create` runs it, then CI runs it.
+  `markgate` exits in milliseconds on every pass after the first.
+- **Skipped steps** — the agent may quietly skip the check it
+  promised to run (context loss, tool timeout, speed pressure).
+  Pair `markgate verify` with your pre-commit / PreToolUse hook and
+  the commit blocks until the check actually ran against the current
+  state. **No marker, no commit.**
+
 ## 20-second tour
 
 ```sh
@@ -32,11 +45,22 @@ command.)
 
 ## Why markgate?
 
-Your agent (or you) just ran `make check`. The commit hook runs it
-again. `gh pr create` runs it again. CI runs it again — four passes,
-one change. `markgate` lets the second / third / fourth of those exit
-instantly when the repo state hasn't moved. (The CI pass needs a bit
-of extra wiring — see [Sharing markers](#sharing-markers-across-machines-ci--teammates).)
+Two failure modes in an agent-driven workflow, one cache layer.
+
+**Redundant re-runs.** Your agent (or you) just ran `make check`.
+The commit hook runs it again. `gh pr create` runs it again. CI
+runs it again — four passes, one change. `markgate` lets the second
+/ third / fourth of those exit instantly when the repo state hasn't
+moved. (The CI pass needs a bit of extra wiring — see
+[Sharing markers](#sharing-markers-across-machines-ci--teammates).)
+
+**Quietly skipped checks.** Your agent decided to run `/check`, then
+ran out of tool budget / context and committed anyway. Or a tool
+call silently failed. Or it simply forgot. Wire `markgate verify`
+into your pre-commit or PreToolUse hook and there's no bypass by
+"forgetting" — a fresh marker exists only after a check actually
+passed against the current state. Exit 1 with "no marker" is a
+loud, debuggable failure; a silent skip is not.
 
 Concrete gates you can build (see [Use cases](#use-cases) for full
 configs):
@@ -51,11 +75,12 @@ configs):
   when `src/**` or `tests/**` changed.
 
 Existing hook managers (husky / lefthook / pre-commit / Claude Code
-hooks) are great at *running* checks. None of them *remember* that the
-checks just passed and nothing relevant has changed since. `markgate`
-is that memory layer — exit 0 means "verified, skip", exit 1 means
-"stale, re-run". It's not a hook manager itself; it slots into the one
-you already use — one line to adopt, one line to remove.
+hooks) are great at *running* checks. None of them remember that a
+check just passed, or notice when it hasn't run yet. `markgate` is
+that memory layer — exit 0 = "verified, skip", exit 1 = "stale or
+absent, run it". It's not a hook manager itself; it slots into
+whatever hook manager you already use — one line to adopt, one line
+to remove.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ You can skip this only if:
   required — see why below).
 
 <details>
-<summary>Why it's required on <code>git-tree</code> (click to expand)</summary>
+<summary>Why it's required on <code>hash: git-tree</code> (click to expand)</summary>
 
 The `git-tree` digest hashes `HEAD + diff-vs-HEAD ∪
 untracked-not-ignored`. The saved marker file is itself an untracked

--- a/README.md
+++ b/README.md
@@ -474,7 +474,9 @@ gitignore is optional on `files`.
 
 #### Step 2. Wire up CI
 
-**Across runs of the same workflow** — `actions/cache`:
+**Across runs of the same workflow** — `actions/cache`, extending the
+`pre-image-push` gate from
+[Use case 3](#3-pre-image-push-vulnerability-scan-freshness):
 
 ```yaml
 # .github/workflows/scan.yml
@@ -493,7 +495,10 @@ jobs:
 
 **Across jobs within one workflow** — `actions/upload-artifact` →
 `actions/download-artifact`. A setup job runs the expensive check
-once; matrix jobs on the same commit download the marker and skip:
+once; matrix jobs on the same commit download the marker and skip.
+(`expensive` below is a placeholder key — define it in your
+`.markgate.yml` using the [Use cases](#use-cases) as templates, or
+pass `--include` / `--hash` via CLI flags.)
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -407,26 +407,47 @@ git so CI sees it without any cache layer, skip to
 [Pattern B](#b-committed-files-hash) — that's a different shape, not
 a variant of this one.)
 
-> **⚠ Required for `hash: git-tree` + state dir inside the repo:
-> gitignore the state dir.** Not hygiene — *required*. The `git-tree`
-> digest includes untracked-not-ignored files, and the marker itself
-> is an untracked file. Without gitignore:
->
-> 1. `markgate run` computes digest_1 (before the marker exists) and
->    saves the marker with digest_1.
-> 2. The saved marker file now exists as untracked-not-ignored.
-> 3. The next `markgate verify` computes digest_2 — which *includes*
->    the marker file — so digest_2 ≠ digest_1 → mismatch → the check
->    re-runs every time. The feature is defeated on the first verify,
->    before any commit.
->
-> Gitignoring the state dir keeps the marker out of the digest.
-> Placing the state dir outside the repo (absolute path,
-> `$RUNNER_TEMP/...`, etc.) also works — untracked-not-ignored only
-> applies to files under the repo tree.
->
-> `hash: files` sidesteps this: the marker is only in the digest if a
-> glob matches it. Gitignore is optional on `files` — pure hygiene.
+#### Step 1. Add the state dir to `.gitignore`
+
+**This is a required setup step on `hash: git-tree`, not optional
+hygiene.** Do this *before* your first `markgate run`:
+
+```gitignore
+# .gitignore — add the state dir you chose
+/.markgate-cache/
+```
+
+You can skip this only if:
+
+- the state dir is **outside the repo** (e.g. `$RUNNER_TEMP/mg`,
+  `/tmp/mg`, `$HOME/.cache/markgate`), **or**
+- you're on `hash: files` (gitignore then becomes hygiene, not
+  required — see why below).
+
+<details>
+<summary>Why it's required on <code>git-tree</code> (click to expand)</summary>
+
+The `git-tree` digest hashes `HEAD + diff-vs-HEAD ∪
+untracked-not-ignored`. The saved marker file is itself an untracked
+file, so without gitignore:
+
+1. `markgate run` computes **digest_1** (before the marker exists)
+   and saves the marker with digest_1.
+2. The saved marker file now exists as untracked-not-ignored.
+3. The next `markgate verify` computes **digest_2**, which *includes*
+   the marker file. digest_2 ≠ digest_1 → mismatch → the check
+   re-runs every time.
+
+The feature is defeated on the first verify, before any commit.
+Gitignoring the state dir keeps the marker out of the digest.
+
+`hash: files` sidesteps this: the marker is only in the digest if an
+`include` glob matches it, which it normally won't. That's why
+gitignore is optional on `files`.
+
+</details>
+
+#### Step 2. Wire up CI
 
 **Across runs of the same workflow** — `actions/cache`:
 
@@ -444,9 +465,6 @@ jobs:
             markgate-scan-
       - run: markgate run pre-image-push --state-dir .markgate-cache -- trivy fs .
 ```
-
-Make sure `.markgate-cache/` is in `.gitignore` before the first run
-(see the warning above for why it's required on `git-tree`).
 
 **Across jobs within one workflow** — `actions/upload-artifact` →
 `actions/download-artifact`. A setup job runs the expensive check

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -11,6 +13,11 @@ import (
 	"github.com/go-to-k/markgate/internal/key"
 	"github.com/go-to-k/markgate/internal/state"
 )
+
+// EnvStateDir overrides the directory that stores marker files. CLI
+// flag --state-dir takes precedence over this env var, and both override
+// the default (<git-dir>/markgate).
+const EnvStateDir = "MARKGATE_STATE_DIR"
 
 // DefaultKey is the key used when the user omits the positional argument.
 const DefaultKey = "default"
@@ -24,15 +31,17 @@ func resolveKey(args []string) string {
 }
 
 // gateFlagValues holds CLI flags that can override the config-derived
-// gate on a per-invocation basis.
+// gate (hash/include/exclude) plus the marker storage directory, on a
+// per-invocation basis.
 type gateFlagValues struct {
-	hash    string
-	include []string
-	exclude []string
+	hash     string
+	include  []string
+	exclude  []string
+	stateDir string
 }
 
-// addGateFlags registers --hash / --include / --exclude on cmd and
-// returns a pointer whose fields are populated when RunE fires.
+// addGateFlags registers --hash / --include / --exclude / --state-dir on
+// cmd and returns a pointer whose fields are populated when RunE fires.
 func addGateFlags(cmd *cobra.Command) *gateFlagValues {
 	v := &gateFlagValues{}
 	cmd.Flags().StringVar(&v.hash, "hash", "",
@@ -41,6 +50,8 @@ func addGateFlags(cmd *cobra.Command) *gateFlagValues {
 		"glob to include (repeatable); overrides config include list")
 	cmd.Flags().StringArrayVar(&v.exclude, "exclude", nil,
 		"glob to exclude (repeatable); overrides config exclude list")
+	cmd.Flags().StringVar(&v.stateDir, "state-dir", "",
+		"directory to store marker files; overrides "+EnvStateDir+" (default: <git-dir>/markgate)")
 	return v
 }
 
@@ -105,8 +116,34 @@ func newGateCtx(k string, overrides *gateFlagValues) (*gateCtx, error) {
 		gitDir:     gitDir,
 		gate:       gate,
 		hasher:     h,
-		markerPath: state.Path(gitDir, k),
+		markerPath: resolveMarkerPath(overrides, gate, top, gitDir, k),
 	}, nil
+}
+
+// resolveMarkerPath picks the marker file location based on precedence:
+// --state-dir flag > MARKGATE_STATE_DIR env > gate.StateDir (from
+// .markgate.yml) > default (<gitDir>/markgate). When an override is
+// used, the "markgate" subdirectory is not injected: the user-specified
+// directory is treated as the final storage location. Relative override
+// paths resolve against the repo top-level so the location is stable
+// across cwds (e.g. when invoked from a git hook).
+func resolveMarkerPath(overrides *gateFlagValues, gate config.Gate, topLevel, gitDir, k string) string {
+	dir := ""
+	switch {
+	case overrides != nil && overrides.stateDir != "":
+		dir = overrides.stateDir
+	case os.Getenv(EnvStateDir) != "":
+		dir = os.Getenv(EnvStateDir)
+	case gate.StateDir != "":
+		dir = gate.StateDir
+	}
+	if dir == "" {
+		return state.Path(gitDir, k)
+	}
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(topLevel, dir)
+	}
+	return state.PathIn(dir, k)
 }
 
 // validateGate enforces the invariants that config.validate also enforces,

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -14,9 +14,9 @@ import (
 	"github.com/go-to-k/markgate/internal/state"
 )
 
-// EnvStateDir overrides the directory that stores marker files. CLI
-// flag --state-dir takes precedence over this env var, and both override
-// the default (<git-dir>/markgate).
+// EnvStateDir overrides the directory that stores marker files.
+// Precedence: --state-dir flag > this env > gate.StateDir in
+// .markgate.yml > default (<git-dir>/markgate).
 const EnvStateDir = "MARKGATE_STATE_DIR"
 
 // DefaultKey is the key used when the user omits the positional argument.
@@ -51,7 +51,7 @@ func addGateFlags(cmd *cobra.Command) *gateFlagValues {
 	cmd.Flags().StringArrayVar(&v.exclude, "exclude", nil,
 		"glob to exclude (repeatable); overrides config exclude list")
 	cmd.Flags().StringVar(&v.stateDir, "state-dir", "",
-		"directory to store marker files; overrides "+EnvStateDir+" (default: <git-dir>/markgate)")
+		"directory to store marker files; overrides "+EnvStateDir+" env and state_dir: in .markgate.yml (default: <git-dir>/markgate)")
 	return v
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -16,7 +16,9 @@ const initSkeleton = `# markgate configuration - https://github.com/go-to-k/mark
 # This file is optional. Zero-config (hash: git-tree) is the default.
 # Define a gate here only when you want:
 #   - exclude patterns on the default git-tree hash, or
-#   - a narrow-scope (hash: files) gate for docs / Docker / coverage.
+#   - a narrow-scope (hash: files) gate for docs / Docker / coverage, or
+#   - a non-default marker storage directory (state_dir) for sharing
+#     markers across machines / CI.
 
 gates:
   # Default gate (used when ` + "`markgate verify`" + ` runs without a key).
@@ -25,6 +27,22 @@ gates:
     # exclude:
     #   - "vendor/**"
     #   - "node_modules/**"
+    #
+    # state_dir controls where the marker file is written. Prefer
+    # relative paths (resolved against the repo top-level) so every
+    # machine agrees on the location. Two patterns:
+    #
+    #   Pattern A: not committed (e.g. restored from CI cache).
+    #     state_dir: .markgate-cache
+    #     -> gitignore .markgate-cache/ (required if you stay on
+    #        hash: git-tree, optional hygiene for hash: files).
+    #
+    #   Pattern B: committed to git for zero-infra local->CI sharing.
+    #     state_dir: .markgate-state
+    #     -> requires hash: files (git-tree would break: the commit
+    #        changes HEAD and stales the marker it just wrote).
+    #
+    # See README "Sharing markers" for the full picture.
 
   # Example: narrow-scope gate for PR-time docs checks.
   # pre-pr:

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -539,6 +539,30 @@ func TestStateDir_FlagBeatsConfig(t *testing.T) {
 	}
 }
 
+func TestStateDir_StatusCmd(t *testing.T) {
+	initRepo(t)
+	stateDir := t.TempDir()
+
+	code, out := runCmd(t, "status", "check", "--state-dir", stateDir)
+	if code != 1 {
+		t.Errorf("status with no marker: code = %d, want 1", code)
+	}
+	if !bytes.Contains([]byte(out), []byte("no marker")) {
+		t.Errorf("status output missing 'no marker' line:\n%s", out)
+	}
+
+	if code, _ := runCmd(t, "set", "check", "--state-dir", stateDir); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	code, out = runCmd(t, "status", "check", "--state-dir", stateDir)
+	if code != 0 {
+		t.Errorf("status after set: code = %d, want 0", code)
+	}
+	if !bytes.Contains([]byte(out), []byte("state:      match")) {
+		t.Errorf("status output missing match line:\n%s", out)
+	}
+}
+
 func TestStateDir_RunCmd(t *testing.T) {
 	dir := initRepo(t)
 	stateDir := t.TempDir()

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -551,8 +551,8 @@ func TestStateDir_StatusCmd(t *testing.T) {
 		t.Errorf("status output missing 'no marker' line:\n%s", out)
 	}
 
-	if code, _ := runCmd(t, "set", "check", "--state-dir", stateDir); code != 0 {
-		t.Fatalf("set: %d", code)
+	if setCode, _ := runCmd(t, "set", "check", "--state-dir", stateDir); setCode != 0 {
+		t.Fatalf("set: %d", setCode)
 	}
 	code, out = runCmd(t, "status", "check", "--state-dir", stateDir)
 	if code != 0 {

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -356,6 +356,206 @@ func TestInit_ExistingBlocks(t *testing.T) {
 	}
 }
 
+func TestStateDir_FlagAbsolutePath(t *testing.T) {
+	initRepo(t)
+	stateDir := t.TempDir()
+
+	if code, _ := runCmd(t, "set", "check", "--state-dir", stateDir); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	// Marker must be at <stateDir>/<key>.json, NOT <stateDir>/markgate/<key>.json.
+	if _, err := os.Stat(filepath.Join(stateDir, "check.json")); err != nil {
+		t.Errorf("marker not at <dir>/<key>.json: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "markgate", "check.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("unexpected markgate/ subdir under --state-dir")
+	}
+
+	if code, _ := runCmd(t, "verify", "check", "--state-dir", stateDir); code != 0 {
+		t.Errorf("verify after set: %d, want 0", code)
+	}
+	if code, _ := runCmd(t, "clear", "check", "--state-dir", stateDir); code != 0 {
+		t.Errorf("clear: %d, want 0", code)
+	}
+	if code, _ := runCmd(t, "verify", "check", "--state-dir", stateDir); code != 1 {
+		t.Errorf("verify after clear: %d, want 1", code)
+	}
+}
+
+func TestStateDir_FlagRelativeResolvesToRepoRoot(t *testing.T) {
+	dir := initRepo(t)
+	// Relative path must resolve from repo top-level, not cwd.
+	sub := filepath.Join(dir, "nested")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(sub)
+
+	if code, _ := runCmd(t, "set", "check", "--state-dir", ".cache/markgate"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	want := filepath.Join(dir, ".cache", "markgate", "check.json")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("marker not at repo-root-relative path %s: %v", want, err)
+	}
+}
+
+func TestStateDir_EnvVar(t *testing.T) {
+	initRepo(t)
+	stateDir := t.TempDir()
+	t.Setenv("MARKGATE_STATE_DIR", stateDir)
+
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "check.json")); err != nil {
+		t.Errorf("env-var marker not found: %v", err)
+	}
+	if code, _ := runCmd(t, "verify", "check"); code != 0 {
+		t.Errorf("verify via env: %d, want 0", code)
+	}
+}
+
+func TestStateDir_FlagBeatsEnv(t *testing.T) {
+	initRepo(t)
+	envDir := t.TempDir()
+	flagDir := t.TempDir()
+	t.Setenv("MARKGATE_STATE_DIR", envDir)
+
+	if code, _ := runCmd(t, "set", "check", "--state-dir", flagDir); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	// Flag wins: file is in flagDir, not envDir.
+	if _, err := os.Stat(filepath.Join(flagDir, "check.json")); err != nil {
+		t.Errorf("flag path not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(envDir, "check.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("env path should not have been written when flag is set")
+	}
+}
+
+func TestStateDir_DoesNotTouchDefaultLocation(t *testing.T) {
+	dir := initRepo(t)
+	stateDir := t.TempDir()
+
+	if code, _ := runCmd(t, "set", "check", "--state-dir", stateDir); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	// Default .git/markgate/<key>.json must not exist: override is exclusive.
+	defaultPath := filepath.Join(dir, ".git", "markgate", "check.json")
+	if _, err := os.Stat(defaultPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("default marker path should not exist when --state-dir is used")
+	}
+}
+
+func TestStateDir_FromConfigAbsolutePath(t *testing.T) {
+	dir := initRepo(t)
+	absDir := t.TempDir()
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  check:\n    hash: git-tree\n    state_dir: "+absDir+"\n")
+
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	if _, err := os.Stat(filepath.Join(absDir, "check.json")); err != nil {
+		t.Errorf("marker not at config-specified absolute path: %v", err)
+	}
+	if code, _ := runCmd(t, "verify", "check"); code != 0 {
+		t.Errorf("verify: %d, want 0", code)
+	}
+}
+
+func TestStateDir_ConfigWithFilesHash(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.ts", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  coverage:\n    hash: files\n    include:\n      - \"src/**\"\n    state_dir: .mg\n")
+
+	if code, _ := runCmd(t, "set", "coverage"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	// Marker must be at config state_dir (files hash + state_dir combine correctly).
+	if _, err := os.Stat(filepath.Join(dir, ".mg", "coverage.json")); err != nil {
+		t.Errorf("marker not at config state_dir for files hash: %v", err)
+	}
+	// Out-of-scope change does not invalidate (files hash).
+	writeRepoFile(t, dir, "docs/x.md", "x")
+	if code, _ := runCmd(t, "verify", "coverage"); code != 0 {
+		t.Errorf("verify after out-of-scope edit: %d, want 0", code)
+	}
+	// In-scope change does invalidate (files hash).
+	writeRepoFile(t, dir, "src/a.ts", "edited")
+	if code, _ := runCmd(t, "verify", "coverage"); code != 1 {
+		t.Errorf("verify after in-scope edit: %d, want 1", code)
+	}
+}
+
+func TestStateDir_FromConfig(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  check:\n    hash: git-tree\n    state_dir: .mg-cache\n")
+
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	want := filepath.Join(dir, ".mg-cache", "check.json")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("marker not at config-specified path %s: %v", want, err)
+	}
+}
+
+func TestStateDir_EnvBeatsConfig(t *testing.T) {
+	dir := initRepo(t)
+	envDir := t.TempDir()
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  check:\n    state_dir: .mg-cache\n")
+	t.Setenv("MARKGATE_STATE_DIR", envDir)
+
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	if _, err := os.Stat(filepath.Join(envDir, "check.json")); err != nil {
+		t.Errorf("env path should win over config: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".mg-cache", "check.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("config path should have been shadowed by env")
+	}
+}
+
+func TestStateDir_FlagBeatsConfig(t *testing.T) {
+	dir := initRepo(t)
+	flagDir := t.TempDir()
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  check:\n    state_dir: .mg-cache\n")
+
+	if code, _ := runCmd(t, "set", "check", "--state-dir", flagDir); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	if _, err := os.Stat(filepath.Join(flagDir, "check.json")); err != nil {
+		t.Errorf("flag path should win over config: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".mg-cache", "check.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("config path should have been shadowed by flag")
+	}
+}
+
+func TestStateDir_RunCmd(t *testing.T) {
+	dir := initRepo(t)
+	stateDir := t.TempDir()
+	writeRepoFile(t, dir, "seed.txt", "edited")
+
+	if code, _ := runCmd(t, "run", "check", "--state-dir", stateDir, "--", "true"); code != 0 {
+		t.Errorf("run success: %d, want 0", code)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "check.json")); err != nil {
+		t.Errorf("run did not persist marker to --state-dir: %v", err)
+	}
+	// Second run should skip (match on same state).
+	if code, _ := runCmd(t, "run", "check", "--state-dir", stateDir, "--", "false"); code != 0 {
+		t.Errorf("run skip: %d, want 0 (should not execute child)", code)
+	}
+}
+
 func TestVersion_PrintsInjected(t *testing.T) {
 	root := newRootCmd("v1.2.3")
 	var stdout bytes.Buffer

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,11 @@ type Gate struct {
 	Hash    string   `yaml:"hash"`
 	Include []string `yaml:"include,omitempty"`
 	Exclude []string `yaml:"exclude,omitempty"`
+	// StateDir overrides the marker storage directory for this gate.
+	// Relative paths resolve against the repo top-level (same semantics as
+	// the --state-dir flag). Committing an absolute path is an anti-pattern
+	// because it won't exist on other machines; prefer a relative path.
+	StateDir string `yaml:"state_dir,omitempty"`
 }
 
 // Load reads topLevel/.markgate.yml. A missing file yields an empty

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -77,6 +77,18 @@ func TestGate_DefaultForNilConfig(t *testing.T) {
 	}
 }
 
+func TestLoad_StateDirPreserved(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "gates:\n  pre-pr:\n    hash: git-tree\n    state_dir: .cache/mg\n")
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g := c.Gate("pre-pr"); g.StateDir != ".cache/mg" {
+		t.Errorf("Gate.StateDir = %q, want %q", g.StateDir, ".cache/mg")
+	}
+}
+
 func TestGate_DefaultForMissingKey(t *testing.T) {
 	dir := t.TempDir()
 	writeConfig(t, dir, "gates:\n  pre-commit:\n    hash: git-tree\n")

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,4 +1,7 @@
-// Package state reads and writes marker files under .git/markgate/<key>.json.
+// Package state reads and writes marker files. The default layout is
+// <gitDir>/markgate/<key>.json; callers may also supply a custom
+// directory (e.g. for CI cache integration), in which case the marker
+// is written at <dir>/<key>.json without the extra "markgate" subdir.
 //
 // The on-disk JSON schema is an implementation detail; no compatibility
 // guarantees are made across markgate versions. Writes are atomic: data
@@ -31,8 +34,19 @@ type Marker struct {
 }
 
 // Path returns the marker file path for a given git directory and key.
+// The default layout places markers under <gitDir>/markgate/<key>.json so
+// they live inside .git and need no gitignore entry.
 func Path(gitDir, key string) string {
-	return filepath.Join(gitDir, "markgate", key+".json")
+	return PathIn(filepath.Join(gitDir, "markgate"), key)
+}
+
+// PathIn returns the marker file path directly under dir, without the
+// extra "markgate" subdirectory that Path adds. Callers use this when the
+// user has explicitly chosen a storage directory (e.g. --state-dir or
+// MARKGATE_STATE_DIR): the directory is already theirs, so there is no
+// reason to nest another folder inside it.
+func PathIn(dir, key string) string {
+	return filepath.Join(dir, key+".json")
 }
 
 // Load reads a marker. Returns ErrNotFound when the file does not exist.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -41,10 +41,11 @@ func Path(gitDir, key string) string {
 }
 
 // PathIn returns the marker file path directly under dir, without the
-// extra "markgate" subdirectory that Path adds. Callers use this when the
-// user has explicitly chosen a storage directory (e.g. --state-dir or
-// MARKGATE_STATE_DIR): the directory is already theirs, so there is no
-// reason to nest another folder inside it.
+// extra "markgate" subdirectory that Path adds. Callers use this when
+// the user has explicitly chosen a storage directory (via --state-dir,
+// MARKGATE_STATE_DIR, or state_dir: in .markgate.yml): the directory
+// is already theirs, so there is no reason to nest another folder
+// inside it.
 func PathIn(dir, key string) string {
 	return filepath.Join(dir, key+".json")
 }


### PR DESCRIPTION
## Summary

- Adds three ways to override the marker storage directory: `--state-dir` flag, `MARKGATE_STATE_DIR` env, and per-gate `state_dir:` in `.markgate.yml`. Precedence: flag > env > config > default (`.git/markgate/`).
- When overridden, markers live at `<dir>/<key>.json` (no nested `markgate/` subdirectory) so the user owns the layout. Relative paths resolve against the repo top-level, so the location is identical on every machine regardless of cwd.
- Unblocks two sharing patterns documented in README:
  - **Pattern A (not committed)** — e.g. `actions/cache` or `actions/upload-artifact` carries the marker dir between runs/jobs. Works with both hash types; recommend gitignoring the dir on `hash: git-tree` to prevent accidental commits that stale the marker.
  - **Pattern B (committed)** — commit the marker alongside code for zero-infra local→CI sharing. Requires `hash: files`; `git-tree` would change HEAD on the marker commit and instantly stale the digest.

## Notes

- `.git/markgate/` default path is preserved — zero breaking change for existing users.
- `state_dir` is not validated beyond filesystem semantics (empty = unset, absolute/relative both allowed). Docs warn against committing absolute paths.
- Signed markers remain future work; tamper resistance still depends on who can write to the directory (FAQ updated).

## Test plan

- [x] `go test ./...` — all pass, 11 new integration tests covering flag/env/config, absolute/relative paths, full pairwise precedence, override exclusivity, and files-hash combo.
- [x] `go vet ./...` clean.
- [x] Manual smoke: `--state-dir <abs-path-outside-repo>` round-trip → `run` creates `<dir>/default.json`, `verify` returns 0.
- [x] Manual smoke: `MARKGATE_STATE_DIR=<abs-path-outside-repo> markgate set` → marker lands at `<dir>/default.json`.
- [x] Manual smoke: `.markgate.yml` with `state_dir: .mg-state` + `.mg-state/` in `.gitignore` → `set` + `verify` round-trip at `<repo-root>/.mg-state/default.json`.

### Finding during smoke testing

Using `--state-dir .mg-cache` (inside repo, **not gitignored**) with `hash: git-tree` breaks the round-trip: `run` writes the marker, which then appears as untracked-not-ignored and changes the next digest, so `verify` returns 1. This is the exact failure mode the README already warns about — the gitignore advice isn't hygiene, it's required. Working as intended.