### PR TITLE
docs: add use case for AI-judgment checks (non-scriptable reviews)

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ go test -cover && markgate set pre-push
 markgate verify pre-push || exit 1
 ```
 
-### 4. Pre-commit: AI-judgment checks
+### 4. Pre-commit: enforce AI checks that aren't commands
 
 **Scope**: src + docs + README — the AI re-judges only when something in those scopes changes.
 
@@ -438,7 +438,7 @@ Why the agent can't trivially bypass it: `markgate set` lives at the end of the 
 
 **Scope**: two gates on the same `git commit` event. `check` covers code artifacts; `docs` covers code **and** documentation. Source files appear in both `include` lists on purpose — a src edit invalidates both gates (forcing both checks), while a tests-only edit invalidates only `check` and a docs-only edit invalidates only `docs`.
 
-Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (see [Use case 4](#4-pre-commit-ai-judgment-checks)). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
+Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (see [Use case 4](#4-pre-commit-enforce-ai-checks-that-arent-commands)). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
 
 ```yaml
 # .markgate.yml

--- a/README.md
+++ b/README.md
@@ -316,6 +316,36 @@ Rule of thumb: start with `git-tree` (add `exclude` if needed).
 Reach for `files` only when you specifically want the "ignore
 commits that don't touch these paths" semantics.
 
+## Enforcing AI checks that aren't commands
+
+Hooks can only execute commands, so on their own they enforce only **mechanical** checks (lint, tests, build). Reviews that need AI judgment — naming consistency with existing symbols, idiomatic style, "does the PR description match the diff?" — can't be reduced to a command. Linters catch snake_case violations, but "is this name semantically clear and consistent with the rest of the package?" isn't a regex. Without markgate, hooks can't gate on these.
+
+markgate gives the hook a grip. The AI skill that performs the review ends in `markgate set`; the hook runs `markgate verify`. When the agent forgets the skill, the marker is stale, the hook blocks, and the agent is pointed back at the skill.
+
+Scope the gate to src so the AI re-judges only when source files change:
+
+```yaml
+# .markgate.yml
+gates:
+  ai-naming:
+    hash: files
+    include:
+      - "src/**"
+```
+
+```sh
+# At the end of /check-naming (Claude Code skill):
+markgate set ai-naming
+
+# In a pre-commit hook (.claude/settings.json, PreToolUse on git commit*):
+markgate verify ai-naming || {
+  echo "Run /check-naming before committing." >&2
+  exit 1
+}
+```
+
+Why the agent can't trivially bypass it: `markgate set` lives at the end of the skill body, so an agent told to run `/check-naming` would have to skip the skill *and* call `markgate set` directly — more work than just running the skill. The skill is the discipline; the hook is the enforcement.
+
 ## Use cases
 
 Each section follows the same shape: **Scope** (what triggers
@@ -400,43 +430,11 @@ go test -cover && markgate set pre-push
 markgate verify pre-push || exit 1
 ```
 
-### 4. Pre-commit: enforce AI checks that aren't commands
-
-**Scope**: just src — the AI re-judges when source files change.
-
-```yaml
-# .markgate.yml
-gates:
-  ai-naming:
-    hash: files
-    include:
-      - "src/**"
-```
-
-Hooks can only execute commands, so on their own they enforce only **mechanical** checks (lint, tests, build). Reviews that need AI judgment — naming consistency with existing symbols, idiomatic style, "does the PR description match the diff?" — can't be reduced to a command. Linters catch snake_case violations, but "is this name semantically clear and consistent with the rest of the package?" isn't a regex. Without markgate, hooks can't gate on these.
-
-markgate gives the hook a grip. The AI skill that performs the review ends in `markgate set`; the hook runs `markgate verify`. When the agent forgets the skill, the marker is stale, the hook blocks, and the agent is pointed back at the skill.
-
-**Commands**:
-
-```sh
-# At the end of /check-naming (Claude Code skill):
-markgate set ai-naming
-
-# In a pre-commit hook (.claude/settings.json, PreToolUse on git commit*):
-markgate verify ai-naming || {
-  echo "Run /check-naming before committing." >&2
-  exit 1
-}
-```
-
-Why the agent can't trivially bypass it: `markgate set` lives at the end of the skill body, so an agent told to run `/check-naming` would have to skip the skill *and* call `markgate set` directly — more work than just running the skill. The skill is the discipline; the hook is the enforcement.
-
-### 5. Pre-commit: isolate a slow check with its own scoped gate
+### 4. Pre-commit: isolate a slow check with its own scoped gate
 
 **Scope**: two gates on the same `git commit` event. `check` covers code artifacts; `docs` covers code **and** documentation. Source files appear in both `include` lists on purpose — a src edit invalidates both gates (forcing both checks), while a tests-only edit invalidates only `check` and a docs-only edit invalidates only `docs`.
 
-Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (same shape as [Use case 4](#4-pre-commit-enforce-ai-checks-that-arent-commands), different scope). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
+Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (same shape as [Enforcing AI checks that aren't commands](#enforcing-ai-checks-that-arent-commands), different scope). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
 
 ```yaml
 # .markgate.yml

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ markgate verify pre-push || exit 1
 
 ### 4. Pre-commit: AI-judgment checks (non-scriptable reviews)
 
-**Scope**: src + docs + README — the AI re-judges only when something in those scopes changes. (Swap to `git-tree` if any commit should re-trigger the review.)
+**Scope**: src + docs + README — the AI re-judges only when something in those scopes changes.
 
 ```yaml
 # .markgate.yml

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ go test -cover && markgate set pre-push
 markgate verify pre-push || exit 1
 ```
 
-### 4. Pre-commit: AI-judgment checks (non-scriptable reviews)
+### 4. Pre-commit: AI-judgment checks
 
 **Scope**: src + docs + README — the AI re-judges only when something in those scopes changes.
 
@@ -415,7 +415,7 @@ gates:
       - "README.md"
 ```
 
-Hooks can only execute scripts, so on their own they enforce only **mechanical** checks (lint, tests, build). Reviews that need AI judgment — doc consistency with src, naming consistency, "does the PR description match the diff?" — aren't scriptable. Without markgate, hooks can't gate on them.
+Hooks can only execute commands, so on their own they enforce only **mechanical** checks (lint, tests, build). Reviews that need AI judgment — doc consistency with src, naming consistency, "does the PR description match the diff?" — can't be reduced to a command. Without markgate, hooks can't gate on them.
 
 markgate gives the hook a grip. The AI skill that performs the review ends in `markgate set`; the hook runs `markgate verify`. When the agent forgets the skill, the marker is stale, the hook blocks, and the agent is pointed back at the skill.
 
@@ -438,7 +438,7 @@ Why the agent can't trivially bypass it: `markgate set` lives at the end of the 
 
 **Scope**: two gates on the same `git commit` event. `check` covers code artifacts; `docs` covers code **and** documentation. Source files appear in both `include` lists on purpose — a src edit invalidates both gates (forcing both checks), while a tests-only edit invalidates only `check` and a docs-only edit invalidates only `docs`.
 
-Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (see [Use case 4](#4-pre-commit-ai-judgment-checks-non-scriptable-reviews)). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
+Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (see [Use case 4](#4-pre-commit-ai-judgment-checks)). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
 
 ```yaml
 # .markgate.yml

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ markgate verify pre-push || exit 1
 
 **Scope**: two gates on the same `git commit` event. `check` covers code artifacts; `docs` covers code **and** documentation. Source files appear in both `include` lists on purpose — a src edit invalidates both gates (forcing both checks), while a tests-only edit invalidates only `check` and a docs-only edit invalidates only `docs`.
 
-Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (see [Enforcing AI checks that aren't commands](#enforcing-ai-checks-that-arent-commands)). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
+Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review. Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
 
 ```yaml
 # .markgate.yml

--- a/README.md
+++ b/README.md
@@ -402,43 +402,41 @@ markgate verify pre-push || exit 1
 
 ### 4. Pre-commit: enforce AI checks that aren't commands
 
-**Scope**: src + docs + README — the AI re-judges only when something in those scopes changes.
+**Scope**: just src — the AI re-judges when source files change.
 
 ```yaml
 # .markgate.yml
 gates:
-  ai-docs:
+  ai-naming:
     hash: files
     include:
       - "src/**"
-      - "docs/**"
-      - "README.md"
 ```
 
-Hooks can only execute commands, so on their own they enforce only **mechanical** checks (lint, tests, build). Reviews that need AI judgment — doc consistency with src, naming consistency, "does the PR description match the diff?" — can't be reduced to a command. Without markgate, hooks can't gate on them.
+Hooks can only execute commands, so on their own they enforce only **mechanical** checks (lint, tests, build). Reviews that need AI judgment — naming consistency with existing symbols, idiomatic style, "does the PR description match the diff?" — can't be reduced to a command. Linters catch snake_case violations, but "is this name semantically clear and consistent with the rest of the package?" isn't a regex. Without markgate, hooks can't gate on these.
 
 markgate gives the hook a grip. The AI skill that performs the review ends in `markgate set`; the hook runs `markgate verify`. When the agent forgets the skill, the marker is stale, the hook blocks, and the agent is pointed back at the skill.
 
 **Commands**:
 
 ```sh
-# At the end of /check-docs (Claude Code skill):
-markgate set ai-docs
+# At the end of /check-naming (Claude Code skill):
+markgate set ai-naming
 
 # In a pre-commit hook (.claude/settings.json, PreToolUse on git commit*):
-markgate verify ai-docs || {
-  echo "Run /check-docs before committing." >&2
+markgate verify ai-naming || {
+  echo "Run /check-naming before committing." >&2
   exit 1
 }
 ```
 
-Why the agent can't trivially bypass it: `markgate set` lives at the end of the skill body, so an agent told to run `/check-docs` would have to skip the skill *and* call `markgate set` directly — more work than just running the skill. The skill is the discipline; the hook is the enforcement.
+Why the agent can't trivially bypass it: `markgate set` lives at the end of the skill body, so an agent told to run `/check-naming` would have to skip the skill *and* call `markgate set` directly — more work than just running the skill. The skill is the discipline; the hook is the enforcement.
 
 ### 5. Pre-commit: isolate a slow check with its own scoped gate
 
 **Scope**: two gates on the same `git commit` event. `check` covers code artifacts; `docs` covers code **and** documentation. Source files appear in both `include` lists on purpose — a src edit invalidates both gates (forcing both checks), while a tests-only edit invalidates only `check` and a docs-only edit invalidates only `docs`.
 
-Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (see [Use case 4](#4-pre-commit-enforce-ai-checks-that-arent-commands)). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
+Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (same shape as [Use case 4](#4-pre-commit-enforce-ai-checks-that-arent-commands), different scope). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
 
 ```yaml
 # .markgate.yml

--- a/README.md
+++ b/README.md
@@ -220,6 +220,24 @@ in `.markgate.yml`, markers go to `<dir>/` instead — see [Sharing
 markers](#sharing-markers-across-machines-ci--teammates). The
 on-disk JSON layout is an implementation detail; don't parse it.
 
+## Enforcing AI checks that aren't commands
+
+Hooks can only execute commands, so on their own they enforce only **mechanical** checks (lint, tests, build). Reviews that need AI judgment — docs consistency with src, naming consistency with existing symbols, "does the PR description match the diff?" — can't be reduced to a command. The mechanical layer can spot a typo or a bad import, but "are these docs still in sync with what the code does?" isn't a regex. Without markgate, hooks can't gate on these.
+
+markgate gives the hook a grip. The AI skill that performs the review ends in `markgate set`; the hook runs `markgate verify`. When the agent forgets the skill, the marker is stale, the hook blocks, and the agent is pointed back at the skill.
+
+```sh
+# At the end of /check-docs (Claude Code skill body):
+markgate set
+
+# In a pre-commit hook (.claude/settings.json, PreToolUse on git commit*):
+markgate verify || { echo "Run /check-docs before committing." >&2; exit 1; }
+```
+
+Why the agent can't trivially bypass it: `markgate set` lives at the end of the skill body, so an agent told to run `/check-docs` would have to skip the skill *and* call `markgate set` directly — more work than just running the skill. The skill is the discipline; the hook is the enforcement.
+
+To narrow the trigger so the marker invalidates only when specific files change — e.g. re-judge docs only when `docs/**` or `src/**` move — see [Scoped gates](#scoped-gates) below.
+
 ## Scoped gates
 
 `markgate` works zero-config — what [Basic setup](#basic-setup)
@@ -316,36 +334,6 @@ Rule of thumb: start with `git-tree` (add `exclude` if needed).
 Reach for `files` only when you specifically want the "ignore
 commits that don't touch these paths" semantics.
 
-## Enforcing AI checks that aren't commands
-
-Hooks can only execute commands, so on their own they enforce only **mechanical** checks (lint, tests, build). Reviews that need AI judgment — naming consistency with existing symbols, idiomatic style, "does the PR description match the diff?" — can't be reduced to a command. Linters catch snake_case violations, but "is this name semantically clear and consistent with the rest of the package?" isn't a regex. Without markgate, hooks can't gate on these.
-
-markgate gives the hook a grip. The AI skill that performs the review ends in `markgate set`; the hook runs `markgate verify`. When the agent forgets the skill, the marker is stale, the hook blocks, and the agent is pointed back at the skill.
-
-Scope the gate to src so the AI re-judges only when source files change:
-
-```yaml
-# .markgate.yml
-gates:
-  ai-naming:
-    hash: files
-    include:
-      - "src/**"
-```
-
-```sh
-# At the end of /check-naming (Claude Code skill):
-markgate set ai-naming
-
-# In a pre-commit hook (.claude/settings.json, PreToolUse on git commit*):
-markgate verify ai-naming || {
-  echo "Run /check-naming before committing." >&2
-  exit 1
-}
-```
-
-Why the agent can't trivially bypass it: `markgate set` lives at the end of the skill body, so an agent told to run `/check-naming` would have to skip the skill *and* call `markgate set` directly — more work than just running the skill. The skill is the discipline; the hook is the enforcement.
-
 ## Use cases
 
 Each section follows the same shape: **Scope** (what triggers
@@ -434,7 +422,7 @@ markgate verify pre-push || exit 1
 
 **Scope**: two gates on the same `git commit` event. `check` covers code artifacts; `docs` covers code **and** documentation. Source files appear in both `include` lists on purpose — a src edit invalidates both gates (forcing both checks), while a tests-only edit invalidates only `check` and a docs-only edit invalidates only `docs`.
 
-Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (same shape as [Enforcing AI checks that aren't commands](#enforcing-ai-checks-that-arent-commands), different scope). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
+Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (see [Enforcing AI checks that aren't commands](#enforcing-ai-checks-that-arent-commands)). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
 
 ```yaml
 # .markgate.yml

--- a/README.md
+++ b/README.md
@@ -400,11 +400,45 @@ go test -cover && markgate set pre-push
 markgate verify pre-push || exit 1
 ```
 
-### 4. Pre-commit: isolate a slow check with its own scoped gate
+### 4. Pre-commit: AI-judgment checks (non-scriptable reviews)
+
+**Scope**: src + docs + README — the AI re-judges only when something in those scopes changes. (Swap to `git-tree` if any commit should re-trigger the review.)
+
+```yaml
+# .markgate.yml
+gates:
+  ai-docs:
+    hash: files
+    include:
+      - "src/**"
+      - "docs/**"
+      - "README.md"
+```
+
+Hooks can only execute scripts, so on their own they enforce only **mechanical** checks (lint, tests, build). Reviews that need AI judgment — doc consistency with src, naming consistency, "does the PR description match the diff?" — aren't scriptable. Without markgate, hooks can't gate on them.
+
+markgate gives the hook a grip. The AI skill that performs the review ends in `markgate set`; the hook runs `markgate verify`. When the agent forgets the skill, the marker is stale, the hook blocks, and the agent is pointed back at the skill.
+
+**Commands**:
+
+```sh
+# At the end of /check-docs (Claude Code skill):
+markgate set ai-docs
+
+# In a pre-commit hook (.claude/settings.json, PreToolUse on git commit*):
+markgate verify ai-docs || {
+  echo "Run /check-docs before committing." >&2
+  exit 1
+}
+```
+
+Why the agent can't trivially bypass it: `markgate set` lives at the end of the skill body, so an agent told to run `/check-docs` would have to skip the skill *and* call `markgate set` directly — more work than just running the skill. The skill is the discipline; the hook is the enforcement.
+
+### 5. Pre-commit: isolate a slow check with its own scoped gate
 
 **Scope**: two gates on the same `git commit` event. `check` covers code artifacts; `docs` covers code **and** documentation. Source files appear in both `include` lists on purpose — a src edit invalidates both gates (forcing both checks), while a tests-only edit invalidates only `check` and a docs-only edit invalidates only `docs`.
 
-Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review. Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
+Useful when one pre-commit check is much slower than the others — typically an LLM-judged "are the docs still consistent with src?" review (see [Use case 4](#4-pre-commit-ai-judgment-checks-non-scriptable-reviews)). Bundling it into the fast code check would force every tests-only or bug-fix commit to pay the doc-review cost. Splitting it into its own scoped gate means each edit only pays for the scope it actually invalidated.
 
 ```yaml
 # .markgate.yml


### PR DESCRIPTION
## Summary

- Adds a new \"Use case 4: Pre-commit: AI-judgment checks (non-scriptable reviews)\" showing how `markgate set` at the end of a Claude Code skill plus `markgate verify` in a hook lets a hook gate on checks that aren't scriptable (LLM-judged doc consistency, naming review, PR-description ↔ diff alignment, etc.).
- Reorders so the simpler single-gate AI-judgment shape comes first; the multi-gate split case (now Use case 5) references it as the canonical \"slow check\" example, which retroactively explains its previously bare \"typically an LLM-judged review\" mention.

## Why

Hooks can only execute scripts, so on their own they enforce only mechanical checks (lint, tests, build). Reviews that need AI judgment aren't scriptable, and without markgate the hook has no grip on them. Surfacing this as its own use case — separate from the multi-gate split (which is structurally about scope-splitting) — makes the capability discoverable.

## Test plan

- [ ] Render preview on GitHub: section heading, anchors, internal link `#4-pre-commit-ai-judgment-checks-non-scriptable-reviews` from Use case 5
- [ ] Confirm Use case numbering (1–5) and that other sections referencing Use case 2/3 still work