### PR TITLE
docs: restructure README for clarity and flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Linux / macOS / Windows archives (amd64 / arm64 / 386) — see
 ## Drop into your hook manager
 
 Substitute `pnpm test` with your verification command. When the
-hook can wrap the check, use `run`; when it sits *in front of* a
+hook runs the check itself, use `run`; when it sits *in front of* a
 separate command, use `verify` and pair it with `set` in the check
 itself (see [Two shapes](#two-shapes-run-vs-set--verify)).
 
@@ -285,7 +285,7 @@ repos:
 }
 ```
 
-In your check skill: `pnpm test && markgate set`. See
+In your `/check` skill: `pnpm test && markgate set`. See
 [Use case 1](#1-pre-commit-skip-duplicates-catch-forgotten-checks) for the full flow.
 
 ## Command model
@@ -309,7 +309,7 @@ lint, build, tests) that don't fit into a single `<cmd>`:
 
 ```sh
 # Wherever the check runs — record state on success:
-typecheck && lint && build && test && markgate set
+pnpm test && markgate set
 
 # Wherever the gate runs — short-circuit on a fresh marker, else re-run:
 markgate verify || pnpm test

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ managers (Claude Code hooks, husky, lefthook, pre-commit, bare
 agent to run the check; sometimes it forgets (context loss, tokens,
 speed pressure) and commits anyway. You add a pre-commit hook to
 enforce it; now every commit runs the check twice — once by the
-agent, once by the hook. `markgate` breaks this dilemma: commits
-without a fresh check get blocked, and duplicate runs exit instantly.
+agent, once by the hook. `markgate` breaks this dilemma: duplicate
+runs exit instantly, and commits without a fresh check get blocked.
 
 ## 20-second tour
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # markgate
 
-> Stop re-running your checks. Skip the commit hook when nothing has
-> changed since the last time they passed.
+Stop re-running your checks. Skip the commit hook when nothing has
+changed since the last time they passed.
 
 `markgate` is a verification-state cache for hook managers (Claude
 Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). When a

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ and the gate live in different places. Concrete scenarios:
 - **Claude Code gating `git commit`** — the `/check` skill runs the
   check and calls `markgate set` on success; a PreToolUse hook on
   `git commit` calls `markgate verify` to block un-verified commits.
-  The hook sits *in front of* `git commit`, so there's no check for
-  it to wrap. This is the canonical case.
-- **Multi-step checks** — `run -- <cmd>` wraps a single command;
+  The hook sits *in front of* `git commit`, so it can't run the
+  check itself. This is the canonical case.
+- **Multi-step checks** — `run -- <cmd>` takes a single command;
   split lets the check stay a plain script (typecheck → lint → build
   → test → `markgate set`) and stops forcing you to collapse
   everything into one command.
@@ -108,7 +108,9 @@ commit.**
 ## Use cases
 
 Each section below follows the same shape: **Scope** (config) →
-**Wire** (shell).
+**Wire** (shell). The first use case works with zero config; the
+rest define scoped gates in
+[`.markgate.yml`](#markgateyml-optional) at the repo root.
 
 ### 1. Pre-commit: skip duplicates, catch forgotten checks
 
@@ -131,8 +133,7 @@ hook verifies instantly. Commit without a prior `/check` → hook returns
 ### 2. Pre-PR: docs consistency
 
 **Scope**: only `docs/` and `README.md`. Code-only commits don't
-invalidate the marker. Configured in
-[`.markgate.yml`](#markgateyml-optional) at the repo root:
+invalidate the marker.
 
 ```yaml
 # .markgate.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # markgate
 
-Skip the checks that already passed. Catch the ones that never ran.
+**Skip the checks that already passed. Catch the ones that never ran.**
 
 Your agent ran the check. Your commit hook runs it again. CI runs
 it again. `markgate` makes the duplicates instant — and catches

--- a/README.md
+++ b/README.md
@@ -125,9 +125,11 @@ Both shapes appear throughout the use cases below.
 ## Use cases
 
 Each section below follows the same shape: **Scope** (what triggers
-re-verify) → **Commands** (what goes in your shell / hook). The
-first use case works with zero config; the rest define scoped gates
-in [`.markgate.yml`](#markgateyml-optional) at the repo root.
+re-verify — a [`hash`](#hashing-strategy-git-tree-vs-files) strategy)
+→ **Commands** (what goes in your shell / hook). The first use case
+works with zero config (default `git-tree` hash, whole repo); the
+rest define scoped `files`-hash gates in
+[`.markgate.yml`](#markgateyml-optional) at the repo root.
 
 ### 1. Pre-commit: skip duplicates, catch forgotten checks
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,12 @@ pnpm run typecheck
 pnpm run lint:fix
 pnpm run build
 pnpm test
-markgate set
+markgate set   # ← record the pass; markgate's only addition
+```
 
+Then the hook — a separate file — only verifies the marker:
+
+```sh
 # .claude/settings.json PreToolUse on `git commit`:
 markgate verify
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ the check directly (husky, lefthook, pre-commit framework, bare
 `pre-commit`).
 
 ```sh
+# .husky/pre-commit (or lefthook.yml, .pre-commit-hooks.yaml, ...):
 markgate run -- make check
+# First hook: make check runs. Next hook with no changes: instant skip.
 ```
 
 **`markgate set` + `markgate verify`** — split. Use when the check
@@ -63,11 +65,12 @@ and the gate live in different places. Concrete scenarios:
   skipping a second run when nothing has changed since the commit.
 
 ```sh
-# Wherever the check runs — record state on success:
+# In your /check skill (or verify script, build.sh, ...):
 make check && markgate set
 
-# Wherever the gate runs — short-circuit on a fresh marker, else re-run:
-markgate verify || make check
+# In .claude/settings.json PreToolUse hook on `git commit`:
+markgate verify
+# exit 0 → commit proceeds; exit 1 → commit blocked, agent re-runs /check.
 ```
 
 Full semantics and exit codes are in [Command model](#command-model).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ tests passed in 4.2s
 $ markgate run -- pnpm test
 
 # After you edit a file — cache is stale, `pnpm test` runs again.
-$ echo '// fix typo' >> src/foo.go
+$ echo '// fix typo' >> src/foo.ts
 $ markgate run -- pnpm test
 tests passed in 4.1s
 ```
@@ -41,9 +41,9 @@ moved.
 
 Pick by where your hook sits relative to the check.
 
-**`markgate run -- <cmd>`** — one-shot. Use when the hook can wrap
-the check directly (husky, lefthook, pre-commit framework, bare
-`pre-commit`).
+**`markgate run -- <cmd>`** — one-shot. Use where the hook runs the
+check itself (husky, lefthook, pre-commit framework, bare
+`pre-commit`): just prefix your check command with `markgate run --`.
 
 ```sh
 # .husky/pre-commit (or lefthook.yml, .pre-commit-hooks.yaml, ...):

--- a/README.md
+++ b/README.md
@@ -42,13 +42,33 @@ moved.
 Pick by where your hook sits relative to the check.
 
 **`markgate run -- <cmd>`** — one-shot. Use where the hook runs the
-check itself (husky, lefthook, pre-commit framework, bare
-`pre-commit`): just prefix your check command with `markgate run --`.
+check itself — husky, lefthook, pre-commit framework, bare
+`pre-commit`, or Claude Code PreToolUse. Just prefix your check
+command with `markgate run --`.
 
 ```sh
 # .husky/pre-commit (or lefthook.yml, .pre-commit-hooks.yaml, ...):
 markgate run -- pnpm test
 # First hook: pnpm test runs. Next hook with no changes: instant skip.
+```
+
+Or in Claude Code:
+
+```json
+// .claude/settings.json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "if": "Bash(git commit*)",
+        "hooks": [
+          { "type": "command", "command": "markgate run -- pnpm test" }
+        ]
+      }
+    ]
+  }
+}
 ```
 
 **`markgate set` + `markgate verify`** — split. Use when the check
@@ -57,8 +77,9 @@ and the gate live in different places. Concrete scenarios:
 - **Claude Code gating `git commit`** — the `/check` skill runs the
   check and calls `markgate set` on success; a PreToolUse hook on
   `git commit` calls `markgate verify` to block un-verified commits.
-  The hook sits *in front of* `git commit`, so it can't run the
-  check itself. This is the canonical case.
+  Splitting instead of `run` keeps `/check` as an explicit agent
+  action with streaming output in the skill, and keeps the hook
+  itself a lean gate. This is the canonical case.
 - **Multi-step checks** — `run -- <cmd>` takes a single command;
   split lets the check stay a plain script (typecheck → lint → build
   → test → `markgate set`) and stops forcing you to collapse

--- a/README.md
+++ b/README.md
@@ -73,14 +73,28 @@ pnpm run typecheck
 pnpm run lint:fix
 pnpm run build
 pnpm test
-markgate set   # ← record the pass; markgate's only addition
+
+# record the pass; markgate's only addition
+markgate set
 ```
 
 Then the hook only verifies the marker:
 
 ```json
-// .claude/settings.json PreToolUse on `git commit`:
-{ "type": "command", "command": "markgate verify" }
+// .claude/settings.json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "if": "Bash(git commit*)",
+        "hooks": [
+          { "type": "command", "command": "markgate verify" }
+        ]
+      }
+    ]
+  }
+}
 ```
 
 Full semantics and exit codes are in [Command model](#command-model).

--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # markgate
 
 `markgate` is a verification-state cache for hook managers (Claude
-Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). When
-a check passes, it writes a small JSON **marker** recording the
-current repo state — the next hook exits in milliseconds if the
-state matches, or re-runs the check if it's moved. Your hooks can:
+Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). Your
+hooks can:
 
 - **Skip the checks that already passed** — instant exit when the
-  marker matches the current state.
-- **Catch the ones that never ran** — block the commit when no
-  marker matches the current state.
+  repo state hasn't changed since the last successful run.
+- **Catch the ones that never ran** — block the commit when the
+  check hasn't been recorded yet.
 
 **Especially useful in the AI-coding-agent era.** Your agent ran
 the check. Your commit hook runs it again. `gh pr create` runs it
 again. CI runs it again. `markgate` makes the duplicates instant —
 and catches commits where the check never ran.
+
+When a check passes, `markgate` writes a small JSON **marker**
+recording the current repo state. The next hook run exits in
+milliseconds if the state matches, or re-runs the check if it's
+moved.
 
 ## 20-second tour
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # markgate
 
-Stop re-running your checks. Skip the commit hook when nothing has
-changed since the last time they passed.
+Skip the checks that already passed. Catch the ones that never ran.
+
+Your agent ran the check. Your commit hook runs it again. CI runs
+it again. `markgate` makes the duplicates instant — and catches
+commits where the check never ran.
 
 `markgate` is a verification-state cache for hook managers (Claude
 Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). When a
 check passes, it writes a small JSON **marker** recording the current
 repo state. On the next hook run, if the state hasn't moved, the
 check skips in milliseconds — if it has, the check runs again.
-Especially useful in AI-agent-driven workflows, where the same check
-runs redundantly or gets quietly skipped.
 
 ## 20-second tour
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,13 @@ and the gate live in different places. Concrete scenarios:
   skipping a second run when nothing has changed since the commit.
 
 ```sh
-# In your /check skill (or verify script, build.sh, ...):
+# /check skill (or any script that runs the check):
 make check && markgate set
 
-# In .claude/settings.json PreToolUse hook on `git commit`:
+# .claude/settings.json PreToolUse on `git commit` — sits *in front of*
+# the commit, can't wrap `make check`. It only verifies the marker set
+# above. (This is what forces the split — you can't write `run -- make
+# check` here, or every commit would trigger a fresh check run.)
 markgate verify
 # exit 0 → commit proceeds; exit 1 → commit blocked, agent re-runs /check.
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ hook verifies instantly. Commit without a prior `/check` → hook returns
 ### 2. Pre-PR: docs consistency
 
 **Scope**: only `docs/` and `README.md`. Code-only commits don't
-invalidate the marker.
+invalidate the marker. Configured in
+[`.markgate.yml`](#markgateyml-optional) at the repo root:
 
 ```yaml
 # .markgate.yml

--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ hooks can:
 **Especially useful in the AI-coding-agent era.** You tell your
 agent to run the check; sometimes it forgets (context loss, tokens,
 speed pressure) and commits anyway. You add a pre-commit hook to
-enforce it; now the check runs redundantly every commit — agent,
-hook, `gh pr create`, CI, four passes, one state. `markgate` breaks
-this dilemma: commits without a fresh check get blocked, and
-duplicate runs exit instantly.
+enforce it; now every commit runs the check twice — once by the
+agent, once by the hook. `markgate` breaks this dilemma: commits
+without a fresh check get blocked, and duplicate runs exit instantly.
 
 ## 20-second tour
 

--- a/README.md
+++ b/README.md
@@ -57,23 +57,24 @@ and the gate live in different places. Concrete scenarios:
   `git commit` calls `markgate verify` to block un-verified commits.
   The hook sits *in front of* `git commit`, so there's no check for
   it to wrap. This is the canonical case.
-- **Multi-step checks** — `typecheck && lint && build && test &&
-  markgate set`. `run -- <cmd>` wraps a single command; split works
-  with any script or Makefile target.
+- **Multi-step checks** — `run -- <cmd>` wraps a single command;
+  split lets the check stay a plain script (typecheck → lint → build
+  → test → `markgate set`) and stops forcing you to collapse
+  everything into one command.
 - **Commit-then-push** — the commit hook runs the check (`... &&
   markgate set`); the push hook only calls `markgate verify`,
   skipping a second run when nothing has changed since the commit.
 
 ```sh
-# /check skill (or any script that runs the check):
-make check && markgate set
+# /check skill body (or build script, CI job, Make target):
+pnpm run typecheck
+pnpm run lint:fix
+pnpm run build
+npx vitest --run
+markgate set
 
-# .claude/settings.json PreToolUse on `git commit` — sits *in front of*
-# the commit, can't wrap `make check`. It only verifies the marker set
-# above. (This is what forces the split — you can't write `run -- make
-# check` here, or every commit would trigger a fresh check run.)
+# .claude/settings.json PreToolUse on `git commit`:
 markgate verify
-# exit 0 → commit proceeds; exit 1 → commit blocked, agent re-runs /check.
 ```
 
 Full semantics and exit codes are in [Command model](#command-model).

--- a/README.md
+++ b/README.md
@@ -107,16 +107,16 @@ commit.**
 
 ## Use cases
 
-Each section below follows the same shape: **Scope** (config) →
-**Wire** (shell). The first use case works with zero config; the
-rest define scoped gates in
-[`.markgate.yml`](#markgateyml-optional) at the repo root.
+Each section below follows the same shape: **Scope** (what triggers
+re-verify) → **Commands** (what goes in your shell / hook). The
+first use case works with zero config; the rest define scoped gates
+in [`.markgate.yml`](#markgateyml-optional) at the repo root.
 
 ### 1. Pre-commit: skip duplicates, catch forgotten checks
 
 **Scope**: anything tracked by git. No config needed (default `git-tree`).
 
-**Wire**:
+**Commands**:
 
 ```sh
 # In your check command:
@@ -145,7 +145,7 @@ gates:
       - "README.md"
 ```
 
-**Wire**:
+**Commands**:
 
 ```sh
 ./scripts/check-docs && markgate set pre-pr
@@ -172,7 +172,7 @@ gates:
       - "package-lock.json"
 ```
 
-**Wire**:
+**Commands**:
 
 ```sh
 trivy image ... && markgate set pre-image-push
@@ -194,7 +194,7 @@ gates:
       - "tests/**"
 ```
 
-**Wire**:
+**Commands**:
 
 ```sh
 go test -cover && markgate set pre-push

--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ check skips in milliseconds — if it has, the check runs again.
 ## 20-second tour
 
 ```sh
-# First run — no marker yet, so `make check` runs and the marker is saved.
-$ markgate run -- make check
+# First run — no marker yet, so `./check.sh` runs and the marker is saved.
+$ markgate run -- ./check.sh
 linting...
 tests passed in 4.2s
 
 # Second run — nothing changed since the last success: instant skip.
-$ markgate run -- make check
+$ markgate run -- ./check.sh
 
-# After you edit a file — marker is stale, `make check` runs again.
+# After you edit a file — marker is stale, `./check.sh` runs again.
 $ echo '// fix typo' >> src/foo.go
-$ markgate run -- make check
+$ markgate run -- ./check.sh
 linting...
 tests passed in 4.1s
 ```
 
 Zero config. No key argument needed. That is the intended daily usage.
-(`make check` is a placeholder — substitute your project's verification
+(`./check.sh` is a placeholder — substitute your project's verification
 command.)
 
 ## Two shapes: `run` vs `set` + `verify`
@@ -45,8 +45,8 @@ the check directly (husky, lefthook, pre-commit framework, bare
 
 ```sh
 # .husky/pre-commit (or lefthook.yml, .pre-commit-hooks.yaml, ...):
-markgate run -- make check
-# First hook: make check runs. Next hook with no changes: instant skip.
+markgate run -- ./check.sh
+# First hook: ./check.sh runs. Next hook with no changes: instant skip.
 ```
 
 **`markgate set` + `markgate verify`** — split. Use when the check
@@ -70,7 +70,7 @@ and the gate live in different places. Concrete scenarios:
 pnpm run typecheck
 pnpm run lint:fix
 pnpm run build
-npx vitest --run
+pnpm test
 markgate set
 
 # .claude/settings.json PreToolUse on `git commit`:
@@ -87,7 +87,7 @@ Hook managers are great at *running* checks; none remember when one
 just passed. `markgate` is that memory layer — exit 0 = verified,
 exit 1 = run it. One line to adopt, one line to remove.
 
-**Redundant re-runs.** Your agent (or you) just ran `make check`.
+**Redundant re-runs.** Your agent (or you) just ran `./check.sh`.
 The commit hook runs it again. `gh pr create` runs it again. CI
 runs it again — four passes, one change. `markgate` lets the second
 / third / fourth of those exit instantly when the repo state hasn't
@@ -116,7 +116,7 @@ Each section below follows the same shape: **Scope** (config) →
 
 ```sh
 # In your check command:
-make check && markgate set
+./check.sh && markgate set
 
 # In your Claude Code PreToolUse hook on `git commit*`:
 markgate verify
@@ -230,7 +230,7 @@ Linux / macOS / Windows archives (amd64 / arm64 / 386) — see
 
 ## Drop into your hook manager
 
-Substitute `make check` with your verification command. When the
+Substitute `./check.sh` with your verification command. When the
 hook can wrap the check, use `run`; when it sits *in front of* a
 separate command, use `verify` and pair it with `set` in the check
 itself (see [Two shapes](#two-shapes-run-vs-set--verify)).
@@ -238,7 +238,7 @@ itself (see [Two shapes](#two-shapes-run-vs-set--verify)).
 **husky** — `.husky/pre-commit`:
 
 ```sh
-markgate run -- make check
+markgate run -- ./check.sh
 ```
 
 **lefthook** — `lefthook.yml`:
@@ -247,7 +247,7 @@ markgate run -- make check
 pre-commit:
   commands:
     check:
-      run: markgate run -- make check
+      run: markgate run -- ./check.sh
 ```
 
 **pre-commit framework** — `.pre-commit-hooks.yaml`:
@@ -258,7 +258,7 @@ repos:
     hooks:
       - id: markgate-check
         name: markgate check
-        entry: markgate run -- make check
+        entry: markgate run -- ./check.sh
         language: system
         pass_filenames: false
 ```
@@ -281,7 +281,7 @@ repos:
 }
 ```
 
-In your check skill: `make check && markgate set`. See
+In your check skill: `./check.sh && markgate set`. See
 [Use case 1](#1-pre-commit-skip-duplicate-checks) for the full flow.
 
 ## Command model
@@ -308,7 +308,7 @@ lint, build, tests) that don't fit into a single `<cmd>`:
 typecheck && lint && build && test && markgate set
 
 # Wherever the gate runs — short-circuit on a fresh marker, else re-run:
-markgate verify || make check
+markgate verify || ./check.sh
 ```
 
 ### Exit codes
@@ -395,7 +395,7 @@ Flag syntax is identical across hash types. With `--hash files`,
 config file:
 
 ```sh
-markgate run --exclude 'vendor/**' -- make check
+markgate run --exclude 'vendor/**' -- ./check.sh
 ```
 
 ### Environment variables

--- a/README.md
+++ b/README.md
@@ -9,15 +9,13 @@ hooks can:
 - **Catch the ones that never ran** — block the commit when the
   check hasn't been recorded yet.
 
-**Especially useful in the AI-coding-agent era.** Your agent ran
-the check. Your commit hook runs it again. `gh pr create` runs it
-again. CI runs it again. `markgate` makes the duplicates instant —
-and catches commits where the check never ran.
-
-When a check passes, `markgate` writes a small JSON **marker**
-recording the current repo state. The next hook run exits in
-milliseconds if the state matches, or re-runs the check if it's
-moved.
+**Especially useful in the AI-coding-agent era.** You tell your
+agent to run the check; sometimes it forgets (context loss, tokens,
+speed pressure) and commits anyway. You add a pre-commit hook to
+enforce it; now the check runs redundantly every commit — agent,
+hook, `gh pr create`, CI, four passes, one state. `markgate` breaks
+this dilemma: commits without a fresh check get blocked, and
+duplicate runs exit instantly.
 
 ## 20-second tour
 
@@ -40,6 +38,11 @@ tests passed in 4.1s
 Zero config. No key argument needed. That is the intended daily usage.
 (`pnpm test` is a placeholder — substitute your project's verification
 command.)
+
+Under the hood, when a check passes, `markgate` writes a small JSON
+**marker** recording the current repo state. The next hook run exits
+in milliseconds if the state matches, or re-runs the check if it's
+moved.
 
 ## Two shapes: `run` vs `set` + `verify`
 

--- a/README.md
+++ b/README.md
@@ -19,22 +19,20 @@ without a fresh check get blocked, and duplicate runs exit instantly.
 ## 20-second tour
 
 ```sh
-# First run — no marker yet, so `pnpm test` runs and the marker is saved.
+# First run — nothing cached yet, so `pnpm test` runs and the pass is cached.
 $ markgate run -- pnpm test
 tests passed in 4.2s
 
 # Second run — nothing changed since the last success: instant skip.
 $ markgate run -- pnpm test
 
-# After you edit a file — marker is stale, `pnpm test` runs again.
+# After you edit a file — cache is stale, `pnpm test` runs again.
 $ echo '// fix typo' >> src/foo.go
 $ markgate run -- pnpm test
 tests passed in 4.1s
 ```
 
-Zero config. No key argument needed. That is the intended daily usage.
-(`pnpm test` is a placeholder — substitute your project's verification
-command.)
+Zero config. That is the intended daily usage.
 
 Under the hood, when a check passes, `markgate` writes a small JSON
 **marker** recording the current repo state. The next hook run exits

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ Or in Claude Code:
 **`markgate set` + `markgate verify`** — split. Use when the check
 and the gate live in different places. Concrete scenarios:
 
-- **Claude Code gating `git commit`** — the `/check` skill runs the
-  check and calls `markgate set` on success; a PreToolUse hook on
-  `git commit` calls `markgate verify` to block un-verified commits.
-  Splitting instead of `run` keeps `/check` as an explicit agent
-  action with streaming output in the skill, and keeps the hook
-  itself a lean gate. This is the canonical case.
+- **Explicit check + commit gate** — canonical in Claude Code: the
+  `/check` skill runs the check and calls `markgate set`; a
+  PreToolUse hook on `git commit` calls `markgate verify` to block
+  un-verified commits. Splitting (not `run`) keeps `/check` as an
+  explicit agent action with streaming output in the skill, and
+  keeps the hook a lean gate.
 - **Multi-step checks** — `run -- <cmd>` takes a single command;
   split lets the check stay a plain script (typecheck → lint → build
   → test → `markgate set`) and stops forcing you to collapse

--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ check skips in milliseconds — if it has, the check runs again.
 ## 20-second tour
 
 ```sh
-# First run — no marker yet, so `./check.sh` runs and the marker is saved.
-$ markgate run -- ./check.sh
+# First run — no marker yet, so `pnpm test` runs and the marker is saved.
+$ markgate run -- pnpm test
 linting...
 tests passed in 4.2s
 
 # Second run — nothing changed since the last success: instant skip.
-$ markgate run -- ./check.sh
+$ markgate run -- pnpm test
 
-# After you edit a file — marker is stale, `./check.sh` runs again.
+# After you edit a file — marker is stale, `pnpm test` runs again.
 $ echo '// fix typo' >> src/foo.go
-$ markgate run -- ./check.sh
+$ markgate run -- pnpm test
 linting...
 tests passed in 4.1s
 ```
 
 Zero config. No key argument needed. That is the intended daily usage.
-(`./check.sh` is a placeholder — substitute your project's verification
+(`pnpm test` is a placeholder — substitute your project's verification
 command.)
 
 ## Two shapes: `run` vs `set` + `verify`
@@ -45,8 +45,8 @@ the check directly (husky, lefthook, pre-commit framework, bare
 
 ```sh
 # .husky/pre-commit (or lefthook.yml, .pre-commit-hooks.yaml, ...):
-markgate run -- ./check.sh
-# First hook: ./check.sh runs. Next hook with no changes: instant skip.
+markgate run -- pnpm test
+# First hook: pnpm test runs. Next hook with no changes: instant skip.
 ```
 
 **`markgate set` + `markgate verify`** — split. Use when the check
@@ -87,14 +87,14 @@ Hook managers are great at *running* checks; none remember when one
 just passed. `markgate` is that memory layer — exit 0 = verified,
 exit 1 = run it. One line to adopt, one line to remove.
 
-**Redundant re-runs.** Your agent (or you) just ran `./check.sh`.
+**Skip what already passed.** Your agent (or you) just ran `pnpm test`.
 The commit hook runs it again. `gh pr create` runs it again. CI
 runs it again — four passes, one change. `markgate` lets the second
 / third / fourth of those exit instantly when the repo state hasn't
 moved. (The CI pass needs a bit of extra wiring — see
 [Sharing markers](#sharing-markers-across-machines-ci--teammates).)
 
-**Quietly skipped checks.** Your agent decided to run `/check`, then
+**Catch what never ran.** Your agent decided to run `/check`, then
 ran out of tool budget / context and committed anyway. Or a tool
 call silently failed. Or it simply forgot. Wire `markgate verify`
 into your pre-commit or PreToolUse hook and there's no bypass by
@@ -108,7 +108,7 @@ commit.**
 Each section below follows the same shape: **Scope** (config) →
 **Wire** (shell).
 
-### 1. Pre-commit: skip duplicate checks
+### 1. Pre-commit: skip duplicates, catch forgotten checks
 
 **Scope**: anything tracked by git. No config needed (default `git-tree`).
 
@@ -116,7 +116,7 @@ Each section below follows the same shape: **Scope** (config) →
 
 ```sh
 # In your check command:
-./check.sh && markgate set
+pnpm test && markgate set
 
 # In your Claude Code PreToolUse hook on `git commit*`:
 markgate verify
@@ -230,7 +230,7 @@ Linux / macOS / Windows archives (amd64 / arm64 / 386) — see
 
 ## Drop into your hook manager
 
-Substitute `./check.sh` with your verification command. When the
+Substitute `pnpm test` with your verification command. When the
 hook can wrap the check, use `run`; when it sits *in front of* a
 separate command, use `verify` and pair it with `set` in the check
 itself (see [Two shapes](#two-shapes-run-vs-set--verify)).
@@ -238,7 +238,7 @@ itself (see [Two shapes](#two-shapes-run-vs-set--verify)).
 **husky** — `.husky/pre-commit`:
 
 ```sh
-markgate run -- ./check.sh
+markgate run -- pnpm test
 ```
 
 **lefthook** — `lefthook.yml`:
@@ -247,7 +247,7 @@ markgate run -- ./check.sh
 pre-commit:
   commands:
     check:
-      run: markgate run -- ./check.sh
+      run: markgate run -- pnpm test
 ```
 
 **pre-commit framework** — `.pre-commit-hooks.yaml`:
@@ -258,7 +258,7 @@ repos:
     hooks:
       - id: markgate-check
         name: markgate check
-        entry: markgate run -- ./check.sh
+        entry: markgate run -- pnpm test
         language: system
         pass_filenames: false
 ```
@@ -281,8 +281,8 @@ repos:
 }
 ```
 
-In your check skill: `./check.sh && markgate set`. See
-[Use case 1](#1-pre-commit-skip-duplicate-checks) for the full flow.
+In your check skill: `pnpm test && markgate set`. See
+[Use case 1](#1-pre-commit-skip-duplicates-catch-forgotten-checks) for the full flow.
 
 ## Command model
 
@@ -308,7 +308,7 @@ lint, build, tests) that don't fit into a single `<cmd>`:
 typecheck && lint && build && test && markgate set
 
 # Wherever the gate runs — short-circuit on a fresh marker, else re-run:
-markgate verify || ./check.sh
+markgate verify || pnpm test
 ```
 
 ### Exit codes
@@ -395,7 +395,7 @@ Flag syntax is identical across hash types. With `--hash files`,
 config file:
 
 ```sh
-markgate run --exclude 'vendor/**' -- ./check.sh
+markgate run --exclude 'vendor/**' -- pnpm test
 ```
 
 ### Environment variables

--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
 # markgate
 
 `markgate` is a verification-state cache for hook managers (Claude
-Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). It
-lets your hooks:
+Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). When
+a check passes, it writes a small JSON **marker** recording the
+current repo state — the next hook exits in milliseconds if the
+state matches, or re-runs the check if it's moved. Your hooks can:
 
 - **Skip the checks that already passed** — instant exit when the
-  repo state matches the last successful run.
-- **Catch the ones that never ran** — block the commit when there's
-  no fresh marker to verify.
+  marker matches the current state.
+- **Catch the ones that never ran** — block the commit when no
+  marker matches the current state.
 
 **Especially useful in the AI-coding-agent era.** Your agent ran
 the check. Your commit hook runs it again. `gh pr create` runs it
 again. CI runs it again. `markgate` makes the duplicates instant —
 and catches commits where the check never ran.
-
-When a check passes, `markgate` writes a small JSON **marker**
-recording the current repo state. On the next hook run, if the
-state hasn't moved, the check skips in milliseconds — if it has,
-the check runs again.
 
 ## 20-second tour
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ without a fresh check get blocked, and duplicate runs exit instantly.
 ```sh
 # First run — no marker yet, so `pnpm test` runs and the marker is saved.
 $ markgate run -- pnpm test
-linting...
 tests passed in 4.2s
 
 # Second run — nothing changed since the last success: instant skip.
@@ -30,7 +29,6 @@ $ markgate run -- pnpm test
 # After you edit a file — marker is stale, `pnpm test` runs again.
 $ echo '// fix typo' >> src/foo.go
 $ markgate run -- pnpm test
-linting...
 tests passed in 4.1s
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # markgate
 
-`markgate` is a verification-state cache for hook managers (Claude
-Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). Your
-hooks can:
+`markgate` is a zero-config verification-state cache for hook
+managers (Claude Code hooks, husky, lefthook, pre-commit, bare
+`.git/hooks/*`). Your hooks can:
 
 - **Skip the checks that already passed** — instant exit when the
   repo state hasn't changed since the last successful run.
@@ -31,8 +31,6 @@ $ echo '// fix typo' >> src/foo.go
 $ markgate run -- pnpm test
 tests passed in 4.1s
 ```
-
-Zero config. That is the intended daily usage.
 
 Under the hood, when a check passes, `markgate` writes a small JSON
 **marker** recording the current repo state. The next hook run exits

--- a/README.md
+++ b/README.md
@@ -4,22 +4,12 @@
 > changed since the last time they passed.
 
 `markgate` is a verification-state cache for hook managers (Claude
-Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). It
-records that a check passed at the current repo state so the next hook
-can skip re-running it.
-
-**Especially useful in the AI-coding-agent era.** Two patterns hit
-hard when Claude Code / Cursor / Codex / Copilot CLI is the one
-running checks:
-
-- **Redundancy** — the agent runs your `/check`, then the commit
-  hook runs it, then `gh pr create` runs it, then CI runs it.
-  `markgate` exits in milliseconds on every pass after the first.
-- **Skipped steps** — the agent may quietly skip the check it
-  promised to run (context loss, tool timeout, speed pressure).
-  Pair `markgate verify` with your pre-commit / PreToolUse hook and
-  the commit blocks until the check actually ran against the current
-  state. **No marker, no commit.**
+Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). When a
+check passes, it writes a small JSON **marker** recording the current
+repo state. On the next hook run, if the state hasn't moved, the
+check skips in milliseconds — if it has, the check runs again.
+Especially useful in AI-agent-driven workflows, where the same check
+runs redundantly or gets quietly skipped.
 
 ## 20-second tour
 
@@ -43,9 +33,24 @@ Zero config. No key argument needed. That is the intended daily usage.
 (`make check` is a placeholder — substitute your project's verification
 command.)
 
+## Two shapes: `run` vs `set` + `verify`
+
+Pick by where your hook sits relative to the check:
+
+- **`markgate run -- <cmd>`** — one-shot. Use when the hook can wrap
+  the check directly (husky, lefthook, pre-commit framework, bare
+  `pre-commit`).
+- **`markgate set` + `markgate verify`** — split. Use when the check
+  and the gate live in different places (Claude Code PreToolUse,
+  multi-step pipelines, commit-then-push flows). The check calls
+  `set` on success; the gate calls `verify` to short-circuit.
+
+Full semantics and exit codes are in [Command model](#command-model).
+Both shapes appear throughout the use cases below.
+
 ## Why markgate?
 
-Two failure modes in an agent-driven workflow, one cache layer.
+Two failure modes in an AI-agent-driven workflow, one cache layer.
 
 **Redundant re-runs.** Your agent (or you) just ran `make check`.
 The commit hook runs it again. `gh pr create` runs it again. CI
@@ -60,19 +65,8 @@ call silently failed. Or it simply forgot. Wire `markgate verify`
 into your pre-commit or PreToolUse hook and there's no bypass by
 "forgetting" — a fresh marker exists only after a check actually
 passed against the current state. Exit 1 with "no marker" is a
-loud, debuggable failure; a silent skip is not.
-
-Concrete gates you can build (see [Use cases](#use-cases) for full
-configs):
-
-- **Pre-commit: skip duplicate checks** — skip lint / test / build when
-  nothing changed since the last `/check`.
-- **Pre-PR: docs consistency** — re-verify docs only when `docs/**` or
-  `README.md` actually changed. Code-only commits are free.
-- **Pre-image-push: vulnerability scan freshness** — re-run `trivy`
-  only when `Dockerfile` or lockfiles changed.
-- **Pre-push: coverage report freshness** — re-run the test suite only
-  when `src/**` or `tests/**` changed.
+loud, debuggable failure; a silent skip is not. **No marker, no
+commit.**
 
 Existing hook managers (husky / lefthook / pre-commit / Claude Code
 hooks) are great at *running* checks. None of them remember that a
@@ -81,209 +75,6 @@ that memory layer — exit 0 = "verified, skip", exit 1 = "stale or
 absent, run it". It's not a hook manager itself; it slots into
 whatever hook manager you already use — one line to adopt, one line
 to remove.
-
-## Usage
-
-### `markgate run -- <cmd>` (main)
-
-`markgate run -- <cmd>` is the idiomatic form. It collapses the common
-verify → run → set cycle into one invocation:
-
-1. **verify** — if the marker matches, `<cmd>` is not executed; exit 0
-   immediately.
-2. Otherwise **execute `<cmd>`**. stdio is passed through;
-   `SIGINT` / `SIGTERM` are forwarded to the child.
-3. On success, **set** the marker. On failure, the marker is **not**
-   updated and `<cmd>`'s exit code is returned as-is.
-
-```sh
-markgate run -- make check
-```
-
-Most hook setups only need this one command.
-
-### `markgate set` / `markgate verify` (building blocks)
-
-Reach for the two halves directly when `run` doesn't fit:
-
-- **Multi-step check pipelines** — `run -- <cmd>` wraps a single
-  command. If your check is several steps (typecheck, lint, build,
-  tests) spread across a script or skill, run them normally and call
-  `markgate set` once at the end, after all pass.
-- **Check and gate in different places** — e.g. a Claude Code skill
-  runs the check and records the marker, while a PreToolUse hook on
-  `git commit*` only calls `markgate verify` to gate.
-
-```sh
-# Wherever the check runs — record state on success:
-typecheck && lint && build && test && markgate set
-
-# Wherever the gate runs — short-circuit on a fresh marker, else re-run:
-markgate verify || make check
-```
-
-Exit codes follow the `grep` / `diff` convention, so `||` composes
-naturally:
-
-| exit | meaning                                                   |
-| ---- | --------------------------------------------------------- |
-| 0    | verified — state matches the marker, safe to skip         |
-| 1    | not verified — no marker, or state differs                |
-| 2    | error — not in a repo, bad config, bad key, etc.          |
-
-## Drop into your hook
-
-If the hook can wrap your check command, use `markgate run -- <cmd>`
-(husky / lefthook / pre-commit). If the hook only sits *in front of*
-the command (Claude Code PreToolUse, bare `.git/hooks/*`), use
-`markgate verify` (exit 0 = skip, exit 1 = re-run) and pair it with
-`markgate set` in the check command itself.
-
-### Claude Code (PreToolUse hook)
-
-`.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "if": "Bash(git commit*)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "markgate verify"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-In your check skill:
-
-```sh
-make check && markgate set
-```
-
-See [Use cases § Pre-commit](#1-pre-commit-skip-duplicate-checks) for
-the full flow.
-
-### husky
-
-`.husky/pre-commit`:
-
-```sh
-markgate run -- make check
-```
-
-### lefthook
-
-`lefthook.yml`:
-
-```yaml
-pre-commit:
-  commands:
-    check:
-      run: markgate run -- make check
-```
-
-### pre-commit framework
-
-`.pre-commit-hooks.yaml`:
-
-```yaml
-repos:
-  - repo: local
-    hooks:
-      - id: markgate-check
-        name: markgate check
-        entry: markgate run -- make check
-        language: system
-        pass_filenames: false
-```
-
-### Bare `.git/hooks/pre-commit`
-
-```sh
-#!/bin/sh
-markgate verify || {
-  echo "Run your check command first, then commit." >&2
-  exit 1
-}
-```
-
-## Install
-
-### Homebrew (macOS / Linux)
-
-```sh
-brew install go-to-k/tap/markgate
-```
-
-### Shell script (macOS / Linux / Windows with Git Bash)
-
-```sh
-# Latest
-curl -fsSL https://raw.githubusercontent.com/go-to-k/markgate/main/install.sh | bash
-
-# Pin a version
-curl -fsSL https://raw.githubusercontent.com/go-to-k/markgate/main/install.sh | bash -s -- v0.1.0
-```
-
-### `go install`
-
-```sh
-go install github.com/go-to-k/markgate/cmd/markgate@latest
-```
-
-### Prebuilt binaries
-
-Linux / macOS / Windows archives (amd64 / arm64 / 386) — see
-[GitHub Releases](https://github.com/go-to-k/markgate/releases).
-
-## Core concepts
-
-### Key (optional)
-
-Every marker is keyed. You only need to think about keys when you run
-**multiple independent gates** in the same repo (e.g. both `pre-commit`
-and `pre-pr`). Omitted key = `default`, which covers the single-gate
-case.
-
-```sh
-markgate set               # same as `markgate set default`
-markgate set pre-pr        # a second, independent gate
-```
-
-Keys must match `[a-z0-9][a-z0-9-]*` (kebab-case ASCII).
-
-### Hashing strategy: `git-tree` vs `files`
-
-`markgate` ships two hashing strategies:
-
-| | `git-tree` (default) | `files` |
-|---|---|---|
-| What it hashes | `HEAD` + diff-vs-HEAD ∪ untracked-not-ignored | whatever matches your `include` globs |
-| `HEAD` in the hash? | **Yes** | **No** |
-| Commits invalidate the marker? | Yes | Only if they touch in-scope files |
-| `.gitignore` respected? | Yes (automatic) | No — scope is explicit |
-| Needs config? | No | Yes (`include` required) |
-
-They serve different purposes:
-
-- **`git-tree`** = "re-verify on *any* repo change". Broad gates
-  (pre-commit running lint/test/build). Add `exclude` patterns to skip
-  `vendor/`, `node_modules/`, etc. — HEAD-aware invalidation is kept.
-- **`files`** = "re-verify *only* when these paths change, ignore other
-  commits". Narrow gates (docs consistency, vuln scan rooted on a
-  lockfile, coverage for one sub-tree).
-
-Rule of thumb: start with `git-tree` (add `exclude` if needed). Reach
-for `files` only when you specifically want the "ignore commits that
-don't touch these paths" semantics.
 
 ## Use cases
 
@@ -379,6 +170,270 @@ go test -cover && markgate set pre-push
 
 # In .git/hooks/pre-push:
 markgate verify pre-push || exit 1
+```
+
+## Install
+
+### Homebrew (macOS / Linux)
+
+```sh
+brew install go-to-k/tap/markgate
+```
+
+### Shell script (macOS / Linux / Windows with Git Bash)
+
+```sh
+# Latest
+curl -fsSL https://raw.githubusercontent.com/go-to-k/markgate/main/install.sh | bash
+
+# Pin a version
+curl -fsSL https://raw.githubusercontent.com/go-to-k/markgate/main/install.sh | bash -s -- v0.1.0
+```
+
+### `go install`
+
+```sh
+go install github.com/go-to-k/markgate/cmd/markgate@latest
+```
+
+### Prebuilt binaries
+
+Linux / macOS / Windows archives (amd64 / arm64 / 386) — see
+[GitHub Releases](https://github.com/go-to-k/markgate/releases).
+
+## Drop into your hook manager
+
+Substitute `make check` with your verification command. When the
+hook can wrap the check, use `run`; when it sits *in front of* a
+separate command, use `verify` and pair it with `set` in the check
+itself (see [Two shapes](#two-shapes-run-vs-set--verify)).
+
+**husky** — `.husky/pre-commit`:
+
+```sh
+markgate run -- make check
+```
+
+**lefthook** — `lefthook.yml`:
+
+```yaml
+pre-commit:
+  commands:
+    check:
+      run: markgate run -- make check
+```
+
+**pre-commit framework** — `.pre-commit-hooks.yaml`:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: markgate-check
+        name: markgate check
+        entry: markgate run -- make check
+        language: system
+        pass_filenames: false
+```
+
+**Bare `.git/hooks/pre-commit`**:
+
+```sh
+#!/bin/sh
+markgate verify || {
+  echo "Run your check command first, then commit." >&2
+  exit 1
+}
+```
+
+**Claude Code (PreToolUse)** — `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "if": "Bash(git commit*)",
+        "hooks": [
+          { "type": "command", "command": "markgate verify" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+In your check skill: `make check && markgate set`. See
+[Use case 1](#1-pre-commit-skip-duplicate-checks) for the full flow.
+
+## Command model
+
+### `markgate run -- <cmd>` (one-shot)
+
+Collapses verify → run → set into one invocation:
+
+1. **verify** — if the marker matches, `<cmd>` is not executed; exit 0
+   immediately.
+2. Otherwise **execute `<cmd>`**. stdio is passed through;
+   `SIGINT` / `SIGTERM` are forwarded to the child.
+3. On success, **set** the marker. On failure, the marker is **not**
+   updated and `<cmd>`'s exit code is returned as-is.
+
+### `markgate set` / `markgate verify` (split)
+
+Reach for these two halves when the check and the gate run in
+different places, or when the check is several steps (typecheck,
+lint, build, tests) that don't fit into a single `<cmd>`:
+
+```sh
+# Wherever the check runs — record state on success:
+typecheck && lint && build && test && markgate set
+
+# Wherever the gate runs — short-circuit on a fresh marker, else re-run:
+markgate verify || make check
+```
+
+### Exit codes
+
+Exit codes follow the `grep` / `diff` convention, so `||` composes
+naturally:
+
+| exit | meaning                                                   |
+| ---- | --------------------------------------------------------- |
+| 0    | verified — state matches the marker, safe to skip         |
+| 1    | not verified — no marker, or state differs                |
+| 2    | error — not in a repo, bad config, bad key, etc.          |
+
+## Core concepts
+
+### Key (optional)
+
+Every marker is keyed. You only need to think about keys when you run
+**multiple independent gates** in the same repo (e.g. both `pre-commit`
+and `pre-pr`). Omitted key = `default`, which covers the single-gate
+case.
+
+```sh
+markgate set               # same as `markgate set default`
+markgate set pre-pr        # a second, independent gate
+```
+
+Keys must match `[a-z0-9][a-z0-9-]*` (kebab-case ASCII).
+
+### Hashing strategy: `git-tree` vs `files`
+
+`markgate` ships two hashing strategies:
+
+| | `git-tree` (default) | `files` |
+|---|---|---|
+| What it hashes | `HEAD` + diff-vs-HEAD ∪ untracked-not-ignored | whatever matches your `include` globs |
+| `HEAD` in the hash? | **Yes** | **No** |
+| Commits invalidate the marker? | Yes | Only if they touch in-scope files |
+| `.gitignore` respected? | Yes (automatic) | No — scope is explicit |
+| Needs config? | No | Yes (`include` required) |
+
+They serve different purposes:
+
+- **`git-tree`** = "re-verify on *any* repo change". Broad gates
+  (pre-commit running lint/test/build). Add `exclude` patterns to skip
+  `vendor/`, `node_modules/`, etc. — HEAD-aware invalidation is kept.
+- **`files`** = "re-verify *only* when these paths change, ignore other
+  commits". Narrow gates (docs consistency, vuln scan rooted on a
+  lockfile, coverage for one sub-tree).
+
+Rule of thumb: start with `git-tree` (add `exclude` if needed). Reach
+for `files` only when you specifically want the "ignore commits that
+don't touch these paths" semantics.
+
+## CLI reference
+
+```text
+markgate set    [key]              Record the current state hash.
+markgate verify [key]              Exit 0 match, 1 mismatch, 2 error.
+markgate status [key]              Show marker + match status.
+markgate clear  [key]              Delete the marker (idempotent).
+markgate run    [key] -- <cmd>...  Sugar for verify + <cmd> + set.
+markgate init                      Write a starter .markgate.yml.
+markgate version                   Print the version.
+```
+
+### Per-invocation overrides
+
+`set` / `verify` / `status` / `clear` / `run` each accept these flags,
+so one-off scopes don't need a `.markgate.yml`:
+
+```text
+--hash git-tree|files    Override hash type for this call.
+--include <glob>         Repeatable. Override the gate's include list.
+--exclude <glob>         Repeatable. Override the gate's exclude list.
+--state-dir <path>       Directory to store marker files. Takes
+                         precedence over MARKGATE_STATE_DIR env and
+                         state_dir: in .markgate.yml. Default:
+                         <git-dir>/markgate. See "Sharing markers".
+```
+
+Flag syntax is identical across hash types. With `--hash files`,
+`--include` is required. Example — exclude `vendor/` without any
+config file:
+
+```sh
+markgate run --exclude 'vendor/**' -- make check
+```
+
+### Environment variables
+
+```text
+MARKGATE_STATE_DIR       Marker storage directory. Same effect as
+                         --state-dir and state_dir: in config.
+                         Precedence: --state-dir > this env >
+                         state_dir: in .markgate.yml > default.
+```
+
+## `.markgate.yml` (optional)
+
+Only needed for multiple gates, or for `files` hash, or to persist
+include / exclude / state_dir. Looked up at
+`$(git rev-parse --show-toplevel)/.markgate.yml` (no parent-dir
+walking).
+
+Per-gate fields:
+
+| field | purpose |
+|---|---|
+| `hash` | `git-tree` (default) or `files` |
+| `include` | glob list; required for `hash: files` |
+| `exclude` | glob list |
+| `state_dir` | marker storage directory (override per gate). Prefer a **relative** path — it resolves against the repo top-level so it's identical on every machine. An absolute path committed here will point to nonexistent locations on other machines. CLI flag and `MARKGATE_STATE_DIR` still take precedence. |
+
+### Generate a starter — `markgate init`
+
+```sh
+markgate init          # writes .markgate.yml at the repo root
+markgate init --force  # overwrite an existing one
+```
+
+The generated file enables the default `git-tree` gate with
+commented-out examples (an `exclude` list on `git-tree`, plus a
+`files`-type gate) — uncomment what you need.
+
+### Full example
+
+```yaml
+gates:
+  default:
+    hash: git-tree
+    exclude:
+      - "vendor/**"
+      - "node_modules/**"
+
+  pre-pr:
+    hash: files
+    include:
+      - "docs/**"
+      - "README.md"
+    exclude:
+      - "**/*.txt"
 ```
 
 ## Sharing markers across machines (CI / teammates)
@@ -575,96 +630,6 @@ markers where commit-access already implies trust in the signal.
 - **Signing is not yet implemented** — markers are unsigned JSON.
   Tamper resistance depends on who can write to the directory (cache /
   repo).
-
-## CLI reference
-
-```text
-markgate set    [key]              Record the current state hash.
-markgate verify [key]              Exit 0 match, 1 mismatch, 2 error.
-markgate status [key]              Show marker + match status.
-markgate clear  [key]              Delete the marker (idempotent).
-markgate run    [key] -- <cmd>...  Sugar for verify + <cmd> + set.
-markgate init                      Write a starter .markgate.yml.
-markgate version                   Print the version.
-```
-
-### Per-invocation overrides
-
-`set` / `verify` / `status` / `clear` / `run` each accept these flags,
-so one-off scopes don't need a `.markgate.yml`:
-
-```text
---hash git-tree|files    Override hash type for this call.
---include <glob>         Repeatable. Override the gate's include list.
---exclude <glob>         Repeatable. Override the gate's exclude list.
---state-dir <path>       Directory to store marker files. Takes
-                         precedence over MARKGATE_STATE_DIR env and
-                         state_dir: in .markgate.yml. Default:
-                         <git-dir>/markgate. See "Sharing markers".
-```
-
-Flag syntax is identical across hash types. With `--hash files`,
-`--include` is required. Example — exclude `vendor/` without any
-config file:
-
-```sh
-markgate run --exclude 'vendor/**' -- make check
-```
-
-### Environment variables
-
-```text
-MARKGATE_STATE_DIR       Marker storage directory. Same effect as
-                         --state-dir and state_dir: in config.
-                         Precedence: --state-dir > this env >
-                         state_dir: in .markgate.yml > default.
-```
-
-## `.markgate.yml` (optional)
-
-Only needed for multiple gates, or for `files` hash, or to persist
-include / exclude / state_dir. Looked up at
-`$(git rev-parse --show-toplevel)/.markgate.yml` (no parent-dir
-walking).
-
-Per-gate fields:
-
-| field | purpose |
-|---|---|
-| `hash` | `git-tree` (default) or `files` |
-| `include` | glob list; required for `hash: files` |
-| `exclude` | glob list |
-| `state_dir` | marker storage directory (override per gate). Prefer a **relative** path — it resolves against the repo top-level so it's identical on every machine. An absolute path committed here will point to nonexistent locations on other machines. CLI flag and `MARKGATE_STATE_DIR` still take precedence. |
-
-### Generate a starter — `markgate init`
-
-```sh
-markgate init          # writes .markgate.yml at the repo root
-markgate init --force  # overwrite an existing one
-```
-
-The generated file enables the default `git-tree` gate with
-commented-out examples (an `exclude` list on `git-tree`, plus a
-`files`-type gate) — uncomment what you need.
-
-### Full example
-
-```yaml
-gates:
-  default:
-    hash: git-tree
-    exclude:
-      - "vendor/**"
-      - "node_modules/**"
-
-  pre-pr:
-    hash: files
-    include:
-      - "docs/**"
-      - "README.md"
-    exclude:
-      - "**/*.txt"
-```
 
 ## Marker storage
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pnpm test
 markgate set   # ← record the pass; markgate's only addition
 ```
 
-Then the hook — a separate file — only verifies the marker:
+Then the hook only verifies the marker:
 
 ```sh
 # .claude/settings.json PreToolUse on `git commit`:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 **Skip the checks that already passed. Catch the ones that never ran.**
 
-Your agent ran the check. Your commit hook runs it again. CI runs
-it again. `markgate` makes the duplicates instant — and catches
-commits where the check never ran.
+**Especially useful in the AI-coding-agent era.** Your agent ran
+the check. Your commit hook runs it again. `gh pr create` runs it
+again. CI runs it again. `markgate` makes the duplicates instant —
+and catches commits where the check never ran.
 
 `markgate` is a verification-state cache for hook managers (Claude
 Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). When a
@@ -36,15 +37,38 @@ command.)
 
 ## Two shapes: `run` vs `set` + `verify`
 
-Pick by where your hook sits relative to the check:
+Pick by where your hook sits relative to the check.
 
-- **`markgate run -- <cmd>`** — one-shot. Use when the hook can wrap
-  the check directly (husky, lefthook, pre-commit framework, bare
-  `pre-commit`).
-- **`markgate set` + `markgate verify`** — split. Use when the check
-  and the gate live in different places (Claude Code PreToolUse,
-  multi-step pipelines, commit-then-push flows). The check calls
-  `set` on success; the gate calls `verify` to short-circuit.
+**`markgate run -- <cmd>`** — one-shot. Use when the hook can wrap
+the check directly (husky, lefthook, pre-commit framework, bare
+`pre-commit`).
+
+```sh
+markgate run -- make check
+```
+
+**`markgate set` + `markgate verify`** — split. Use when the check
+and the gate live in different places. Concrete scenarios:
+
+- **Claude Code gating `git commit`** — the `/check` skill runs the
+  check and calls `markgate set` on success; a PreToolUse hook on
+  `git commit` calls `markgate verify` to block un-verified commits.
+  The hook sits *in front of* `git commit`, so there's no check for
+  it to wrap. This is the canonical case.
+- **Multi-step checks** — `typecheck && lint && build && test &&
+  markgate set`. `run -- <cmd>` wraps a single command; split works
+  with any script or Makefile target.
+- **Commit-then-push** — the commit hook runs the check (`... &&
+  markgate set`); the push hook only calls `markgate verify`,
+  skipping a second run when nothing has changed since the commit.
+
+```sh
+# Wherever the check runs — record state on success:
+make check && markgate set
+
+# Wherever the gate runs — short-circuit on a fresh marker, else re-run:
+markgate verify || make check
+```
 
 Full semantics and exit codes are in [Command model](#command-model).
 Both shapes appear throughout the use cases below.
@@ -52,6 +76,9 @@ Both shapes appear throughout the use cases below.
 ## Why markgate?
 
 Two failure modes in an AI-agent-driven workflow, one cache layer.
+Hook managers are great at *running* checks; none remember when one
+just passed. `markgate` is that memory layer — exit 0 = verified,
+exit 1 = run it. One line to adopt, one line to remove.
 
 **Redundant re-runs.** Your agent (or you) just ran `make check`.
 The commit hook runs it again. `gh pr create` runs it again. CI
@@ -68,14 +95,6 @@ into your pre-commit or PreToolUse hook and there's no bypass by
 passed against the current state. Exit 1 with "no marker" is a
 loud, debuggable failure; a silent skip is not. **No marker, no
 commit.**
-
-Existing hook managers (husky / lefthook / pre-commit / Claude Code
-hooks) are great at *running* checks. None of them remember that a
-check just passed, or notice when it hasn't run yet. `markgate` is
-that memory layer — exit 0 = "verified, skip", exit 1 = "stale or
-absent, run it". It's not a hook manager itself; it slots into
-whatever hook manager you already use — one line to adopt, one line
-to remove.
 
 ## Use cases
 
@@ -235,16 +254,6 @@ repos:
         entry: markgate run -- make check
         language: system
         pass_filenames: false
-```
-
-**Bare `.git/hooks/pre-commit`**:
-
-```sh
-#!/bin/sh
-markgate verify || {
-  echo "Run your check command first, then commit." >&2
-  exit 1
-}
 ```
 
 **Claude Code (PreToolUse)** — `.claude/settings.json`:

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ markgate set   # ← record the pass; markgate's only addition
 
 Then the hook only verifies the marker:
 
-```sh
-# .claude/settings.json PreToolUse on `git commit`:
-markgate verify
+```json
+// .claude/settings.json PreToolUse on `git commit`:
+{ "type": "command", "command": "markgate verify" }
 ```
 
 Full semantics and exit codes are in [Command model](#command-model).

--- a/README.md
+++ b/README.md
@@ -1,17 +1,23 @@
 # markgate
 
-**Skip the checks that already passed. Catch the ones that never ran.**
+`markgate` is a verification-state cache for hook managers (Claude
+Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). It
+lets your hooks:
+
+- **Skip the checks that already passed** — instant exit when the
+  repo state matches the last successful run.
+- **Catch the ones that never ran** — block the commit when there's
+  no fresh marker to verify.
 
 **Especially useful in the AI-coding-agent era.** Your agent ran
 the check. Your commit hook runs it again. `gh pr create` runs it
 again. CI runs it again. `markgate` makes the duplicates instant —
 and catches commits where the check never ran.
 
-`markgate` is a verification-state cache for hook managers (Claude
-Code hooks, husky, lefthook, pre-commit, bare `.git/hooks/*`). When a
-check passes, it writes a small JSON **marker** recording the current
-repo state. On the next hook run, if the state hasn't moved, the
-check skips in milliseconds — if it has, the check runs again.
+When a check passes, `markgate` writes a small JSON **marker**
+recording the current repo state. On the next hook run, if the
+state hasn't moved, the check skips in milliseconds — if it has,
+the check runs again.
 
 ## 20-second tour
 

--- a/README.md
+++ b/README.md
@@ -82,29 +82,6 @@ markgate verify
 Full semantics and exit codes are in [Command model](#command-model).
 Both shapes appear throughout the use cases below.
 
-## Why markgate?
-
-Two failure modes in an AI-agent-driven workflow, one cache layer.
-Hook managers are great at *running* checks; none remember when one
-just passed. `markgate` is that memory layer — exit 0 = verified,
-exit 1 = run it. One line to adopt, one line to remove.
-
-**Skip what already passed.** Your agent (or you) just ran `pnpm test`.
-The commit hook runs it again. `gh pr create` runs it again. CI
-runs it again — four passes, one change. `markgate` lets the second
-/ third / fourth of those exit instantly when the repo state hasn't
-moved. (The CI pass needs a bit of extra wiring — see
-[Sharing markers](#sharing-markers-across-machines-ci--teammates).)
-
-**Catch what never ran.** Your agent decided to run `/check`, then
-ran out of tool budget / context and committed anyway. Or a tool
-call silently failed. Or it simply forgot. Wire `markgate verify`
-into your pre-commit or PreToolUse hook and there's no bypass by
-"forgetting" — a fresh marker exists only after a check actually
-passed against the current state. Exit 1 with "no marker" is a
-loud, debuggable failure; a silent skip is not. **No marker, no
-commit.**
-
 ## Use cases
 
 Each section below follows the same shape: **Scope** (what triggers

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ markgate run -- pnpm test
 # First hook: pnpm test runs. Next hook with no changes: instant skip.
 ```
 
-Or in Claude Code:
+Or in Claude Code — same behavior:
 
 ```json
 // .claude/settings.json
@@ -84,9 +84,10 @@ and the gate live in different places. Concrete scenarios:
   split lets the check stay a plain script (typecheck → lint → build
   → test → `markgate set`) and stops forcing you to collapse
   everything into one command.
-- **Commit-then-push** — the commit hook runs the check (`... &&
-  markgate set`); the push hook only calls `markgate verify`,
-  skipping a second run when nothing has changed since the commit.
+- **Commit-then-push** — commit hook: `pnpm test && markgate set`;
+  push hook: `markgate verify`. The two hooks see the same marker,
+  so push skips re-running when nothing has changed since the
+  commit.
 
 ```sh
 # /check skill body (or build script, CI job, Make target):
@@ -95,7 +96,7 @@ pnpm run lint:fix
 pnpm run build
 pnpm test
 
-# record the pass; markgate's only addition
+# Record the pass; markgate's only addition
 markgate set
 ```
 


### PR DESCRIPTION
## Summary

- Restructure README so readers hit the value pitch and use cases before admin material.
- Define "marker" in the opening paragraph — previously it first appeared undefined in "No marker, no commit."
- Merge the overlapping "Especially useful in AI era" and "Why markgate?" sections into a single Why.
- Add a short "Two shapes: `run` vs `set` + `verify`" section right after the 20-second tour, so the use cases below no longer reference `set` / `verify` before those commands are introduced.
- Move Use cases ahead of Install (let the emotional peak land before the admin section), and move Install ahead of hook-manager wire-up.

## New section order

1. Title + tagline
2. Opening paragraph (defines "marker")
3. 20-second tour
4. Two shapes: `run` vs `set` + `verify`
5. Why markgate?
6. Use cases
7. Install
8. Drop into your hook manager
9. Command model + exit codes
10. Core concepts (keys, hashing)
11. CLI reference
12. `.markgate.yml`
13. Sharing markers across machines
14. Marker storage
15. FAQ
16. License

## Test plan

- [ ] Render README on GitHub and eyeball the flow top-to-bottom.
- [ ] Click every internal `#anchor` link and confirm it resolves (especially `#two-shapes-run-vs-set--verify`, `#command-model`, `#sharing-markers-across-machines-ci--teammates`).
- [ ] Confirm no use case references `set` / `verify` before the "Two shapes" section introduces them.
- [ ] Confirm "marker" is defined before its first standalone use.
