### PR TITLE
chore: add Claude Code harness (CLAUDE.md, skill, hooks, permissions)

### DIFF
--- a/.claude/hooks/go-vet-on-edit.sh
+++ b/.claude/hooks/go-vet-on-edit.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# PostToolUse hook: run `go vet ./...` after Claude edits a .go file.
+#
+# Dogfoods markgate itself to skip the vet run when repo state has not
+# changed since the last successful vet. Runs markgate via `go run
+# ./cmd/markgate` so the hook always reflects current source — no
+# global install needed, no stale-binary problem. Go's content-based
+# build cache keeps steady-state invocations well under 0.1s; only
+# the first compile after `go clean -cache` is slow (~2-3s).
+#
+# On vet failure, prints the report to stderr and exits 2 so Claude
+# Code surfaces it as blocking feedback (and Claude sees the
+# diagnostic). On non-.go edits or clean vet, exits 0 silently.
+#
+# Input (stdin): the tool-use JSON from Claude Code; we only need
+# .tool_input.file_path.
+set -u
+input=$(cat)
+file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+case "$file" in
+  *.go) ;;
+  *) exit 0 ;;
+esac
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+if ! go run ./cmd/markgate run hook-vet -- go vet ./... 1>&2; then
+  printf '[claude hook] go vet or markgate failed after editing %s\n' "$file" >&2
+  exit 2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(go build:*)",
+      "Bash(go test:*)",
+      "Bash(go vet:*)",
+      "Bash(go run:*)",
+      "Bash(go mod tidy)",
+      "Bash(go mod download)",
+      "Bash(go fmt:*)",
+      "Bash(gofmt:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/go-vet-on-edit.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/audit-before-done/SKILL.md
+++ b/.claude/skills/audit-before-done/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: audit-before-done
+description: Pre-push / pre-done-declaration discipline for markgate. Covers implementation anti-patterns (no churn, no silent deletion), a widened proactive audit (grep every introduced name, check --help output, smoke the built binary, run make lint — go vet is not enough), and the post-merge manual smoke pattern. Use whenever you're about to say "done", mark a task complete, push a branch, create a PR, or ask for merge. Companion to `iterate-design`, which covers the pre-code design phase.
+---
+
+# audit-before-done
+
+The discipline you apply **between writing code and declaring it
+finished**. The goal is to catch the things the user would otherwise
+find — stale help text, missed edge-case tests, CI lint failures
+that your local `go vet` didn't catch, smoke bugs in `main.go`
+wiring that unit tests miss.
+
+Invoke this whenever you're tempted to say any of:
+
+- "done"
+- "no gaps"
+- "ready to commit"
+- "pushing now"
+- "ready for review"
+- "complete"
+
+And also right before `git push`, `gh pr create`, or moving a todo
+to `completed` on non-trivial work.
+
+## Phase 3 — implementation discipline
+
+- Use `TodoWrite` to break the work into verifiable steps.
+- Keep diffs minimal — no drive-by refactors, no hypothetical
+  configurability, no "just in case" validation.
+- **Don't delete something because you're unsure it works — test
+  it.** If a hook, script, or feature might be broken, build a
+  minimal reproduction (temp dir, fake input, run it) and verify.
+  Removing the thing to avoid shipping uncertainty is
+  under-delivering; confirming with a 30-second experiment is what
+  the user is paying for.
+- **Don't churn edits on the same region.** If an edit turns out
+  to be wrong, revert to the previous clean state in one operation,
+  then make the correct edit. A sequence of tiny patches that adds
+  then removes the same phrase is a sign of indecision, not
+  progress — the diff review becomes noisy and the history becomes
+  harder to follow.
+
+## Phase 4 — audit (proactive)
+
+Before reporting done, self-audit without waiting to be asked:
+
+- Every item from the pre-code sketch was delivered?
+- Precedence / edge-case tests exist (absolute & relative paths,
+  empty strings, all pairwise precedence combinations, orthogonal
+  feature combos)?
+- README consistency: Use cases, CLI reference, Sharing markers,
+  FAQ, link fragments, any "out of scope" notes that just became
+  in-scope?
+- `init.go` skeleton needs a comment?
+- Package doc comment (`// Package xyz …`) still accurate?
+
+**Don't settle for "no gaps" from a superficial check.** A
+self-audit that returns empty is usually a narrow audit, not a
+complete feature. When tempted to declare "complete", widen the
+lens:
+
+- Grep for every name introduced (flag names, env vars, config
+  keys, new exported symbols) and confirm every doc and code
+  reference matches.
+- **Check the runtime surface, not just files.** Run `<binary>
+  <subcommand> --help` and compare against the README's CLI
+  reference and env var list. When a new source is added to a
+  precedence chain (e.g. config layer added to `flag > env >
+  default`), godoc on the related constants, flag `--help`
+  strings, and package doc comments all tend to still describe the
+  *old* chain. These are user-facing too and drift silently.
+- Run a fresh smoke test of the *built* binary in a throwaway
+  repo, not just `go test ./...`. Failed smokes are valuable
+  data — they often expose docs gaps or wiring bugs that unit
+  tests don't.
+- Cross-check claims that point at other sections: if the Why
+  section says "four passes, one change", are all four passes
+  actually wired up, or is one of them aspirational?
+
+Report the result — "no gaps after N checks" or "one stale link,
+fixing" — in the same message that announces completion. If the
+user then finds something the audit missed, that's a signal the
+checklist above needs a new entry.
+
+## Mirror what CI runs, locally
+
+`go test ./... && go vet ./...` is **not** what CI runs. This
+project's CI runs golangci-lint with `govet: enable: [shadow]`
+plus `gocritic`, `staticcheck`, `gosec`, `errcheck`, `errorlint`,
+`ineffassign`, `misspell`, `nilerr`, `nilnil`, `unconvert`,
+`unparam`, `unused`, and formatters (`gofmt`, `goimports`). Plain
+`go vet` doesn't enable most of these.
+
+Before pushing or marking done, run:
+
+```sh
+go test ./...
+make lint        # golangci-lint run, mirrors CI
+```
+
+`make lint` catches — in descending order of this session's hit
+rate — shadow declarations, unused variables, unchecked errors,
+and format-string mismatches. If you only ran `go test && go vet`
+and `make lint` is still unproven, the CI run is the audit, which
+is too late.
+
+## Post-merge: manual smoke
+
+Integration tests cover most cases, but when the feature changes
+how the built binary behaves (new flag / env / path handling), run
+a quick smoke against a fresh build in a throwaway repo.
+Integration tests exercise the cobra root, not the compiled
+binary — they won't catch `main.go` wiring bugs or
+version-injection issues.
+
+```sh
+go build -o /tmp/markgate ./cmd/markgate
+cd "$(mktemp -d)" && git init -q -b main && \
+  git config user.email t@e && git config user.name t && \
+  echo seed > seed.txt && git add . && git commit -qm init
+/tmp/markgate <new-flag-under-test>
+```
+
+Fold surprising smoke findings back into the README or code
+immediately — a smoke that needs an undocumented setup step is
+usually a docs gap, not a smoke problem.
+
+## What this skill is not
+
+- Not a license to over-audit one-line fixes. Size the audit to
+  the risk.
+- Not a substitute for Phase 1-2 design discipline — this skill
+  assumes the design was already agreed via `iterate-design`.

--- a/.claude/skills/iterate-design/SKILL.md
+++ b/.claude/skills/iterate-design/SKILL.md
@@ -84,8 +84,24 @@ Before reporting done, self-audit without waiting to be asked:
 - `init.go` skeleton needs a comment?
 - Package doc comment (`// Package xyz ...`) still accurate?
 
-Report the result — "no gaps" or "one stale link, fixing" — in the
-same message that announces completion.
+**Don't settle for "no gaps" from a superficial check.** A self-audit
+that returns empty is usually a narrow audit, not a complete feature.
+When tempted to declare "complete", widen the lens:
+
+- Grep for every name introduced (flag names, env vars, config keys,
+  new exported symbols) and confirm every doc and code reference
+  matches.
+- Run a fresh smoke test of the *built* binary in a throwaway repo,
+  not just `go test ./...`. Failed smokes are valuable data — they
+  often expose docs gaps or wiring bugs that unit tests don't.
+- Cross-check claims that point at other sections: if the Why
+  section says "four passes, one change", are all four passes
+  actually wired up, or is one of them aspirational?
+
+Report the result — "no gaps after N checks" or "one stale link,
+fixing" — in the same message that announces completion. If the user
+then finds something the audit missed, that's a signal the checklist
+above needs a new entry.
 
 ## Post-merge: manual smoke
 

--- a/.claude/skills/iterate-design/SKILL.md
+++ b/.claude/skills/iterate-design/SKILL.md
@@ -91,6 +91,13 @@ When tempted to declare "complete", widen the lens:
 - Grep for every name introduced (flag names, env vars, config keys,
   new exported symbols) and confirm every doc and code reference
   matches.
+- **Check the runtime surface, not just files.** Run `<binary>
+  <subcommand> --help` and compare against the README's CLI
+  reference and env var list. When a new source is added to a
+  precedence chain (e.g. config layer added to `flag > env > default`),
+  godoc on the related constants, flag `--help` strings, and package
+  doc comments all tend to still describe the *old* chain. These are
+  user-facing too and drift silently.
 - Run a fresh smoke test of the *built* binary in a throwaway repo,
   not just `go test ./...`. Failed smokes are valuable data — they
   often expose docs gaps or wiring bugs that unit tests don't.

--- a/.claude/skills/iterate-design/SKILL.md
+++ b/.claude/skills/iterate-design/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: iterate-design
-description: Structured design iteration for non-trivial features on markgate. Forces a design sketch with trade-offs before code, guards against silent opinion-flipping when the user pushes back, and audits plan-vs-implementation proactively at the end. Use when the user asks for an opinion ("what do you think?", "should we?", "recommended?"), proposes a new flag / env / config field, or raises a feature with multiple valid shapes.
+description: Pre-code design iteration for non-trivial features on markgate. Forces a design sketch with trade-offs before writing code, and guards against silent opinion-flipping when the user pushes back. Use when the user asks for an opinion ("what do you think?", "should we?", "recommended?"), proposes a new flag / env / config field, or raises a feature with multiple valid shapes. For the matching pre-push / done-declaration discipline (implementation anti-patterns, audit checklist, smoke-the-binary), see the companion `audit-before-done` skill.
 ---
 
 # iterate-design
 
-A compact workflow for design-heavy work on markgate. The goal is to
-avoid three patterns that waste the user's time:
+A compact pre-code workflow for design-heavy work on markgate. Goal:
+agree on the shape before any code is written, and don't drift on the
+recommendation once taken. Implementation discipline and the
+pre-push audit live in the companion skill `audit-before-done`.
+
+The patterns this skill guards against:
 
 1. Jumping to implementation before the shape is agreed.
 2. Flipping recommendation based on user reframing without anchoring
    on the original reasoning.
-3. Shipping a feature, then discovering the audit the user would have
-   asked for anyway.
 
 ## Phase 1 — design sketch (before code)
 
@@ -40,83 +42,27 @@ When the user pushes back, don't silently flip. Sequence:
 2. If the new information actually changes that reasoning, say so
    explicitly: "this changes the calculation because X → Y → Z".
 3. If it doesn't, say that too: "the concern you raised still holds,
-   because ...". Then address the sub-question.
+   because …". Then address the sub-question.
 4. Never present an opinion as "it depends" unless it really does.
    Pick one and defend it.
 
 Caution signs that you are drifting:
 
-- Your previous message recommended A; this message recommends B with
-  no new information cited.
+- Your previous message recommended A; this message recommends B
+  with no new information cited.
 - You labeled something "not recommended" without a concrete failure
   mode. Warnings without evidence are noise.
 - You explained a failure mode as "the marker becomes stale" and
-  stopped there. Finish the chain: "stale → verify returns 1 → check
-  re-runs → the whole point of the feature is defeated."
+  stopped there. Finish the chain: "stale → verify returns 1 →
+  check re-runs → the whole point of the feature is defeated."
 
-## Phase 3 — implementation
+## Handoff
 
-- Use `TodoWrite` to break the work into verifiable steps.
-- Keep diffs minimal — no drive-by refactors, no hypothetical
-  configurability, no "just in case" validation.
-- Run `go test ./... && go vet ./...` before claiming done.
-- **Don't delete something because you're unsure it works — test it.**
-  If a hook, script, or feature might be broken, build a minimal
-  reproduction (temp dir, fake input, run it) and verify. Removing the
-  thing to avoid shipping uncertainty is under-delivering; confirming
-  with a 30-second experiment is what the user is paying for.
-- **Don't churn edits on the same region.** If an edit turns out to
-  be wrong, revert to the previous clean state in one operation, then
-  make the correct edit. A sequence of tiny patches that adds then
-  removes the same phrase is a sign of indecision, not progress — the
-  diff review becomes noisy and the history becomes harder to follow.
-
-## Phase 4 — audit (proactive)
-
-Before reporting done, self-audit without waiting to be asked:
-
-- Every item from the Phase 1 sketch was delivered?
-- Precedence / edge-case tests exist (absolute & relative paths,
-  empty strings, all pairwise precedence combinations, orthogonal
-  feature combos)?
-- README consistency: Use cases, CLI reference, Sharing markers, FAQ,
-  link fragments, any "out of scope" notes that just became in-scope?
-- `init.go` skeleton needs a comment?
-- Package doc comment (`// Package xyz ...`) still accurate?
-
-**Don't settle for "no gaps" from a superficial check.** A self-audit
-that returns empty is usually a narrow audit, not a complete feature.
-When tempted to declare "complete", widen the lens:
-
-- Grep for every name introduced (flag names, env vars, config keys,
-  new exported symbols) and confirm every doc and code reference
-  matches.
-- **Check the runtime surface, not just files.** Run `<binary>
-  <subcommand> --help` and compare against the README's CLI
-  reference and env var list. When a new source is added to a
-  precedence chain (e.g. config layer added to `flag > env > default`),
-  godoc on the related constants, flag `--help` strings, and package
-  doc comments all tend to still describe the *old* chain. These are
-  user-facing too and drift silently.
-- Run a fresh smoke test of the *built* binary in a throwaway repo,
-  not just `go test ./...`. Failed smokes are valuable data — they
-  often expose docs gaps or wiring bugs that unit tests don't.
-- Cross-check claims that point at other sections: if the Why
-  section says "four passes, one change", are all four passes
-  actually wired up, or is one of them aspirational?
-
-Report the result — "no gaps after N checks" or "one stale link,
-fixing" — in the same message that announces completion. If the user
-then finds something the audit missed, that's a signal the checklist
-above needs a new entry.
-
-## Post-merge: manual smoke
-
-Integration tests cover most cases, but when the feature changes how
-the built binary behaves (new flag / env / path handling), run a quick
-smoke against `go build -o /tmp/markgate ./cmd/markgate` in a throwaway
-`git init` repo. Integration tests exercise the cobra root, not the
-compiled binary — they won't catch `main.go` wiring bugs.
+Once the user signs off on the sketch and you start writing code,
+the `audit-before-done` skill takes over: implementation discipline
+(no churn, no deletion on uncertainty), the widened audit
+(grep every introduced name, check `--help`, smoke the built binary,
+run `make lint` not just `go vet`), and the pre-push checklist.
 
 ## What this skill is not
 

--- a/.claude/skills/iterate-design/SKILL.md
+++ b/.claude/skills/iterate-design/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: iterate-design
+description: Structured design iteration for non-trivial features on markgate. Forces a design sketch with trade-offs before code, guards against silent opinion-flipping when the user pushes back, and audits plan-vs-implementation proactively at the end. Use when the user asks "どう思う？" / "やるべき？" / "どう？", proposes a new flag/env/config field, or raises a feature with multiple valid shapes.
+---
+
+# iterate-design
+
+A compact workflow for design-heavy work on markgate. The goal is to
+avoid three patterns that waste the user's time:
+
+1. Jumping to implementation before the shape is agreed.
+2. Flipping recommendation based on user reframing without anchoring
+   on the original reasoning.
+3. Shipping a feature, then discovering the audit the user would have
+   asked for anyway.
+
+## Phase 1 — design sketch (before code)
+
+Produce a short sketch the user can react to:
+
+1. **Goal in one sentence.** What problem, for whom.
+2. **Options.** 2–4 total. More than 4 causes paralysis. Each option
+   gets a one-liner plus its main trade-off.
+3. **Recommendation.** Pick one. Say why, referring to the goal.
+4. **Decisions that aren't obvious.** Flag name, env var name,
+   precedence chain, config field location, validation boundaries,
+   where the docs need to change.
+5. **Ask for sign-off.** Do not write code yet.
+
+When the feature is an override, default to the markgate precedence:
+**CLI flag > env var > `.markgate.yml` > default**. Deviating needs
+an explicit reason.
+
+## Phase 2 — hold the line
+
+When the user pushes back, don't silently flip. Sequence:
+
+1. Restate **why** the original position was taken (the constraint,
+   the past failure mode, the existing invariant).
+2. If the new information actually changes that reasoning, say so
+   explicitly: "this changes the calculation because X → Y → Z".
+3. If it doesn't, say that too: "the concern you raised still holds,
+   because ...". Then address the sub-question.
+4. Never present an opinion as "it depends" unless it really does.
+   Pick one and defend it.
+
+Caution signs that you are drifting:
+
+- Your previous message recommended A; this message recommends B with
+  no new information cited.
+- You labeled something "not recommended" without a concrete failure
+  mode. Warnings without evidence are noise.
+- You explained a failure mode as "the marker becomes stale" and
+  stopped there. Finish the chain: "stale → verify returns 1 → check
+  re-runs → the whole point of the feature is defeated."
+
+## Phase 3 — implementation
+
+- Use `TodoWrite` to break the work into verifiable steps.
+- Keep diffs minimal — no drive-by refactors, no hypothetical
+  configurability, no "just in case" validation.
+- Run `go test ./... && go vet ./...` before claiming done.
+
+## Phase 4 — audit (proactive)
+
+Before reporting done, self-audit without waiting to be asked:
+
+- Every item from the Phase 1 sketch was delivered?
+- Precedence / edge-case tests exist (absolute & relative paths,
+  empty strings, all pairwise precedence combinations, orthogonal
+  feature combos)?
+- README consistency: Use cases, CLI reference, Sharing markers, FAQ,
+  link fragments, any "out of scope" notes that just became in-scope?
+- `init.go` skeleton needs a comment?
+- Package doc comment (`// Package xyz ...`) still accurate?
+
+Report the result — "no gaps" or "one stale link, fixing" — in the
+same message that announces completion.
+
+## Post-merge: manual smoke
+
+Integration tests cover most cases, but when the feature changes how
+the built binary behaves (new flag / env / path handling), run a quick
+smoke against `go build -o /tmp/markgate ./cmd/markgate` in a throwaway
+`git init` repo. Integration tests exercise the cobra root, not the
+compiled binary — they won't catch `main.go` wiring bugs.
+
+## What this skill is not
+
+- Not a substitute for reading the code before proposing changes.
+- Not a reason to over-consult the user on trivial decisions. If the
+  change is one-line or obvious, just do it.

--- a/.claude/skills/iterate-design/SKILL.md
+++ b/.claude/skills/iterate-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: iterate-design
-description: Structured design iteration for non-trivial features on markgate. Forces a design sketch with trade-offs before code, guards against silent opinion-flipping when the user pushes back, and audits plan-vs-implementation proactively at the end. Use when the user asks "どう思う？" / "やるべき？" / "どう？", proposes a new flag/env/config field, or raises a feature with multiple valid shapes.
+description: Structured design iteration for non-trivial features on markgate. Forces a design sketch with trade-offs before code, guards against silent opinion-flipping when the user pushes back, and audits plan-vs-implementation proactively at the end. Use when the user asks for an opinion ("what do you think?", "should we?", "recommended?"), proposes a new flag / env / config field, or raises a feature with multiple valid shapes.
 ---
 
 # iterate-design
@@ -60,6 +60,16 @@ Caution signs that you are drifting:
 - Keep diffs minimal — no drive-by refactors, no hypothetical
   configurability, no "just in case" validation.
 - Run `go test ./... && go vet ./...` before claiming done.
+- **Don't delete something because you're unsure it works — test it.**
+  If a hook, script, or feature might be broken, build a minimal
+  reproduction (temp dir, fake input, run it) and verify. Removing the
+  thing to avoid shipping uncertainty is under-delivering; confirming
+  with a 30-second experiment is what the user is paying for.
+- **Don't churn edits on the same region.** If an edit turns out to
+  be wrong, revert to the previous clean state in one operation, then
+  make the correct edit. A sequence of tiny patches that adds then
+  removes the same phrase is a sign of indecision, not progress — the
+  diff review becomes noisy and the history becomes harder to follow.
 
 ## Phase 4 — audit (proactive)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,10 +70,16 @@ it is the spec — see "README as a spec" below.
 ```sh
 go build ./...        # compile check
 go test ./...         # full test suite (CLI tests spawn real git repos)
-go vet ./...          # catches misuse the compiler misses
+go vet ./...          # basic misuse check
+make lint             # golangci-lint with govet shadow + gocritic +
+                      # staticcheck + gosec + etc. Mirrors CI.
 ```
 
-Before reporting a task complete, run `go test ./... && go vet ./...`.
+Before reporting a task complete, run `go test ./... && make lint`.
+Plain `go vet` is **not enough**: CI's golangci-lint enables shadow
+detection, ineffassign, unused-variable, format-string checks, and
+more that `go vet` alone misses. If only `go vet` passed, CI is your
+audit — which is too late.
 
 ## Style
 
@@ -101,15 +107,17 @@ behavior, update the README in the same change. Pay attention to:
 
 ## Working with Claude on this repo
 
-- When the user asks for an opinion or proposes a new flag / env /
-  config field with multiple valid shapes, reach for the
-  [iterate-design](.claude/skills/iterate-design/SKILL.md) skill —
-  sketch options, pick one, get sign-off before coding.
-- When you implement a non-trivial feature, audit plan-vs-actual
-  proactively before reporting done (same skill).
-- Hold the line on recommendations. If the user pushes back, restate
-  the original reasoning first. Only flip if new information genuinely
-  invalidates it — and say so explicitly.
+Two project skills split the workflow by triggering moment:
+
+- **[iterate-design](.claude/skills/iterate-design/SKILL.md)** — fires
+  when the user asks for an opinion or proposes a new flag / env /
+  config field. Sketch options, pick one, hold the line if the user
+  pushes back, get sign-off before coding.
+- **[audit-before-done](.claude/skills/audit-before-done/SKILL.md)** —
+  fires when you're about to say "done" / push / create a PR. Covers
+  implementation discipline, the widened proactive audit, and the
+  "run what CI runs" rule (`make lint`, not just `go vet`). Use this
+  before every `git push` on non-trivial work.
 
 ### Subagents and branches
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,15 @@ it returns. Otherwise subagent findings can come from the wrong
 branch (e.g. "function X doesn't exist" because the agent was on a
 branch where X hasn't landed yet).
 
+For review tasks that span multiple branches, or to avoid *any* risk
+of the subagent shifting your working tree, pass
+`isolation: "worktree"` when spawning it. The agent runs against a
+throwaway git worktree, so its checkouts / edits never leak back.
+
+Always verify a subagent's negative findings ("X doesn't exist", "no
+reference to Y") against your current branch with `grep` before
+acting — the answer is only as good as the branch the agent read.
+
 ### Commit messages with non-ASCII
 
 When a commit message contains Japanese or other non-ASCII text,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,137 @@
+# markgate development notes
+
+markgate is a verification-state cache for hook managers. Users run
+`markgate run -- <cmd>` (or the `verify` / `set` / `clear` building
+blocks) to skip re-running a check when nothing relevant has changed
+since the last success. This file captures conventions for working on
+the tool itself; user-facing docs live in [README.md](README.md) and
+it is the spec — see "README as a spec" below.
+
+## Layout
+
+- `cmd/markgate/` — entrypoint; wires cobra into a binary.
+- `internal/cli/` — cobra commands (`set`, `verify`, `status`, `clear`,
+  `run`, `init`, `version`). Shared wiring is in `helper.go`:
+  - `newGateCtx` is the single reconciliation point for flags + env +
+    config. Every command goes through it.
+  - `addGateFlags` registers the override flags each command accepts.
+- `internal/config/` — `.markgate.yml` parsing (`Gate` struct,
+  `Config.Gate(key)`).
+- `internal/state/` — marker read / write. Atomic save via temp-file +
+  fsync + rename. Callers never touch files directly.
+- `internal/hasher/` — `GitTree` and `Files` strategies implement
+  `Hasher`.
+- `internal/gitutil/` — `git rev-parse` wrappers (top-level, git-dir,
+  HEAD SHA).
+- `internal/key/` — key syntax validation (`[a-z0-9][a-z0-9-]*`).
+
+## Design principles
+
+- **Zero-config default must keep working.** Adding a feature MUST NOT
+  require editing `.markgate.yml` to preserve existing behavior. Any
+  new override follows the chain:
+  **CLI flag > env var > `.markgate.yml` > default**.
+  See `resolveMarkerPath` in [internal/cli/helper.go](internal/cli/helper.go)
+  for the canonical implementation.
+- **Exit codes follow `grep` / `diff`**: 0 match, 1 mismatch, 2 error.
+  Errors surface as `&ExitError{Code: 2, Err: err}` — never panic on
+  user-facing failures.
+- **Atomic writes** via temp-file + fsync + rename (see `state.Save`).
+  A crash mid-write leaves either the old marker or nothing — never a
+  truncated file.
+- **Relative paths resolve against the repo top-level**, never cwd.
+  This keeps hook-invoked commands deterministic regardless of where
+  they run from.
+- **No implicit nesting of `markgate/`** when the user gives an
+  explicit path (`--state-dir` / `state_dir:`). The user owns the
+  layout they asked for.
+
+## Testing
+
+- End-to-end CLI tests live in
+  [internal/cli/integration_test.go](internal/cli/integration_test.go).
+  They drive the root command via `newRootCmd` + `root.Execute`.
+  **Prefer adding tests here** for new CLI behavior — internal unit
+  tests tend to re-verify what integration already covers.
+- Helpers:
+  - `initRepo(t)` — creates a fresh git repo in a temp dir and
+    `t.Chdir`s into it (auto-restored).
+  - `runCmd(t, args...)` — invokes the CLI, returns
+    `(exitCode, stdout)`.
+  - `writeRepoFile(t, dir, rel, body)` — writes a file under the repo.
+- Use `t.Setenv` for env-var coverage (auto-restored).
+- For precedence features, test each pair explicitly
+  (`flag > env`, `env > config`, `flag > config`) rather than only
+  end-to-end. See the `TestStateDir_*` cluster as the pattern.
+
+## Commands
+
+```sh
+go build ./...        # compile check
+go test ./...         # full test suite (CLI tests spawn real git repos)
+go vet ./...          # catches misuse the compiler misses
+```
+
+Before reporting a task complete, run `go test ./... && go vet ./...`.
+
+## Style
+
+- **No comments that describe *what* the code does.** Identifier names
+  do that. Add a comment only when the *why* is non-obvious (an
+  invariant, a subtle precedence rule, a workaround).
+- Match the existing terse comment voice — see `state.Save`'s
+  description of the temp-file dance.
+- No emojis in code, commits, docs, or responses unless the user asks.
+- Imports grouped stdlib / third-party / internal with blank lines
+  between groups (gofmt + the existing files agree).
+
+## README as a spec
+
+The README is the user-facing spec, not marketing. When changing
+behavior, update the README in the same change. Pay attention to:
+
+- **Use cases** — keep concrete examples working and honest.
+- **CLI reference / Per-invocation overrides / Environment variables
+  / Sharing markers** — these sections cross-reference. Touch one,
+  audit the others.
+- **FAQ** — likely to contain answers that touch the changed area.
+- **Link fragments** — if you rename a heading, fix every
+  `#heading-slug` reference in the file.
+
+## Working with Claude on this repo
+
+- When the user asks for an opinion or proposes a new flag / env /
+  config field with multiple valid shapes, reach for the
+  [iterate-design](.claude/skills/iterate-design/SKILL.md) skill —
+  sketch options, pick one, get sign-off before coding.
+- When you implement a non-trivial feature, audit plan-vs-actual
+  proactively before reporting done (same skill).
+- Hold the line on recommendations. If the user pushes back, restate
+  the original reasoning first. Only flip if new information genuinely
+  invalidates it — and say so explicitly.
+
+## Harness (.claude/)
+
+- `settings.json` pre-allows read-only dev commands (`go test`,
+  `go vet`, `git status`, `gh pr view`, ...) to cut permission
+  prompts.
+- `hooks/go-vet-on-edit.sh` is a PostToolUse hook: after every
+  Edit/Write on a `.go` file it runs `go vet ./...`, and it dogfoods
+  markgate to skip the run when repo state hasn't changed since the
+  last pass. A vet failure exits 2, so the diagnostic is surfaced
+  back to Claude as blocking feedback.
+
+### How the dogfood works (no install needed)
+
+The hook invokes markgate via `go run ./cmd/markgate` rather than a
+globally installed binary. Benefits:
+
+- Always reflects the current source — no `go install` / `make build`
+  to keep in sync.
+- Go's content-based build cache makes steady-state invocations fast
+  (~0.1s skip, ~0.3s run after cold compile). Only the first compile
+  after `go clean -cache` is slow (~2–3s).
+- Nothing lands outside the repo.
+
+Marker for this hook lives at `.git/markgate/hook-vet.json` (default
+location, git-ignored by virtue of being inside `.git/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,9 @@ it is the spec — see "README as a spec" below.
   require editing `.markgate.yml` to preserve existing behavior. Any
   new override follows the chain:
   **CLI flag > env var > `.markgate.yml` > default**.
-  See `resolveMarkerPath` in [internal/cli/helper.go](internal/cli/helper.go)
-  for the canonical implementation.
+  The canonical wire-up point is `newGateCtx` in
+  [internal/cli/helper.go](internal/cli/helper.go); whatever precedence
+  helper an existing override uses is the template for the next one.
 - **Exit codes follow `grep` / `diff`**: 0 match, 1 mismatch, 2 error.
   Errors surface as `&ExitError{Code: 2, Err: err}` — never panic on
   user-facing failures.
@@ -109,6 +110,24 @@ behavior, update the README in the same change. Pay attention to:
 - Hold the line on recommendations. If the user pushes back, restate
   the original reasoning first. Only flip if new information genuinely
   invalidates it — and say so explicitly.
+
+### Subagents and branches
+
+If you spawn an Explore or general-purpose subagent and the task
+needs a specific branch, **pin the branch in the prompt** ("on branch
+`feat/foo`, check …") and — since the subagent can `git checkout` in
+your working tree — `git checkout` back to your original branch after
+it returns. Otherwise subagent findings can come from the wrong
+branch (e.g. "function X doesn't exist" because the agent was on a
+branch where X hasn't landed yet).
+
+### Commit messages with non-ASCII
+
+When a commit message contains Japanese or other non-ASCII text,
+pass it via `git commit -F <file>` rather than a bash heredoc:
+heredoc + `$(...)` substitution can mis-parse embedded
+question-marks or quotes and fail with "unexpected EOF". Writing the
+message to a temp file first sidesteps all shell escaping.
 
 ## Harness (.claude/)
 


### PR DESCRIPTION
## Summary

Introduces `CLAUDE.md`, a project-scoped skill, a PostToolUse hook, and a pre-allowed permissions list for Claude Code sessions on this repo. Distilled from recent pairing sessions — no code changes to markgate itself.

## What's included

- **`CLAUDE.md`** — development notes specific to hacking on markgate (not marketing — `README.md` owns that). Covers package layout, the precedence-chain pattern for new overrides, integration-test helpers (`initRepo`, `runCmd`, `writeRepoFile`), style rules, and the "README as a spec" discipline.

- **`.claude/skills/iterate-design/SKILL.md`** — a project-scoped skill that triggers on opinion requests and new-flag proposals. Enforces: sketch options + trade-offs before code, hold the line instead of silently flipping when the user pushes back, and audit plan-vs-implementation proactively before reporting done.

- **`.claude/hooks/go-vet-on-edit.sh`** — PostToolUse hook on `Edit|Write` of `.go` files. **Dogfoods markgate** by calling `go run ./cmd/markgate run hook-vet -- go vet ./...`, so an unchanged repo state skips the vet run instantly. Uses `go run` rather than an installed binary so the hook always reflects current source with no `make install` required; Go's content-based build cache keeps steady-state invocations to ~0.1s. Vet failure exits 2 — Claude Code surfaces the diagnostic as blocking feedback.

- **`.claude/settings.json`** — pre-allows read-only dev commands (`go test`, `go vet`, `git status`, `gh pr view`, ...) to cut permission prompts, and wires the hook into `PostToolUse`.

## Test plan

- [x] `jq .` validates `.claude/settings.json`.
- [x] Hook: `.go` edit + vet clean → exit 0 silent.
- [x] Hook: non-`.go` edit → exit 0 silent.
- [x] Hook: `.go` edit + vet error (simulated) → exit 2 with stderr report.
- [x] Hook: repeat invocation with identical repo state → markgate skip path taken, end-to-end time ~0.1s.
- [x] Hook: markgate marker lands at `.git/markgate/hook-vet.json` (default location).
