### PR TITLE
feat: --explain on verify, status, run

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,10 @@ markgate version                       Print the version.
 markgate completion <shell>            Emit a completion script (bash / zsh / fish / powershell).
 ```
 
+`verify`, `status`, and `run` accept `--explain` / `-e` to print the
+files currently in scope to stderr (with `--json` for a structured
+form on stdout). See [Debugging a stale gate](#debugging-a-stale-gate).
+
 ### Per-invocation overrides
 
 `set` / `verify` / `status` / `clear` / `run` each accept these flags,
@@ -664,12 +668,60 @@ so one-off scopes don't need a `.markgate.yml`:
                          <git-dir>/markgate. See "Sharing markers".
 ```
 
+`verify` / `status` / `run` additionally accept a debug flag:
+
+```text
+--explain, -e            Print the in-scope file list to stderr ahead
+                         of normal output. Does NOT change exit codes.
+                         See "Debugging a stale gate" below.
+--json                   With --explain: emit a single JSON object on
+                         stdout instead of the text scope listing.
+                         (--json without --explain is an error.)
+```
+
 Flag syntax is identical across hash types. With `--hash files`,
 `--include` is required. Example — exclude `vendor/` without any
 config file:
 
 ```sh
 markgate run --exclude 'vendor/**' -- pnpm build
+```
+
+#### Debugging a stale gate
+
+`--explain` lists the files **currently in scope** for the active
+hasher (`git-tree` or `files`) after `--include` / `--exclude`
+filtering. It is **not** a diff against the marker — markgate stores
+only a single SHA-256, so "files that changed since `set`" cannot be
+reconstructed post-hoc. What you see is the candidate set the hasher
+would fold into the digest right now; if the wrong files appear (or
+expected ones are missing), your globs are misconfigured.
+
+```sh
+$ markgate verify check -e
+scope:
+  go.mod
+  internal/cli/helper.go
+  internal/cli/status.go
+  internal/state/state.go
+state: mismatch
+```
+
+The state line uses one of `match`, `mismatch`, `no marker` — the
+same vocabulary as the JSON form below. The exit code is unchanged
+(0 / 1 / 2), so `--explain` is safe to leave on inside a hook while
+debugging.
+
+`--explain --json` emits a single object on stdout instead, suitable
+for piping into `jq`:
+
+```json
+{
+  "key": "check",
+  "scope": ["go.mod", "internal/cli/helper.go"],
+  "hasher": "git-tree",
+  "state": "mismatch"
+}
 ```
 
 ### Environment variables
@@ -910,6 +962,14 @@ markers where commit-access already implies trust in the signal.
   (28-31 days) and would make `now - created_at > 1mo` non-deterministic.
   Use `30d` or `4w` to be explicit. Same reasoning rules out `1y`.
   (See [Wall-clock expiry](#wall-clock-expiry-ttl).)
+- **My gate keeps re-running. How do I debug it?** Run `markgate
+  verify <key> --explain` (or `-e`). It lists the files currently in
+  scope on stderr, so you can see whether your `include` /
+  `exclude` globs match what you expect. Note: this is the
+  *current* scope, not a diff against the marker — markgate stores a
+  single hash, so "which files changed since `set`" can't be
+  reconstructed. See
+  [Debugging a stale gate](#debugging-a-stale-gate).
 
 ## License
 

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/go-to-k/markgate/internal/state"
+)
+
+// State labels for the --explain output. Match exactly across text and
+// JSON modes so callers parsing either form see the same vocabulary.
+const (
+	stateMatch    = "match"
+	stateMismatch = "mismatch"
+	stateNoMarker = "no marker"
+)
+
+// explainFlags holds the values populated by addExplainFlags. nil-safe:
+// commands that did not register the flags pass nil and get default
+// (no-op) behavior.
+type explainFlags struct {
+	enabled bool
+	json    bool
+}
+
+// addExplainFlags registers --explain/-e and --json on cmd. --json is a
+// modifier on --explain; passing --json without --explain is a usage
+// error reported at run time.
+func addExplainFlags(cmd *cobra.Command) *explainFlags {
+	v := &explainFlags{}
+	cmd.Flags().BoolVarP(&v.enabled, "explain", "e", false,
+		"list files in the current gate scope (to stderr)")
+	cmd.Flags().BoolVar(&v.json, "json", false,
+		"with --explain: emit a single JSON object on stdout instead of the text form")
+	return v
+}
+
+// validate enforces the "--json requires --explain" rule.
+func (v *explainFlags) validate() error {
+	if v == nil {
+		return nil
+	}
+	if v.json && !v.enabled {
+		return errors.New("--json requires --explain")
+	}
+	return nil
+}
+
+// explainPayload mirrors the documented JSON shape. Keys are snake_case;
+// the field set is locked at {key, scope, hasher, state}.
+type explainPayload struct {
+	Key    string   `json:"key"`
+	Scope  []string `json:"scope"`
+	Hasher string   `json:"hasher"`
+	State  string   `json:"state"`
+}
+
+// emitExplain writes the scope listing for c. In text mode the listing
+// goes to errOut (stderr), preserving stdout for downstream composition;
+// in --json mode a single object goes to out (stdout) and nothing goes
+// to stderr.
+//
+// markerState is one of stateMatch / stateMismatch / stateNoMarker and
+// reflects what verify would return for the same context. Callers that
+// already loaded the marker pass the result of explainStateForVerify.
+func emitExplain(c *gateCtx, flags *explainFlags, out, errOut io.Writer, markerState string) error {
+	if flags == nil || !flags.enabled {
+		return nil
+	}
+	scope, err := c.hasher.Scope(c.repo)
+	if err != nil {
+		return err
+	}
+	// Empty scope is a real signal (globs match nothing); render an
+	// empty list rather than nil so JSON consumers see []  .
+	if scope == nil {
+		scope = []string{}
+	}
+
+	if flags.json {
+		payload := explainPayload{
+			Key:    c.key,
+			Scope:  scope,
+			Hasher: c.hasher.Type(),
+			State:  markerState,
+		}
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(payload)
+	}
+
+	fmt.Fprintln(errOut, "scope:")
+	for _, p := range scope {
+		fmt.Fprintf(errOut, "  %s\n", p)
+	}
+	fmt.Fprintf(errOut, "state: %s\n", markerState)
+	return nil
+}
+
+// explainStateForVerify computes the state label that --explain should
+// report for c, using the same rules as `verify`: missing marker yields
+// "no marker"; a hash-type or digest mismatch yields "mismatch";
+// otherwise "match". The boolean tracks whether the marker matched, so
+// `run` can decide whether to skip the child without re-loading.
+func explainStateForVerify(c *gateCtx) (label string, matched bool, marker *state.Marker, err error) {
+	m, loadErr := state.Load(c.markerPath)
+	if loadErr != nil {
+		if errors.Is(loadErr, state.ErrNotFound) {
+			return stateNoMarker, false, nil, nil
+		}
+		return "", false, nil, loadErr
+	}
+	digest, hashErr := c.hasher.Hash(c.repo)
+	if hashErr != nil {
+		return "", false, nil, hashErr
+	}
+	if m.HashType != c.hasher.Type() || m.Digest != digest {
+		return stateMismatch, false, m, nil
+	}
+	return stateMatch, true, m, nil
+}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -25,23 +25,32 @@ func withClock(t *testing.T, instant time.Time) {
 // code (0 match, 1 mismatch, 2 error) plus captured stdout.
 func runCmd(t *testing.T, args ...string) (int, string) {
 	t.Helper()
+	code, stdout, _ := runCmdStderr(t, args...)
+	return code, stdout
+}
+
+// runCmdStderr is the long form of runCmd: same exit-code semantics, but
+// also returns the captured stderr. Used by --explain tests where the
+// scope listing is written to stderr.
+func runCmdStderr(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
 	root := newRootCmd("test")
-	var stdout bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	root.SetOut(&stdout)
-	root.SetErr(io.Discard)
+	root.SetErr(&stderr)
 	root.SetArgs(args)
 
 	err := root.Execute()
 	if err == nil {
-		return 0, stdout.String()
+		return 0, stdout.String(), stderr.String()
 	}
 	var ee *ExitError
 	if errors.As(err, &ee) {
-		return ee.Code, stdout.String()
+		return ee.Code, stdout.String(), stderr.String()
 	}
 	// Mirrors Execute(): unknown errors (e.g. cobra Args validation
 	// rejections) map to exit code 2.
-	return 2, stdout.String()
+	return 2, stdout.String(), stderr.String()
 }
 
 // initRepo creates a fresh repo in a temp dir, chdirs into it (auto-
@@ -894,5 +903,218 @@ func TestTTL_MalformedRejectedAtConfigLoad(t *testing.T) {
 	}
 	if code, _ := runCmd(t, "verify", "g"); code != 2 {
 		t.Errorf("malformed ttl on verify: code = %d, want 2", code)
+	}
+}
+
+func TestExplain_VerifyNoMarkerListsScope(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+
+	code, stdout, stderr := runCmdStderr(t, "verify", "check", "--explain")
+	if code != 1 {
+		t.Errorf("verify with no marker: code = %d, want 1", code)
+	}
+	if stdout != "" {
+		t.Errorf("--explain text mode wrote to stdout: %q", stdout)
+	}
+	if !bytes.Contains([]byte(stderr), []byte("scope:")) {
+		t.Errorf("stderr missing 'scope:' header:\n%s", stderr)
+	}
+	if !bytes.Contains([]byte(stderr), []byte("src/a.go")) {
+		t.Errorf("stderr missing untracked file in scope:\n%s", stderr)
+	}
+	if !bytes.Contains([]byte(stderr), []byte("state: no marker")) {
+		t.Errorf("stderr missing 'state: no marker':\n%s", stderr)
+	}
+}
+
+func TestExplain_VerifyMismatchListsScope(t *testing.T) {
+	dir := initRepo(t)
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	writeRepoFile(t, dir, "seed.txt", "edited")
+
+	code, _, stderr := runCmdStderr(t, "verify", "check", "-e")
+	if code != 1 {
+		t.Errorf("verify after edit: code = %d, want 1", code)
+	}
+	if !bytes.Contains([]byte(stderr), []byte("seed.txt")) {
+		t.Errorf("stderr missing edited file in scope:\n%s", stderr)
+	}
+	if !bytes.Contains([]byte(stderr), []byte("state: mismatch")) {
+		t.Errorf("stderr missing mismatch state:\n%s", stderr)
+	}
+}
+
+func TestExplain_VerifyMatchPreservesExitZero(t *testing.T) {
+	initRepo(t)
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	code, _, stderr := runCmdStderr(t, "verify", "check", "--explain")
+	if code != 0 {
+		t.Errorf("verify (match) with --explain: code = %d, want 0", code)
+	}
+	if !bytes.Contains([]byte(stderr), []byte("state: match")) {
+		t.Errorf("stderr missing match state:\n%s", stderr)
+	}
+}
+
+func TestExplain_RespectsIncludeOnly(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, "docs/x.md", "x")
+
+	_, _, stderr := runCmdStderr(t, "verify", "check", "--include", "src/**", "-e")
+	if !bytes.Contains([]byte(stderr), []byte("src/a.go")) {
+		t.Errorf("stderr missing included path:\n%s", stderr)
+	}
+	if bytes.Contains([]byte(stderr), []byte("docs/x.md")) {
+		t.Errorf("stderr should not list out-of-include path:\n%s", stderr)
+	}
+}
+
+func TestExplain_RespectsExcludeFilter(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "vendor/lib.go", "lib")
+	writeRepoFile(t, dir, "src/a.go", "a")
+
+	_, _, stderr := runCmdStderr(t, "verify", "check", "--exclude", "vendor/**", "-e")
+	if !bytes.Contains([]byte(stderr), []byte("src/a.go")) {
+		t.Errorf("stderr missing non-excluded path:\n%s", stderr)
+	}
+	if bytes.Contains([]byte(stderr), []byte("vendor/lib.go")) {
+		t.Errorf("stderr should not list excluded path:\n%s", stderr)
+	}
+}
+
+func TestExplain_VerifyJSON(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+
+	code, stdout, stderr := runCmdStderr(t, "verify", "check", "--explain", "--json")
+	if code != 1 {
+		t.Errorf("verify (no marker) JSON: code = %d, want 1", code)
+	}
+	if stderr != "" {
+		t.Errorf("--explain --json wrote to stderr: %q", stderr)
+	}
+	var doc struct {
+		Key    string   `json:"key"`
+		Scope  []string `json:"scope"`
+		Hasher string   `json:"hasher"`
+		State  string   `json:"state"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout)
+	}
+	if doc.Key != "check" {
+		t.Errorf("key = %q, want check", doc.Key)
+	}
+	if doc.Hasher != "git-tree" {
+		t.Errorf("hasher = %q, want git-tree", doc.Hasher)
+	}
+	if doc.State != "no marker" {
+		t.Errorf("state = %q, want %q", doc.State, "no marker")
+	}
+	found := false
+	for _, p := range doc.Scope {
+		if p == "src/a.go" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("scope missing src/a.go: %v", doc.Scope)
+	}
+}
+
+func TestExplain_JSONRequiresExplain(t *testing.T) {
+	initRepo(t)
+	if code, _ := runCmd(t, "verify", "check", "--json"); code != 2 {
+		t.Errorf("--json without --explain: code = %d, want 2", code)
+	}
+}
+
+func TestExplain_StatusListsScope(t *testing.T) {
+	dir := initRepo(t)
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	writeRepoFile(t, dir, "seed.txt", "edited")
+
+	code, stdout, stderr := runCmdStderr(t, "status", "check", "-e")
+	if code != 1 {
+		t.Errorf("status mismatch: code = %d, want 1", code)
+	}
+	if !bytes.Contains([]byte(stderr), []byte("scope:")) {
+		t.Errorf("stderr missing scope listing:\n%s", stderr)
+	}
+	if !bytes.Contains([]byte(stdout), []byte("state:      mismatch")) {
+		t.Errorf("stdout missing existing status block:\n%s", stdout)
+	}
+}
+
+func TestExplain_StatusJSON(t *testing.T) {
+	dir := initRepo(t)
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	writeRepoFile(t, dir, "seed.txt", "edited")
+
+	code, stdout, _ := runCmdStderr(t, "status", "check", "--explain", "--json")
+	if code != 1 {
+		t.Errorf("status JSON mismatch: code = %d, want 1", code)
+	}
+	var doc struct {
+		Key    string   `json:"key"`
+		Scope  []string `json:"scope"`
+		Hasher string   `json:"hasher"`
+		State  string   `json:"state"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout)
+	}
+	if doc.State != "mismatch" {
+		t.Errorf("state = %q, want mismatch", doc.State)
+	}
+	if doc.Hasher != "git-tree" {
+		t.Errorf("hasher = %q", doc.Hasher)
+	}
+}
+
+func TestExplain_RunListsScopeOnSkip(t *testing.T) {
+	initRepo(t)
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	// Match → child must not run; --explain still emits scope + state.
+	code, _, stderr := runCmdStderr(t, "run", "check", "-e", "--", "false")
+	if code != 0 {
+		t.Errorf("run skip with --explain: code = %d, want 0", code)
+	}
+	if !bytes.Contains([]byte(stderr), []byte("state: match")) {
+		t.Errorf("stderr missing state line:\n%s", stderr)
+	}
+}
+
+func TestExplain_RunJSONOnSkip(t *testing.T) {
+	initRepo(t)
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	code, stdout, _ := runCmdStderr(t, "run", "check", "--explain", "--json", "--", "false")
+	if code != 0 {
+		t.Errorf("run skip JSON: code = %d, want 0", code)
+	}
+	var doc struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, stdout)
+	}
+	if doc.State != "match" {
+		t.Errorf("state = %q, want match", doc.State)
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -25,13 +25,17 @@ func newRunCmd() *cobra.Command {
 		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
+	explain := addExplainFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		return runE(cmd, args, overrides)
+		return runE(cmd, args, overrides, explain)
 	}
 	return cmd
 }
 
-func runE(cmd *cobra.Command, args []string, overrides *gateFlagValues) error {
+func runE(cmd *cobra.Command, args []string, overrides *gateFlagValues, explain *explainFlags) error {
+	if err := explain.validate(); err != nil {
+		return &ExitError{Code: 2, Err: err}
+	}
 	dash := cmd.ArgsLenAtDash()
 	if dash < 0 {
 		return &ExitError{Code: 2, Err: errors.New("run: '--' separator before the command is required")}
@@ -53,27 +57,25 @@ func runE(cmd *cobra.Command, args []string, overrides *gateFlagValues) error {
 		return err
 	}
 
-	// Verify first; on match, skip execution entirely.
-	m, loadErr := state.Load(c.markerPath)
-	switch {
-	case loadErr == nil:
-		digest, hashErr := c.hasher.Hash(c.repo)
-		if hashErr != nil {
-			return &ExitError{Code: 2, Err: hashErr}
+	label, matched, m, stateErr := explainStateForVerify(c)
+	if stateErr != nil {
+		return &ExitError{Code: 2, Err: stateErr}
+	}
+	if matched {
+		ttl, ttlErr := checkTTL(c.gate, m)
+		if ttlErr != nil {
+			return &ExitError{Code: 2, Err: ttlErr}
 		}
-		if m.HashType == c.hasher.Type() && m.Digest == digest {
-			ttl, ttlErr := checkTTL(c.gate, m)
-			if ttlErr != nil {
-				return &ExitError{Code: 2, Err: ttlErr}
-			}
-			if !ttl.expired {
-				return nil
-			}
+		if ttl.expired {
+			label = stateMismatch
+			matched = false
 		}
-	case errors.Is(loadErr, state.ErrNotFound):
-		// fall through to execution
-	default:
-		return &ExitError{Code: 2, Err: loadErr}
+	}
+	if emitErr := emitExplain(c, explain, cmd.OutOrStdout(), cmd.ErrOrStderr(), label); emitErr != nil {
+		return &ExitError{Code: 2, Err: emitErr}
+	}
+	if matched {
+		return nil
 	}
 
 	code, execErr := execChild(cmdArgs)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -18,16 +18,27 @@ func newStatusCmd() *cobra.Command {
 		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
+	explain := addExplainFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := explain.validate(); err != nil {
+			return &ExitError{Code: 2, Err: err}
+		}
 		c, err := newGateCtx(resolveKey(args), overrides)
 		if err != nil {
 			return err
 		}
 		out := cmd.OutOrStdout()
+		errOut := cmd.ErrOrStderr()
 
 		m, err := state.Load(c.markerPath)
 		if err != nil {
 			if errors.Is(err, state.ErrNotFound) {
+				if emitErr := emitExplain(c, explain, out, errOut, stateNoMarker); emitErr != nil {
+					return &ExitError{Code: 2, Err: emitErr}
+				}
+				if explain != nil && explain.json {
+					return &ExitError{Code: 1}
+				}
 				fmt.Fprintf(out, "key:        %s\nstate:      no marker\n", c.key)
 				return &ExitError{Code: 1}
 			}
@@ -37,6 +48,39 @@ func newStatusCmd() *cobra.Command {
 		digest, err := c.hasher.Hash(c.repo)
 		if err != nil {
 			return &ExitError{Code: 2, Err: err}
+		}
+
+		// JSON --explain replaces the textual status block entirely so
+		// stdout stays a single object.
+		if explain != nil && explain.json {
+			label := stateMatch
+			exit := 0
+			switch {
+			case m.HashType != c.hasher.Type(), m.Digest != digest:
+				label = stateMismatch
+				exit = 1
+			}
+			if emitErr := emitExplain(c, explain, out, errOut, label); emitErr != nil {
+				return &ExitError{Code: 2, Err: emitErr}
+			}
+			if exit != 0 {
+				return &ExitError{Code: exit}
+			}
+			return nil
+		}
+
+		// Text --explain: scope listing on stderr first, then the
+		// existing status block on stdout. Recompute the label here so
+		// the stderr line agrees with the detailed stdout line.
+		if explain != nil && explain.enabled {
+			label := stateMatch
+			switch {
+			case m.HashType != c.hasher.Type(), m.Digest != digest:
+				label = stateMismatch
+			}
+			if emitErr := emitExplain(c, explain, out, errOut, label); emitErr != nil {
+				return &ExitError{Code: 2, Err: emitErr}
+			}
 		}
 
 		fmt.Fprintf(out, "key:        %s\n", c.key)

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -1,12 +1,9 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
-
-	"github.com/go-to-k/markgate/internal/state"
 )
 
 func newVerifyCmd() *cobra.Command {
@@ -17,33 +14,38 @@ func newVerifyCmd() *cobra.Command {
 		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
+	explain := addExplainFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := explain.validate(); err != nil {
+			return &ExitError{Code: 2, Err: err}
+		}
 		c, err := newGateCtx(resolveKey(args), overrides)
 		if err != nil {
 			return err
 		}
-		m, err := state.Load(c.markerPath)
+		label, matched, m, err := explainStateForVerify(c)
 		if err != nil {
-			if errors.Is(err, state.ErrNotFound) {
+			return &ExitError{Code: 2, Err: err}
+		}
+		if matched {
+			ttl, ttlErr := checkTTL(c.gate, m)
+			if ttlErr != nil {
+				return &ExitError{Code: 2, Err: ttlErr}
+			}
+			if ttl.expired {
+				if emitErr := emitExplain(c, explain, cmd.OutOrStdout(), cmd.ErrOrStderr(), stateMismatch); emitErr != nil {
+					return &ExitError{Code: 2, Err: emitErr}
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"markgate: state mismatch (expired by ttl: %s, marker is %s old)\n",
+					c.gate.TTL, formatAge(ttl.age))
 				return &ExitError{Code: 1}
 			}
-			return &ExitError{Code: 2, Err: err}
 		}
-		digest, err := c.hasher.Hash(c.repo)
-		if err != nil {
-			return &ExitError{Code: 2, Err: err}
+		if emitErr := emitExplain(c, explain, cmd.OutOrStdout(), cmd.ErrOrStderr(), label); emitErr != nil {
+			return &ExitError{Code: 2, Err: emitErr}
 		}
-		if m.HashType != c.hasher.Type() || m.Digest != digest {
-			return &ExitError{Code: 1}
-		}
-		ttl, err := checkTTL(c.gate, m)
-		if err != nil {
-			return &ExitError{Code: 2, Err: err}
-		}
-		if ttl.expired {
-			fmt.Fprintf(cmd.ErrOrStderr(),
-				"markgate: state mismatch (expired by ttl: %s, marker is %s old)\n",
-				c.gate.TTL, formatAge(ttl.age))
+		if !matched {
 			return &ExitError{Code: 1}
 		}
 		return nil

--- a/internal/hasher/files.go
+++ b/internal/hasher/files.go
@@ -45,6 +45,15 @@ func (f Files) Hash(repo *gitutil.Repo) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
+// Scope implements Hasher.
+func (f Files) Scope(repo *gitutil.Repo) ([]string, error) {
+	top, err := repo.TopLevel()
+	if err != nil {
+		return nil, err
+	}
+	return f.resolve(top)
+}
+
 // resolve returns the sorted, deduplicated, repo-relative paths that match
 // include minus exclude. Directories and matches that disappear between
 // glob and stat are filtered out.

--- a/internal/hasher/hasher.go
+++ b/internal/hasher/hasher.go
@@ -31,6 +31,11 @@ import (
 type Hasher interface {
 	Type() string
 	Hash(repo *gitutil.Repo) (string, error)
+	// Scope returns the sorted, repo-relative file list that Hash would
+	// fold into the digest, after Include/Exclude filtering. Used by
+	// --explain to surface what is in scope without requiring callers to
+	// re-derive the glob filter.
+	Scope(repo *gitutil.Repo) ([]string, error)
 }
 
 // For returns a Hasher matching the gate configuration.
@@ -67,16 +72,7 @@ func (g GitTree) Hash(repo *gitutil.Repo) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	diffs, err := repo.DiffHeadNames()
-	if err != nil {
-		return "", err
-	}
-	untracked, err := repo.UntrackedNames()
-	if err != nil {
-		return "", err
-	}
-	files := dedupSort(append(diffs, untracked...))
-	files, err = filterGlobs(files, g.Include, g.Exclude)
+	files, err := g.Scope(repo)
 	if err != nil {
 		return "", err
 	}
@@ -89,6 +85,20 @@ func (g GitTree) Hash(repo *gitutil.Repo) (string, error) {
 		}
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// Scope implements Hasher.
+func (g GitTree) Scope(repo *gitutil.Repo) ([]string, error) {
+	diffs, err := repo.DiffHeadNames()
+	if err != nil {
+		return nil, err
+	}
+	untracked, err := repo.UntrackedNames()
+	if err != nil {
+		return nil, err
+	}
+	files := dedupSort(append(diffs, untracked...))
+	return filterGlobs(files, g.Include, g.Exclude)
 }
 
 // hashEntry feeds one path into h, framed so that "F a\nbody" and


### PR DESCRIPTION
## Why

When `markgate verify` returns mismatch, users have no easy way to
see what the gate is currently tracking. Wrong `include`/`exclude`
globs, surprise files, and "why is this gate re-running" are all
common confusions. The marker stores a single SHA-256, so a real
diff against the marker isn't recoverable post-hoc — but "what is
in scope right now" is cheap and is the diagnostic users actually
need.

## What

- New `--explain` / `-e` flag on `verify`, `status`, and `run`. In
  text mode it prints the scope listing to **stderr** ahead of the
  normal output, then a `state:` line (one of `match`, `mismatch`,
  `no marker`). Stdout is left clean for hook composition.
- New `--json` modifier (only valid with `--explain`). Emits a
  single JSON object on stdout instead of the text scope listing:
  `{key, scope, hasher, state}` (snake_case fields locked, no extras).
  Calling `--json` without `--explain` is a usage error (exit 2).
- New `Scope(repo) ([]string, error)` method on the `Hasher`
  interface so `GitTree` and `Files` share their existing
  candidate-list construction with `--explain` instead of
  duplicating glob filtering.
- Exit codes are unchanged: `--explain` only adds output.
- README updates: CLI reference cross-link, a "Debugging a stale
  gate" subsection under Per-invocation overrides, and a matching
  FAQ entry. Explicitly calls out that this is the **current**
  scope, not a diff against the marker.

## Test plan

- [x] `go test ./...` (new `TestExplain_*` cluster covers
  no-marker / mismatch / match, include-only, exclude filtering,
  short-form `-e`, `--json` shape, `--json` requires `--explain`,
  status text + JSON, run-on-skip text + JSON).
- [x] `make lint` (golangci-lint clean).
- [x] Smoke-built binary against a throwaway repo: `verify -e`
  routes scope listing to stderr only; `--explain --json` emits
  one object on stdout; `--json` alone exits 2 with the documented
  error.

Closes #24
