### PR TITLE
docs: cover 'edit after set' case in Two shapes bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ moved.
 
 Pick by where your hook sits relative to the check.
 
-**`markgate run -- <cmd>`** — one-shot.
+**`markgate run -- <cmd>`** — one-shot. One command does it all:
+checks the marker, runs `<cmd>` if stale or missing, caches on
+pass (leaves the marker untouched on fail).
 
 - **When**: the hook itself runs the check. Simplest for
   single-command checks.
 - **AI forget**: the hook runs the check before the commit (safety
   net — commit proceeds if the check passes).
 - **How**: prefix your check — `pnpm test` → `markgate run -- pnpm test`.
-- **Behavior**: first call runs and caches on pass; later calls
-  with unchanged state skip; a failed check doesn't cache.
 
 ```sh
 markgate run -- pnpm test
@@ -76,7 +76,9 @@ In Claude Code's JSON hook config:
 }
 ```
 
-**`markgate set` + `markgate verify`** — split.
+**`markgate set` + `markgate verify`** — split. Two commands:
+`markgate set` records the current state as a marker; `markgate
+verify` exits 0 if state still matches the marker, 1 otherwise.
 
 - **When**: the hook only verifies. Check runs elsewhere (skill /
   script / CI), ending with `markgate set`.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Pick by where your hook sits relative to the check.
 
 - **When**: the hook itself runs the check. Simplest for
   single-command checks.
-- **AI forget**: the hook runs the check before the commit (a
-  safety net — commit proceeds if the check passes).
+- **Stale / missing marker**: the hook runs the check before the
+  commit (safety net — e.g. agent forgot to run it, or edited
+  files after running it). Commit proceeds if the check passes.
 - **How**: prefix your check — `pnpm test` → `markgate run -- pnpm test`.
 - **Behavior**: first call runs and caches on pass; later calls
   with unchanged state skip; a failed check doesn't cache.
@@ -82,8 +83,9 @@ In Claude Code's JSON hook config:
   script / CI), ending with `markgate set`.
 - **Why**: check command lives in one place — the hook doesn't
   duplicate it.
-- **AI forget**: the commit is blocked loudly — no auto-fallback,
-  agent must re-run.
+- **Stale / missing marker**: commit is blocked loudly — e.g. agent
+  forgot to run the check, or edited files after `markgate set`.
+  No auto-fallback; agent must re-run.
 
 Concrete scenarios:
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ tests passed in 4.1s
 ```
 
 Under the hood, when a check passes, `markgate` writes a small JSON
-**marker** recording the current repo state. Later calls compare
-current state to the marker — matched → skip; moved (edit, missed
-run, new commit) → shape-specific response (`run` re-runs the
-check; split's `verify` fails and blocks the commit).
+**marker** recording the current repo state. The next hook run exits
+in milliseconds if the state matches, or re-runs the check if it's
+moved.
 
 ## Two shapes: `run` vs `set` + `verify`
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ pass (leaves the marker untouched on fail).
   single-command checks.
 - **Why**: no separate `set` and `verify` to wire — `markgate run`
   collapses them into one call.
-- **AI forget (or edit after the check)**: the hook runs the check
-  before the commit (safety net — commit proceeds if the check
-  passes).
+- **AI forget**: the hook runs the check before the commit (safety
+  net — commit proceeds if the check passes). Same response if
+  files are edited after the check.
 - **How**: prefix your check — `pnpm test` → `markgate run -- pnpm test`.
 
 ```sh
@@ -87,8 +87,9 @@ verify` exits 0 if state still matches the marker, 1 otherwise.
   script / CI), ending with `markgate set`.
 - **Why**: check command lives in one place — the hook doesn't
   duplicate it.
-- **AI forget (or edit after the check)**: the commit is blocked
-  loudly — no auto-fallback, agent must re-run.
+- **AI forget**: the commit is blocked loudly — no auto-fallback,
+  agent must re-run. Same response if files are edited after
+  `markgate set`.
 - **How**: `markgate set` at the check site, `markgate verify` in
   the hook (concrete scenarios below).
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ pass (leaves the marker untouched on fail).
   single-command checks.
 - **Why**: no separate `set` and `verify` to wire — `markgate run`
   collapses them into one call.
-- **AI forget**: the hook runs the check before the commit (safety
-  net — commit proceeds if the check passes).
+- **AI forget (or edit after the check)**: the hook runs the check
+  before the commit (safety net — commit proceeds if the check
+  passes).
 - **How**: prefix your check — `pnpm test` → `markgate run -- pnpm test`.
 
 ```sh
@@ -86,8 +87,8 @@ verify` exits 0 if state still matches the marker, 1 otherwise.
   script / CI), ending with `markgate set`.
 - **Why**: check command lives in one place — the hook doesn't
   duplicate it.
-- **AI forget**: the commit is blocked loudly — no auto-fallback,
-  agent must re-run.
+- **AI forget (or edit after the check)**: the commit is blocked
+  loudly — no auto-fallback, agent must re-run.
 - **How**: `markgate set` at the check site, `markgate verify` in
   the hook (concrete scenarios below).
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ pass (leaves the marker untouched on fail).
 
 - **When**: the hook itself runs the check. Simplest for
   single-command checks.
+- **Why**: no separate `set` and `verify` to wire — `markgate run`
+  collapses them into one call.
 - **AI forget**: the hook runs the check before the commit (safety
   net — commit proceeds if the check passes).
 - **How**: prefix your check — `pnpm test` → `markgate run -- pnpm test`.
@@ -86,6 +88,8 @@ verify` exits 0 if state still matches the marker, 1 otherwise.
   duplicate it.
 - **AI forget**: the commit is blocked loudly — no auto-fallback,
   agent must re-run.
+- **How**: `markgate set` at the check site, `markgate verify` in
+  the hook (concrete scenarios below).
 
 Concrete scenarios:
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ In Claude Code's JSON hook config:
 ```
 
 **`markgate set` + `markgate verify`** — split. Two commands:
-`markgate set` records the current state as a marker; `markgate
-verify` exits 0 if state still matches the marker, 1 otherwise.
+`markgate set` records the current state as a marker;
+`markgate verify` compares current state to the marker — exit 0 on match, 1 otherwise.
 
 - **When**: the hook only verifies. Check runs elsewhere (skill /
   script / CI), ending with `markgate set`.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ tests passed in 4.1s
 ```
 
 Under the hood, when a check passes, `markgate` writes a small JSON
-**marker** recording the current repo state. The next hook run exits
-in milliseconds if the state matches, or re-runs the check if it's
-moved.
+**marker** recording the current repo state. Later calls compare
+current state to the marker — matched → skip; moved (edit, missed
+run, new commit) → shape-specific response (`run` re-runs the
+check; split's `verify` fails and blocks the commit).
 
 ## Two shapes: `run` vs `set` + `verify`
 
@@ -45,9 +46,8 @@ Pick by where your hook sits relative to the check.
 
 - **When**: the hook itself runs the check. Simplest for
   single-command checks.
-- **Stale / missing marker**: the hook runs the check before the
-  commit (safety net — e.g. agent forgot to run it, or edited
-  files after running it). Commit proceeds if the check passes.
+- **AI forget**: the hook runs the check before the commit (safety
+  net — commit proceeds if the check passes).
 - **How**: prefix your check — `pnpm test` → `markgate run -- pnpm test`.
 - **Behavior**: first call runs and caches on pass; later calls
   with unchanged state skip; a failed check doesn't cache.
@@ -83,9 +83,8 @@ In Claude Code's JSON hook config:
   script / CI), ending with `markgate set`.
 - **Why**: check command lives in one place — the hook doesn't
   duplicate it.
-- **Stale / missing marker**: commit is blocked loudly — e.g. agent
-  forgot to run the check, or edited files after `markgate set`.
-  No auto-fallback; agent must re-run.
+- **AI forget**: the commit is blocked loudly — no auto-fallback,
+  agent must re-run.
 
 Concrete scenarios:
 


### PR DESCRIPTION
## Summary

The `AI forget` bullet in each Two-shapes description only covered the "agent never ran the check" case. The other case — agent ran the check, marker was set, **then files were edited before the commit fired** — was invisible. In that case verify also returns 1 (marker is stale), and the commit blocks the same way.

Rename both bullets to **Stale / missing marker** and list both triggers as examples:

**Run**:
> **Stale / missing marker**: the hook runs the check before the commit (safety net — e.g. agent forgot to run it, or edited files after running it). Commit proceeds if the check passes.

**Split**:
> **Stale / missing marker**: commit is blocked loudly — e.g. agent forgot to run the check, or edited files after `markgate set`. No auto-fallback; agent must re-run.

Shape-specific handling stays the same (run = safety net, split = loud block). The rename just widens the trigger from "no marker only" to "no marker OR stale marker", so a reader doesn't walk away assuming "set + then-commit always succeeds" and then get surprised when verify fails after a small edit.

## Test plan

- [ ] Render README on GitHub and confirm both bullets mention the edit-after-`set` case alongside the forget case.
- [ ] No internal links break (bullet label change only).
