### PR TITLE
docs: add multi-gate pre-commit use case with overlapping scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,53 @@ go test -cover && markgate set pre-push
 markgate verify pre-push || exit 1
 ```
 
+### 5. Pre-commit: isolate a slow check with its own scoped gate
+
+**Scope**: two gates on the same `git commit` event. `check` covers code artifacts; `docs` covers code **and** documentation. Source files appear in both `include` lists on purpose — a src edit invalidates both gates (forcing both checks), while a tests-only edit invalidates only `check` and a docs-only edit invalidates only `docs`.
+
+Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review. Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
+
+```yaml
+# .markgate.yml
+gates:
+  check:
+    hash: files
+    include:
+      - "src/**"
+      - "tests/**"
+      - "package.json"
+  docs:
+    hash: files
+    include:
+      - "src/**"        # src edits invalidate docs too — see matrix below
+      - "docs/**"
+      - "README.md"
+```
+
+Invalidation matrix:
+
+| edit                              | `check` | `docs`  | re-runs needed         |
+|-----------------------------------|---------|---------|------------------------|
+| `tests/**` only                   | stale   | fresh   | fast code check only   |
+| `docs/**` / `README.md` only      | fresh   | stale   | slow docs check only   |
+| `src/**`                          | stale   | stale   | both                   |
+
+**Commands**:
+
+```sh
+# Fast code check (src / tests / config):
+pnpm run typecheck && pnpm run lint && pnpm test && markgate set check
+
+# Slow docs consistency check (src / docs / README):
+./scripts/check-docs && markgate set docs
+
+# One pre-commit hook verifies both; the failing gate names itself:
+markgate verify check || { echo "run the code check" >&2; exit 1; }
+markgate verify docs  || { echo "run the docs check" >&2; exit 1; }
+```
+
+A working wire-up — Claude Code `/check` and `/check-docs` skills sharing a single pre-commit hook — is in [go-to-k/cdkd#27](https://github.com/go-to-k/cdkd/pull/27).
+
 ## Install
 
 ### Homebrew (macOS / Linux)

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ markgate verify check || { echo "run the code check" >&2; exit 1; }
 markgate verify docs  || { echo "run the docs check" >&2; exit 1; }
 ```
 
-A working wire-up — Claude Code `/check` and `/check-docs` skills sharing a single pre-commit hook — lives in [go-to-k/cdkd](https://github.com/go-to-k/cdkd): see [`.markgate.yml`](https://github.com/go-to-k/cdkd/blob/main/.markgate.yml) and [`.claude/hooks/check-gate.sh`](https://github.com/go-to-k/cdkd/blob/main/.claude/hooks/check-gate.sh).
+A working wire-up lives in [go-to-k/cdkd](https://github.com/go-to-k/cdkd): the [`.markgate.yml`](https://github.com/go-to-k/cdkd/blob/main/.markgate.yml) gate definitions, the [`.claude/hooks/check-gate.sh`](https://github.com/go-to-k/cdkd/blob/main/.claude/hooks/check-gate.sh) pre-commit hook, and the Claude Code [`/check`](https://github.com/go-to-k/cdkd/blob/main/.claude/skills/check/SKILL.md) and [`/check-docs`](https://github.com/go-to-k/cdkd/blob/main/.claude/skills/check-docs/SKILL.md) skills that produce the markers (including the diff-based short-circuit `/check-docs` uses to keep the cost low on internal src edits).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -267,11 +267,14 @@ gates:
 
 Invalidation matrix:
 
-| edit                              | `check` | `docs`  | re-runs needed         |
-|-----------------------------------|---------|---------|------------------------|
-| `tests/**` only                   | stale   | fresh   | fast code check only   |
-| `docs/**` / `README.md` only      | fresh   | stale   | slow docs check only   |
-| `src/**`                          | stale   | stale   | both                   |
+| edit                         | `check` | `docs` | re-runs needed          |
+|------------------------------|---------|--------|-------------------------|
+| `tests/**` only              | stale   | fresh  | fast code check only    |
+| `docs/**` / `README.md` only | fresh   | stale  | slow docs check only    |
+| `src/**`                     | stale   | stale  | both                    |
+| outside both scopes          | fresh   | fresh  | neither — commit passes |
+
+The last row is what makes the idiom scale: edits that land in neither `include` list (CI config, editor settings, hook scripts, tooling dotfiles) keep both markers fresh, so a hook verifying both stays silent when nothing relevant moved. That's only possible because each gate owns its own scope — `hash: files` + per-gate `include` is the primitive that makes it work.
 
 **Commands**:
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ markgate verify check || { echo "run the code check" >&2; exit 1; }
 markgate verify docs  || { echo "run the docs check" >&2; exit 1; }
 ```
 
-A working wire-up — Claude Code `/check` and `/check-docs` skills sharing a single pre-commit hook — is in [go-to-k/cdkd#27](https://github.com/go-to-k/cdkd/pull/27).
+A working wire-up — Claude Code `/check` and `/check-docs` skills sharing a single pre-commit hook — lives in [go-to-k/cdkd](https://github.com/go-to-k/cdkd): see [`.markgate.yml`](https://github.com/go-to-k/cdkd/blob/main/.markgate.yml) and [`.claude/hooks/check-gate.sh`](https://github.com/go-to-k/cdkd/blob/main/.claude/hooks/check-gate.sh).
 
 ## Install
 


### PR DESCRIPTION
## Summary

Adds a fifth use case to the README under `## Use cases` documenting a pattern that came up integrating markgate with a Claude Code project: stacking multiple gates on the same pre-commit trigger with intentional scope overlap.

- Existing cases #1–#4 all follow the "one trigger, one gate" pattern.
- Real-world need: one of the pre-commit checks (LLM-judged doc consistency) is much slower than the rest. Bundling it into the fast code check penalises every tests-only commit; making it unconditional on `src/**` edits is still too coarse.
- The idiom documented here: two gates (`check`, `docs`), each with narrow `hash: files` scope, but with `src/**` in **both** include lists. A src edit invalidates both, a tests-only edit invalidates only `check`, a docs-only edit invalidates only `docs`.
- Includes an invalidation matrix and ready-to-paste config + hook commands, plus a link to the concrete wire-up at [go-to-k/cdkd#27](https://github.com/go-to-k/cdkd/pull/27).

## Test plan

- [x] Heading structure preserved (no link-fragment breakage); no existing section renamed
- [x] Config / command examples use already-documented primitives (`hash: files`, `include`, `markgate set`, `markgate verify`)
- [x] No behavior change — docs only
- [ ] Rendering review on GitHub once pushed (table formatting, code fences)
