### PR TITLE
docs: add mise install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,21 @@ curl -fsSL https://raw.githubusercontent.com/go-to-k/markgate/main/install.sh | 
 curl -fsSL https://raw.githubusercontent.com/go-to-k/markgate/main/install.sh | bash -s -- v0.1.0
 ```
 
+### mise
+
+Pin a version per repo via [`.mise.toml`](https://mise.jdx.dev/configuration.html):
+
+```toml
+[tools]
+"ubi:go-to-k/markgate" = "0.2.0"
+```
+
+Or one-shot:
+
+```sh
+mise use "ubi:go-to-k/markgate@0.2.0"
+```
+
 ### `go install`
 
 ```sh


### PR DESCRIPTION
## Summary
- Add a `mise` section to the Install part of the README, between Homebrew and the shell-script installer
- Show both the `.mise.toml` pinning shape (used by [go-to-k/cdkd](https://github.com/go-to-k/cdkd)) and the one-shot `mise use` form
- Uses the `ubi:` backend so users get the prebuilt GitHub Releases binary, matching the existing install paths

## Test plan
- [x] Render the README locally and confirm the new section renders / links resolve