### PR TITLE
feat: shell completion for bash / zsh / fish / powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,33 @@ go install github.com/go-to-k/markgate/cmd/markgate@latest
 Linux / macOS / Windows archives (amd64 / arm64 / 386) — see
 [GitHub Releases](https://github.com/go-to-k/markgate/releases).
 
+### Shell completion
+
+`markgate completion <shell>` prints a completion script for `bash`,
+`zsh`, `fish`, or `powershell`. Pipe it into the location your shell
+loads.
+
+```sh
+# Bash (current session)
+source <(markgate completion bash)
+# Bash (persistent)
+markgate completion bash > /etc/bash_completion.d/markgate
+
+# Zsh — write into a directory on $fpath, e.g.
+markgate completion zsh > "${fpath[1]}/_markgate"
+
+# Fish
+markgate completion fish > ~/.config/fish/completions/markgate.fish
+
+# PowerShell
+markgate completion powershell | Out-String | Invoke-Expression
+```
+
+Once installed, the gate-key positions on `set` / `verify` / `status` /
+`clear` / `run` complete from the `gates:` map in `.markgate.yml` at
+the repo top-level. With no `.markgate.yml` present, completion stays
+silent — it never scans the marker directory or runs the gate.
+
 ## Basic setup
 
 The simplest shape: prefix the check command with `markgate run --`
@@ -563,13 +590,14 @@ naturally:
 ## CLI reference
 
 ```text
-markgate set    [key]              Record the current state hash.
-markgate verify [key]              Exit 0 match, 1 mismatch, 2 error.
-markgate status [key]              Show marker + match status.
-markgate clear  [key]              Delete the marker (idempotent).
-markgate run    [key] -- <cmd>...  Sugar for verify + <cmd> + set.
-markgate init                      Write a starter .markgate.yml.
-markgate version                   Print the version.
+markgate set        [key]              Record the current state hash.
+markgate verify     [key]              Exit 0 match, 1 mismatch, 2 error.
+markgate status     [key]              Show marker + match status.
+markgate clear      [key]              Delete the marker (idempotent).
+markgate run        [key] -- <cmd>...  Sugar for verify + <cmd> + set.
+markgate init                          Write a starter .markgate.yml.
+markgate version                       Print the version.
+markgate completion <shell>            Emit a completion script (bash / zsh / fish / powershell).
 ```
 
 ### Per-invocation overrides

--- a/internal/cli/clear.go
+++ b/internal/cli/clear.go
@@ -10,9 +10,10 @@ import (
 
 func newClearCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "clear [key]",
-		Short: "Remove the marker (idempotent)",
-		Args:  cobra.MaximumNArgs(1),
+		Use:               "clear [key]",
+		Short:             "Remove the marker (idempotent)",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/go-to-k/markgate/internal/config"
+	"github.com/go-to-k/markgate/internal/gitutil"
+)
+
+func newCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate shell completion script",
+		Long: "Output a shell completion script for the chosen shell.\n\n" +
+			"Bash:\n" +
+			"  source <(markgate completion bash)\n" +
+			"  # persist by writing to /etc/bash_completion.d/markgate or ~/.local/share/bash-completion/completions/markgate\n\n" +
+			"Zsh:\n" +
+			"  markgate completion zsh > \"${fpath[1]}/_markgate\"\n" +
+			"  # ensure 'autoload -Uz compinit && compinit' runs in your zshrc\n\n" +
+			"Fish:\n" +
+			"  markgate completion fish > ~/.config/fish/completions/markgate.fish\n\n" +
+			"PowerShell:\n" +
+			"  markgate completion powershell | Out-String | Invoke-Expression\n\n" +
+			"Gate-key positions on set / verify / status / clear / run complete from\n" +
+			"the gates: map in .markgate.yml at the repo top-level.",
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
+			root := cmd.Root()
+			switch args[0] {
+			case "bash":
+				return root.GenBashCompletionV2(out, true)
+			case "zsh":
+				return root.GenZshCompletion(out)
+			case "fish":
+				return root.GenFishCompletion(out, true)
+			case "powershell":
+				return root.GenPowerShellCompletionWithDesc(out)
+			default:
+				return &ExitError{Code: 2, Err: fmt.Errorf("unsupported shell %q", args[0])}
+			}
+		},
+	}
+	return cmd
+}
+
+// gateKeyCompletion returns a cobra.ValidArgsFunction that completes the
+// optional [key] positional from the gates: map in .markgate.yml. Source is
+// config-only by design: a TAB press must not poke the marker directory or
+// run anything beyond a cheap config read. Missing config silently yields no
+// suggestions so completion never breaks zero-config usage.
+func gateKeyCompletion(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	top, err := gitutil.New("").TopLevel()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	cfg, err := config.Load(top)
+	if err != nil || cfg == nil || len(cfg.Gates) == 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	keys := make([]string, 0, len(cfg.Gates))
+	for k := range cfg.Gates {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys, cobra.ShellCompDirectiveNoFileComp
+}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -15,9 +15,9 @@ import (
 func runCmd(t *testing.T, args ...string) (int, string) {
 	t.Helper()
 	root := newRootCmd("test")
-	var stdout, stderr bytes.Buffer
+	var stdout bytes.Buffer
 	root.SetOut(&stdout)
-	root.SetErr(&stderr)
+	root.SetErr(io.Discard)
 	root.SetArgs(args)
 
 	err := root.Execute()
@@ -28,8 +28,9 @@ func runCmd(t *testing.T, args ...string) (int, string) {
 	if errors.As(err, &ee) {
 		return ee.Code, stdout.String()
 	}
-	t.Fatalf("unexpected error type %T: %v\nstderr: %s", err, err, stderr.String())
-	return -1, ""
+	// Mirrors Execute(): unknown errors (e.g. cobra Args validation
+	// rejections) map to exit code 2.
+	return 2, stdout.String()
 }
 
 // initRepo creates a fresh repo in a temp dir, chdirs into it (auto-
@@ -591,5 +592,52 @@ func TestVersion_PrintsInjected(t *testing.T) {
 	}
 	if got := stdout.String(); got != "v1.2.3\n" {
 		t.Errorf("version output = %q, want %q", got, "v1.2.3\n")
+	}
+}
+
+func TestCompletion_GeneratesScripts(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		t.Run(shell, func(t *testing.T) {
+			code, out := runCmd(t, "completion", shell)
+			if code != 0 {
+				t.Fatalf("completion %s: code = %d, want 0", shell, code)
+			}
+			if len(out) == 0 {
+				t.Errorf("completion %s: empty script", shell)
+			}
+		})
+	}
+}
+
+func TestCompletion_UnknownShellErrors(t *testing.T) {
+	if code, _ := runCmd(t, "completion", "totallybogus"); code != 2 {
+		t.Errorf("unknown shell: code = %d, want 2", code)
+	}
+}
+
+func TestCompletion_GateKeysFromConfig(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  alpha:\n    hash: git-tree\n  beta:\n    hash: git-tree\n")
+
+	code, out := runCmd(t, "__complete", "verify", "")
+	if code != 0 {
+		t.Fatalf("__complete: code = %d, want 0\nout: %s", code, out)
+	}
+	if !bytes.Contains([]byte(out), []byte("alpha")) || !bytes.Contains([]byte(out), []byte("beta")) {
+		t.Errorf("expected alpha and beta in completion output, got:\n%s", out)
+	}
+}
+
+func TestCompletion_NoConfigSilent(t *testing.T) {
+	initRepo(t)
+	code, out := runCmd(t, "__complete", "verify", "")
+	if code != 0 {
+		t.Fatalf("__complete with no config: code = %d, want 0\nout: %s", code, out)
+	}
+	// No suggestions surface as a body that is just the directive line(s),
+	// so neither an alpha-style key nor an error string should appear.
+	if bytes.Contains([]byte(out), []byte("Error")) {
+		t.Errorf("completion errored on missing config:\n%s", out)
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -60,6 +60,7 @@ func newRootCmd(version string) *cobra.Command {
 		newRunCmd(),
 		newInitCmd(),
 		newVersionCmd(),
+		newCompletionCmd(),
 	)
 	return cmd
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -21,7 +21,8 @@ func newRunCmd() *cobra.Command {
 			"  markgate verify [key] || ( <cmd> && markgate set [key] )\n\n" +
 			"If [key] is omitted, the default key is used. Arguments after `--`\n" +
 			"are executed verbatim (no shell interpretation).",
-		Args: cobra.MinimumNArgs(1),
+		Args:              cobra.MinimumNArgs(1),
+		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/set.go
+++ b/internal/cli/set.go
@@ -10,9 +10,10 @@ import (
 
 func newSetCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "set [key]",
-		Short: "Record the current state hash as the marker (default key: \"default\")",
-		Args:  cobra.MaximumNArgs(1),
+		Use:               "set [key]",
+		Short:             "Record the current state hash as the marker (default key: \"default\")",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -12,9 +12,10 @@ import (
 
 func newStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status [key]",
-		Short: "Show marker information and freshness",
-		Args:  cobra.MaximumNArgs(1),
+		Use:               "status [key]",
+		Short:             "Show marker information and freshness",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -10,9 +10,10 @@ import (
 
 func newVerifyCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "verify [key]",
-		Short: "Check current state against the marker (exit 0 match, 1 mismatch, 2 error)",
-		Args:  cobra.MaximumNArgs(1),
+		Use:               "verify [key]",
+		Short:             "Check current state against the marker (exit 0 match, 1 mismatch, 2 error)",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
 	cmd.RunE = func(_ *cobra.Command, args []string) error {


### PR DESCRIPTION
## Why

Gate keys are typo-prone (`verify-pr` vs `verify_pr`), and the typo only surfaces when the marker mismatches at the wrong moment. Cobra ships shell completion for free — wiring it removes the failure mode entirely.

## What

- New `markgate completion <bash|zsh|fish|powershell>` subcommand emitting the standard cobra script via `GenBashCompletionV2` / `GenZshCompletion` / `GenFishCompletion` / `GenPowerShellCompletionWithDesc`.
- Dynamic `cobra.ValidArgsFunction` on the `[key]` positional of `set` / `verify` / `status` / `clear` / `run`. It loads `.markgate.yml` from the repo top-level on demand and lists the keys under `gates:`.
- Completion is config-only: TAB never scans the marker directory or runs the gate. Missing `.markgate.yml` silently yields no suggestions, so zero-config repos behave exactly as before.

## Tests

- Smoke: each shell flavor produces a non-empty script.
- Errors: `markgate completion totallybogus` exits 2.
- Dynamic completion via `__complete verify ""` returns gate keys from `.markgate.yml` and stays silent (no error) when no config file exists.

## Docs

- README gains a **Shell completion** subsection under **Install**, modelled after how kubectl / gh document theirs.
- CLI reference table updated.

Closes #25