### PR TITLE
docs: fix pre-commit framework config filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ pre-commit:
       run: markgate run -- pnpm test
 ```
 
-**pre-commit framework** — `.pre-commit-hooks.yaml`:
+**pre-commit framework** — `.pre-commit-config.yaml`:
 
 ```yaml
 repos:


### PR DESCRIPTION
## Summary
- The example block uses `repos: - repo: local` syntax, which is the **end-user** config form. Its correct filename is `.pre-commit-config.yaml`, not `.pre-commit-hooks.yaml` (the latter is the hook *provider*'s manifest).
- Only the filename label changes; the YAML body is untouched.

## Test plan
- [x] Confirmed against pre-commit.com docs that `.pre-commit-config.yaml` is the end-user file and `.pre-commit-hooks.yaml` is the provider manifest
- [x] Verified diff is a single-line label change
