### PR TITLE
fix: add top-level description to release composite action

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -1,4 +1,5 @@
 name: release
+description: Build and publish a release with GoReleaser, updating the Homebrew tap.
 inputs:
   github-token:
     required: true


### PR DESCRIPTION
## Summary
- Add the required top-level `description` field to `.github/actions/release/action.yml`. The composite action schema flags it as missing and the YAML linter surfaces it as an error.

## Test plan
- [x] Lint no longer reports "Required property is missing: description" for this file.
- [ ] CI green on this PR (release action itself only runs on tag push, so no behavior change expected here).