### PR TITLE
chore: block git commit/push on main via PreToolUse hook

### DIFF
--- a/.claude/hooks/guard-main-branch.sh
+++ b/.claude/hooks/guard-main-branch.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# PreToolUse hook: refuse mutating git commands on main.
+#
+# After a PR merges, local state can drift — the remote deleted the
+# feature branch, but the old branch is still checked out, or a
+# checkout to main slipped in unnoticed. Claude then commits to main
+# locally. The project's branch-protection rule rejects the push, so
+# the commit has to be unwound (cherry-pick to a new branch, reset
+# main). This hook catches the mistake at commit time.
+#
+# Blocks `git commit`, `git push`, `git merge`, `git rebase` when the
+# current branch is `main`. Exits 2 so Claude Code surfaces it as a
+# blocking error and Claude sees the diagnostic. Exits 0 silently on
+# non-git or off-main commands.
+#
+# Input (stdin): the tool-use JSON from Claude Code; we need
+# .tool_input.command.
+
+set -u
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+
+case "$command" in
+  "git commit"*|"git push"*|"git merge"*|"git rebase"*) ;;
+  *) exit 0 ;;
+esac
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+branch=$(git branch --show-current 2>/dev/null || echo "")
+if [ "$branch" = "main" ]; then
+  printf '[claude hook] Refusing `%s` on main.\n' "$command" >&2
+  printf 'Create or switch to a feature branch first (e.g. git checkout -b docs/short-name).\n' >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,17 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-main-branch.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.claude/skills/audit-before-done/SKILL.md
+++ b/.claude/skills/audit-before-done/SKILL.md
@@ -28,6 +28,14 @@ to `completed` on non-trivial work.
 - Use `TodoWrite` to break the work into verifiable steps.
 - Keep diffs minimal — no drive-by refactors, no hypothetical
   configurability, no "just in case" validation.
+- **Check your branch before every `git commit` / `git push`.**
+  Run `git branch --show-current`. If it says `main`, stop — create
+  or switch to a feature branch first. The `guard-main-branch.sh`
+  PreToolUse hook blocks `git commit`/`push`/`merge`/`rebase` on
+  main as a safety net, but the check belongs in your head too. A
+  lost-then-recovered commit from main is expensive to unwind (cherry
+  -pick onto a new branch, hard-reset main); the 2-second branch
+  check before committing prevents it.
 - **Don't delete something because you're unsure it works — test
   it.** If a hook, script, or feature might be broken, build a
   minimal reproduction (temp dir, fake input, run it) and verify.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,14 @@ message to a temp file first sidesteps all shell escaping.
   markgate to skip the run when repo state hasn't changed since the
   last pass. A vet failure exits 2, so the diagnostic is surfaced
   back to Claude as blocking feedback.
+- `hooks/guard-main-branch.sh` is a PreToolUse hook on Bash: blocks
+  `git commit` / `git push` / `git merge` / `git rebase` when the
+  current branch is `main`. Protects against the "PR merged → local
+  branch still on main (or got switched) → Claude commits to main"
+  mistake, which the project's branch-protection rule catches at
+  push time but only after the commit has already landed locally
+  (expensive to unwind). Exits 2 with a message pointing at the fix
+  (`git checkout -b <feature-branch>`).
 
 ### How the dogfood works (no install needed)
 


### PR DESCRIPTION
## Summary

Blocks `git commit` / `git push` / `git merge` / `git rebase` when the current branch is `main` via a PreToolUse hook. Adds the matching reminder to the `audit-before-done` skill and documents the hook in CLAUDE.md.

## Why

After PR #10 merged, local state drifted (branch switched to main without me noticing) and Claude committed directly to main. The project's branch-protection rule caught it at push time, but the commit had to be unwound (cherry-pick onto a new branch, hard-reset main). Three-layer defense so this is caught before it lands locally instead:

1. **Harness-enforced hook** (`.claude/hooks/guard-main-branch.sh`) — the PreToolUse gate. Refuses the mutating git verbs on main with a message pointing at the fix.
2. **Skill-level reminder** (`audit-before-done`) — the mental check stays in the workflow even if the hook is ever disabled.
3. **Documentation** (CLAUDE.md) — new hook listed in the Harness section alongside the existing go-vet-on-edit hook.

## Test plan

Verified locally on two branches:

- [x] `echo '{"tool_input":{"command":"echo hello"}}' | guard-main-branch.sh` → exit 0 (non-git command passes).
- [x] `echo '{"tool_input":{"command":"git status"}}' | guard-main-branch.sh` → exit 0 (non-mutating git command passes).
- [x] On feature branch, `git commit` via the hook → exit 0 (allowed).
- [x] On main, `git commit` via the hook → exit 2 with `[claude hook] Refusing 'git commit -m test' on main. Create or switch to a feature branch first (e.g. git checkout -b docs/short-name).` printed to stderr.
- [ ] After merge: trigger the hook via Claude Code on a real `git commit` to confirm the harness surfaces the block message.

## Rollback

Single revert restores the previous state — the hook script is new, and the other three files have small, localized diffs.
