### PR TITLE
docs: clarify run shape covers all invocation sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ moved.
 
 Pick by where your hook sits relative to the check.
 
-**`markgate run -- <cmd>`** — one-shot. Use when the hook itself
-runs the check — simplest for single-command checks. If the agent
-forgot to run it, the hook runs it before the commit (a safety
-net). Prefix your check: `pnpm test` → `markgate run -- pnpm
-test`. First call runs; later calls skip on unchanged state. A
-failed check doesn't cache.
+**`markgate run -- <cmd>`** — one-shot.
+
+- **When**: the hook itself runs the check. Simplest for
+  single-command checks.
+- **AI safety net**: if the agent forgot to run the check, the
+  hook runs it before the commit.
+- **How**: prefix your check — `pnpm test` → `markgate run -- pnpm test`.
+- **Behavior**: first call runs and caches on pass; later calls
+  with unchanged state skip; a failed check doesn't cache.
 
 ```sh
 markgate run -- pnpm test

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Pick by where your hook sits relative to the check.
 
 ```sh
 markgate run -- pnpm test
-# Pass: marker cached, later calls skip instantly.
-# Fail: marker unchanged, next call re-runs the check.
+# pnpm test passes → marker cached, later calls skip instantly.
+# pnpm test fails  → marker unchanged, next call re-runs it.
 ```
 
 In Claude Code's JSON hook config:

--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ command, or a CI job. First run fills the cache; the rest skip on
 unchanged state.
 
 ```sh
-# Example — .husky/pre-commit (or lefthook.yml, .pre-commit-hooks.yaml, ...):
 markgate run -- pnpm test
-# First invocation caches the pass; later invocations with no changes: instant skip.
+# First invocation caches the pass; later invocations with no changes skip.
 ```
 
 Or in Claude Code — same behavior:
@@ -78,9 +77,8 @@ and the gate live in different places. Concrete scenarios:
 - **Explicit check + commit gate** — canonical in Claude Code: the
   `/check` skill runs the check and calls `markgate set`; a
   PreToolUse hook on `git commit` calls `markgate verify` to block
-  un-verified commits. Splitting (not `run`) keeps `/check` as an
-  explicit agent action with streaming output in the skill, and
-  keeps the hook a lean gate.
+  un-verified commits. Splitting keeps the hook a pure `verify`
+  gate that never runs the check itself.
 - **Multi-step checks** — `run -- <cmd>` takes a single command;
   split lets the check stay a plain script (typecheck → lint → build
   → test → `markgate set`) and stops forcing you to collapse

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ moved.
 
 Pick by where your hook sits relative to the check.
 
-**`markgate run -- <cmd>`** — one-shot. Use when the check and the
-gate happen in one command — a single `markgate run -- <cmd>`
-handles both. Prefix your check: `pnpm test` → `markgate run --
-pnpm test`. First call runs; later calls skip on unchanged state.
-A failed check doesn't cache.
+**`markgate run -- <cmd>`** — one-shot. Use when the hook itself
+runs the check — simplest for single-command checks. If the agent
+forgot to run it, the hook runs it before the commit (a safety
+net). Prefix your check: `pnpm test` → `markgate run -- pnpm
+test`. First call runs; later calls skip on unchanged state. A
+failed check doesn't cache.
 
 ```sh
 markgate run -- pnpm test
@@ -72,18 +73,22 @@ In Claude Code's JSON hook config:
 }
 ```
 
-**`markgate set` + `markgate verify`** — split. Use when the check
-and the gate live in different places. Concrete scenarios:
+**`markgate set` + `markgate verify`** — split. Use when the hook
+only verifies — the check runs elsewhere (skill / script / CI)
+and ends with `markgate set`. The check command lives in one
+place — the hook doesn't duplicate it. If the agent forgot to
+run the check, the commit is blocked loudly — no auto-fallback.
+Concrete scenarios:
 
 - **Explicit check + commit gate** — canonical in Claude Code: the
   `/check` skill runs the check and calls `markgate set`; a
   PreToolUse hook on `git commit` calls `markgate verify` to block
   un-verified commits. Splitting keeps the hook a pure `verify`
   gate that never runs the check itself.
-- **Multi-step checks** — `run -- <cmd>` takes a single command;
-  split lets the check stay a plain script (typecheck → lint → build
-  → test → `markgate set`) and stops forcing you to collapse
-  everything into one command.
+- **Multi-step checks** — with `run`, you'd have to repeat the
+  multi-step chain in the hook too. Split lets the chain live only
+  in the script (typecheck → lint → build → test → `markgate set`);
+  the hook stays a single `markgate verify` line.
 - **Commit-then-push** — commit hook: `pnpm test && markgate set`;
   push hook: `markgate verify`. The two hooks see the same marker,
   so push skips re-running when nothing has changed since the

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ moved.
 
 Pick by where your hook sits relative to the check.
 
-**`markgate run -- <cmd>`** — one-shot. Prefix your check command
-with `markgate run --` (`pnpm test` → `markgate run -- pnpm test`).
-First call runs the check; later calls skip on unchanged state.
-Works anywhere — a hook (husky, lefthook, pre-commit framework,
-bare `pre-commit`, Claude Code PreToolUse), a dev terminal, or CI.
+**`markgate run -- <cmd>`** — one-shot. Use when the check and the
+gate live in the same place — one `markgate run -- <cmd>` handles
+both. Prefix your check command (`pnpm test` → `markgate run --
+pnpm test`). First call runs the check; later calls skip on
+unchanged state.
 
 ```sh
 markgate run -- pnpm test

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ markgate run -- pnpm test
 # First invocation caches the pass; later invocations with no changes skip.
 ```
 
-Or in Claude Code — same behavior:
+In Claude Code's JSON hook config:
 
 ```json
 // .claude/settings.json

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ moved.
 
 Pick by where your hook sits relative to the check.
 
-**`markgate run -- <cmd>`** — one-shot. Put `markgate run -- <cmd>`
-wherever the check runs — a hook (husky, lefthook, pre-commit
-framework, bare `pre-commit`, or Claude Code PreToolUse), a dev
-command, or a CI job. First run fills the cache; the rest skip on
-unchanged state.
+**`markgate run -- <cmd>`** — one-shot. Prefix your check command
+with `markgate run --` (`pnpm test` → `markgate run -- pnpm test`).
+First call runs the check; later calls skip on unchanged state.
+Works anywhere — a hook (husky, lefthook, pre-commit framework,
+bare `pre-commit`, Claude Code PreToolUse), a dev terminal, or CI.
 
 ```sh
 markgate run -- pnpm test

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Pick by where your hook sits relative to the check.
 
 - **When**: the hook itself runs the check. Simplest for
   single-command checks.
-- **AI safety net**: if the agent forgot to run the check, the
-  hook runs it before the commit.
+- **AI forget**: the hook runs the check before the commit (a
+  safety net — commit proceeds if the check passes).
 - **How**: prefix your check — `pnpm test` → `markgate run -- pnpm test`.
 - **Behavior**: first call runs and caches on pass; later calls
   with unchanged state skip; a failed check doesn't cache.
@@ -76,11 +76,15 @@ In Claude Code's JSON hook config:
 }
 ```
 
-**`markgate set` + `markgate verify`** — split. Use when the hook
-only verifies — the check runs elsewhere (skill / script / CI)
-and ends with `markgate set`. The check command lives in one
-place — the hook doesn't duplicate it. If the agent forgot to
-run the check, the commit is blocked loudly — no auto-fallback.
+**`markgate set` + `markgate verify`** — split.
+
+- **When**: the hook only verifies. Check runs elsewhere (skill /
+  script / CI), ending with `markgate set`.
+- **Why**: check command lives in one place — the hook doesn't
+  duplicate it.
+- **AI forget**: the commit is blocked loudly — no auto-fallback,
+  agent must re-run.
+
 Concrete scenarios:
 
 - **Explicit check + commit gate** — canonical in Claude Code: the

--- a/README.md
+++ b/README.md
@@ -42,14 +42,15 @@ moved.
 Pick by where your hook sits relative to the check.
 
 **`markgate run -- <cmd>`** — one-shot. Use when the check and the
-gate live in the same place — one `markgate run -- <cmd>` handles
-both. Prefix your check command (`pnpm test` → `markgate run --
-pnpm test`). First call runs the check; later calls skip on
-unchanged state.
+gate happen in one command — a single `markgate run -- <cmd>`
+handles both. Prefix your check: `pnpm test` → `markgate run --
+pnpm test`. First call runs; later calls skip on unchanged state.
+A failed check doesn't cache.
 
 ```sh
 markgate run -- pnpm test
-# First invocation caches the pass; later invocations with no changes skip.
+# Pass: marker cached, later calls skip instantly.
+# Fail: marker unchanged, next call re-runs the check.
 ```
 
 In Claude Code's JSON hook config:

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ moved.
 
 Pick by where your hook sits relative to the check.
 
-**`markgate run -- <cmd>`** — one-shot. Prefix your check command
-with `markgate run --` wherever it runs — the hook (husky,
-lefthook, pre-commit framework, bare `pre-commit`, or Claude Code
-PreToolUse), a manual dev invocation, a CI job. All sites share
-the cache, so whichever runs first fills it and the rest skip.
+**`markgate run -- <cmd>`** — one-shot. Put `markgate run -- <cmd>`
+wherever the check runs — a hook (husky, lefthook, pre-commit
+framework, bare `pre-commit`, or Claude Code PreToolUse), a dev
+command, or a CI job. First run fills the cache; the rest skip on
+unchanged state.
 
 ```sh
 # Example — .husky/pre-commit (or lefthook.yml, .pre-commit-hooks.yaml, ...):

--- a/README.md
+++ b/README.md
@@ -41,15 +41,16 @@ moved.
 
 Pick by where your hook sits relative to the check.
 
-**`markgate run -- <cmd>`** — one-shot. Use where the hook runs the
-check itself — husky, lefthook, pre-commit framework, bare
-`pre-commit`, or Claude Code PreToolUse. Just prefix your check
-command with `markgate run --`.
+**`markgate run -- <cmd>`** — one-shot. Prefix your check command
+with `markgate run --` wherever it runs — the hook (husky,
+lefthook, pre-commit framework, bare `pre-commit`, or Claude Code
+PreToolUse), a manual dev invocation, a CI job. All sites share
+the cache, so whichever runs first fills it and the rest skip.
 
 ```sh
-# .husky/pre-commit (or lefthook.yml, .pre-commit-hooks.yaml, ...):
+# Example — .husky/pre-commit (or lefthook.yml, .pre-commit-hooks.yaml, ...):
 markgate run -- pnpm test
-# First hook: pnpm test runs. Next hook with no changes: instant skip.
+# First invocation caches the pass; later invocations with no changes: instant skip.
 ```
 
 Or in Claude Code — same behavior:


### PR DESCRIPTION
## Summary

- Rewrite the `markgate run` description in the Two shapes section so it covers every invocation site, not just the hook.
- Update the inline code comment from `# First hook: ... Next hook with no changes: ...` to `# First invocation caches ...` so the wording is neutral about where that first run came from.

## Why

The previous wording (`Use where the hook runs the check itself`) and the comment (`First hook`) implied the hook was the only — or at least the primary — place the check runs. That contradicts the opening dilemma, which explicitly describes the agent running the check first and the hook running it again. A reader following the run example would be left wondering where the first invocation actually happens.

The fix frames run as `prefix your check command with 'markgate run --' wherever it runs`: the hook, a manual dev invocation, or a CI job. All sites share the cache, so whichever invocation fires first fills it and the rest skip — regardless of whether that's the hook or something else.

## Test plan

- [ ] Render the README on GitHub and read the Two shapes section top-to-bottom — confirm the run description no longer implies the hook is the only invocation site.
- [ ] Confirm the code comment `First invocation caches ...` no longer uses `hook` or `commit` as the invocation anchor.
- [ ] Confirm the dilemma at the top of the README and the run shape description now tell a consistent story (agent can be the first invocation; the hook picks up the cache).
