### PR TITLE
feat: markgate config lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,11 @@ markgate status     [key]              Show marker + match status.
 markgate clear      [key]              Delete the marker (idempotent).
 markgate run        [key] -- <cmd>...  Sugar for verify + <cmd> + set.
 markgate init                          Write a starter .markgate.yml.
+markgate config lint                   Warn on dead include/exclude globs
+                                       and unknown fields in .markgate.yml.
+                                       Exit 0 clean, 1 warnings, 2 error.
+                                       --json emits an array of
+                                       {path, severity, message}.
 markgate version                       Print the version.
 markgate completion <shell>            Emit a completion script (bash / zsh / fish / powershell).
 ```

--- a/internal/cli/config_lint.go
+++ b/internal/cli/config_lint.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-to-k/markgate/internal/config"
+	"github.com/go-to-k/markgate/internal/gitutil"
+	"github.com/go-to-k/markgate/internal/hasher"
+)
+
+// lintFinding is one warning emitted by `markgate config lint`.
+type lintFinding struct {
+	Path     string `json:"path"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+// gateFields lists the YAML keys recognized inside a gate. Kept in sync
+// with config.Gate's yaml tags; the lint command treats anything else as
+// an unknown field.
+var gateFields = map[string]struct{}{
+	"hash":      {},
+	"include":   {},
+	"exclude":   {},
+	"state_dir": {},
+}
+
+// topFields lists the YAML keys recognized at the document root. Mirrors
+// config.Config's yaml tags.
+var topFields = map[string]struct{}{
+	"gates": {},
+}
+
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Inspect or check .markgate.yml",
+	}
+	cmd.AddCommand(newConfigLintCmd())
+	return cmd
+}
+
+func newConfigLintCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "lint",
+		Short: "Report dead globs and unknown fields in .markgate.yml",
+		Long: "Walks .markgate.yml and warns on:\n" +
+			"  - include/exclude globs that match zero files in the working tree\n" +
+			"  - unknown top-level or per-gate keys (typos, leftovers).\n\n" +
+			"Exit codes: 0 clean, 1 warnings, 2 parse / read error.",
+		Args: cobra.NoArgs,
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit findings as a JSON array of {path, severity, message}")
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		return runConfigLint(cmd.OutOrStdout(), jsonOut)
+	}
+	return cmd
+}
+
+func runConfigLint(out io.Writer, jsonOut bool) error {
+	repo := gitutil.New("")
+	top, err := repo.TopLevel()
+	if err != nil {
+		return &ExitError{Code: 2, Err: err}
+	}
+	path := filepath.Join(top, config.Filename)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &ExitError{Code: 2, Err: fmt.Errorf("%s not found at repo root", config.Filename)}
+		}
+		return &ExitError{Code: 2, Err: err}
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return &ExitError{Code: 2, Err: fmt.Errorf("parse %s: %w", config.Filename, err)}
+	}
+
+	var cfg config.Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return &ExitError{Code: 2, Err: fmt.Errorf("parse %s: %w", config.Filename, err)}
+	}
+
+	findings := collectFindings(top, &root, &cfg)
+	sortFindings(findings)
+
+	if jsonOut {
+		if err := emitJSON(out, findings); err != nil {
+			return &ExitError{Code: 2, Err: err}
+		}
+	} else {
+		emitText(out, findings)
+	}
+
+	if len(findings) > 0 {
+		return &ExitError{Code: 1}
+	}
+	return nil
+}
+
+// collectFindings walks the YAML tree for unknown keys and the typed
+// config for dead include/exclude globs, returning the merged warning set.
+func collectFindings(topLevel string, root *yaml.Node, cfg *config.Config) []lintFinding {
+	findings := unknownFieldFindings(root)
+	findings = append(findings, deadGlobFindings(topLevel, cfg)...)
+	return findings
+}
+
+// unknownFieldFindings reports keys that are not defined on Config or Gate.
+// Walks yaml.Node directly so messages stay user-facing
+// ("gates.legacy.legacy_field") rather than leaking Go type names that
+// yaml.v3's KnownFields error would otherwise expose.
+func unknownFieldFindings(root *yaml.Node) []lintFinding {
+	var out []lintFinding
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return out
+	}
+	docRoot := root.Content[0]
+	if docRoot.Kind != yaml.MappingNode {
+		return out
+	}
+	for i := 0; i+1 < len(docRoot.Content); i += 2 {
+		keyNode := docRoot.Content[i]
+		valNode := docRoot.Content[i+1]
+		k := keyNode.Value
+		if _, ok := topFields[k]; !ok {
+			out = append(out, lintFinding{
+				Path:     k,
+				Severity: "warning",
+				Message:  fmt.Sprintf("unknown field: %s", k),
+			})
+			continue
+		}
+		if k == "gates" && valNode.Kind == yaml.MappingNode {
+			out = append(out, unknownGateFieldFindings(valNode)...)
+		}
+	}
+	return out
+}
+
+func unknownGateFieldFindings(gates *yaml.Node) []lintFinding {
+	var out []lintFinding
+	for i := 0; i+1 < len(gates.Content); i += 2 {
+		gateName := gates.Content[i].Value
+		gateNode := gates.Content[i+1]
+		if gateNode.Kind != yaml.MappingNode {
+			continue
+		}
+		for j := 0; j+1 < len(gateNode.Content); j += 2 {
+			fieldName := gateNode.Content[j].Value
+			if _, ok := gateFields[fieldName]; ok {
+				continue
+			}
+			dotted := fmt.Sprintf("gates.%s.%s", gateName, fieldName)
+			out = append(out, lintFinding{
+				Path:     dotted,
+				Severity: "warning",
+				Message:  fmt.Sprintf("unknown field: %s", dotted),
+			})
+		}
+	}
+	return out
+}
+
+// deadGlobFindings flags include/exclude globs that match zero files in
+// the working tree. The check expands each pattern against the FS so
+// typos (`docss/**`) and patterns left over after refactors surface
+// immediately rather than waiting for someone to notice the gate has
+// stopped invalidating.
+func deadGlobFindings(topLevel string, cfg *config.Config) []lintFinding {
+	var out []lintFinding
+	names := make([]string, 0, len(cfg.Gates))
+	for name := range cfg.Gates {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		g := cfg.Gates[name]
+		for i, pat := range g.Include {
+			if dead, _ := isDeadGlob(topLevel, pat); dead {
+				path := fmt.Sprintf("gates.%s.include[%d]", name, i)
+				out = append(out, lintFinding{
+					Path:     path,
+					Severity: "warning",
+					Message:  fmt.Sprintf("%s: '%s' matches 0 files", path, pat),
+				})
+			}
+		}
+		for i, pat := range g.Exclude {
+			if dead, _ := isDeadGlob(topLevel, pat); dead {
+				path := fmt.Sprintf("gates.%s.exclude[%d]", name, i)
+				out = append(out, lintFinding{
+					Path:     path,
+					Severity: "warning",
+					Message:  fmt.Sprintf("%s: '%s' matches 0 files", path, pat),
+				})
+			}
+		}
+	}
+	return out
+}
+
+func isDeadGlob(topLevel, pat string) (bool, error) {
+	matches, err := hasher.MatchGlob(topLevel, pat)
+	if err != nil {
+		return false, err
+	}
+	return len(matches) == 0, nil
+}
+
+func sortFindings(f []lintFinding) {
+	sort.SliceStable(f, func(i, j int) bool { return f[i].Path < f[j].Path })
+}
+
+func emitText(out io.Writer, findings []lintFinding) {
+	for _, f := range findings {
+		fmt.Fprintln(out, f.Message)
+	}
+}
+
+func emitJSON(out io.Writer, findings []lintFinding) error {
+	if findings == nil {
+		findings = []lintFinding{}
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(findings)
+}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -578,6 +579,147 @@ func TestStateDir_RunCmd(t *testing.T) {
 	// Second run should skip (match on same state).
 	if code, _ := runCmd(t, "run", "check", "--state-dir", stateDir, "--", "false"); code != 0 {
 		t.Errorf("run skip: %d, want 0 (should not execute child)", code)
+	}
+}
+
+func TestConfigLint_CleanConfig(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  check:\n    hash: files\n    include:\n      - \"src/**\"\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 0 {
+		t.Errorf("clean config: code = %d, want 0; out: %q", code, out)
+	}
+	if out != "" {
+		t.Errorf("clean config: want empty stdout, got %q", out)
+	}
+}
+
+func TestConfigLint_DeadIncludeGlob(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  docs:\n    hash: files\n    include:\n      - \"README.md\"\n      - \"docss/**\"\n")
+	writeRepoFile(t, dir, "README.md", "x")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("dead include: code = %d, want 1", code)
+	}
+	if !bytes.Contains([]byte(out), []byte("gates.docs.include[1]: 'docss/**' matches 0 files")) {
+		t.Errorf("missing dead-include warning, got:\n%s", out)
+	}
+	if bytes.Contains([]byte(out), []byte("include[0]")) {
+		t.Errorf("unexpected warning on healthy glob:\n%s", out)
+	}
+}
+
+func TestConfigLint_DeadExcludeGlob(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  api:\n    hash: files\n    include:\n      - \"src/**\"\n    exclude:\n      - \"*.proto\"\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("dead exclude: code = %d, want 1", code)
+	}
+	if !bytes.Contains([]byte(out), []byte("gates.api.exclude[0]: '*.proto' matches 0 files")) {
+		t.Errorf("missing dead-exclude warning, got:\n%s", out)
+	}
+}
+
+func TestConfigLint_UnknownTopLevelField(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  check: {}\nweird_top: 1\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("unknown top: code = %d, want 1", code)
+	}
+	if !bytes.Contains([]byte(out), []byte("unknown field: weird_top")) {
+		t.Errorf("missing unknown-field warning, got:\n%s", out)
+	}
+}
+
+func TestConfigLint_UnknownGateField(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  legacy:\n    hash: git-tree\n    legacy_field: foo\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("unknown gate field: code = %d, want 1", code)
+	}
+	if !bytes.Contains([]byte(out), []byte("unknown field: gates.legacy.legacy_field")) {
+		t.Errorf("missing unknown-gate-field warning, got:\n%s", out)
+	}
+}
+
+func TestConfigLint_ParseError(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml", "gates:\n  - bad\n :::not yaml\n")
+
+	code, _ := runCmd(t, "config", "lint")
+	if code != 2 {
+		t.Errorf("parse error: code = %d, want 2", code)
+	}
+}
+
+func TestConfigLint_MissingConfig(t *testing.T) {
+	initRepo(t)
+	code, _ := runCmd(t, "config", "lint")
+	if code != 2 {
+		t.Errorf("missing config: code = %d, want 2", code)
+	}
+}
+
+func TestConfigLint_JSONOutput(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  docs:\n    hash: files\n    include:\n      - \"docss/**\"\n")
+
+	code, out := runCmd(t, "config", "lint", "--json")
+	if code != 1 {
+		t.Errorf("json dead glob: code = %d, want 1", code)
+	}
+	var findings []struct {
+		Path     string `json:"path"`
+		Severity string `json:"severity"`
+		Message  string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(out), &findings); err != nil {
+		t.Fatalf("invalid JSON: %v\nout: %s", err, out)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1; out: %s", len(findings), out)
+	}
+	if findings[0].Path != "gates.docs.include[0]" {
+		t.Errorf("path = %q, want gates.docs.include[0]", findings[0].Path)
+	}
+	if findings[0].Severity != "warning" {
+		t.Errorf("severity = %q, want warning", findings[0].Severity)
+	}
+}
+
+func TestConfigLint_JSONCleanIsEmptyArray(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  check:\n    hash: files\n    include:\n      - \"src/**\"\n")
+
+	code, out := runCmd(t, "config", "lint", "--json")
+	if code != 0 {
+		t.Errorf("clean json: code = %d, want 0", code)
+	}
+	var findings []any
+	if err := json.Unmarshal([]byte(out), &findings); err != nil {
+		t.Fatalf("invalid JSON: %v\nout: %s", err, out)
+	}
+	if len(findings) != 0 {
+		t.Errorf("clean json findings = %d, want 0", len(findings))
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,6 +59,7 @@ func newRootCmd(version string) *cobra.Command {
 		newClearCmd(),
 		newRunCmd(),
 		newInitCmd(),
+		newConfigCmd(),
 		newVersionCmd(),
 		newCompletionCmd(),
 	)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -40,6 +41,26 @@ type Gate struct {
 	// the --state-dir flag). Committing an absolute path is an anti-pattern
 	// because it won't exist on other machines; prefer a relative path.
 	StateDir string `yaml:"state_dir,omitempty"`
+}
+
+// LoadStrict is like Load but rejects unknown YAML fields, surfacing typos
+// or leftover keys via the returned error. Default Load stays forgiving so
+// older binaries can read configs that pick up new keys later. A missing
+// file is an error here: strict callers want explicit feedback, not the
+// silent empty-config default Load returns.
+func LoadStrict(topLevel string) (*Config, error) {
+	path := filepath.Join(topLevel, Filename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	var c Config
+	if err := dec.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", Filename, err)
+	}
+	return &c, nil
 }
 
 // Load reads topLevel/.markgate.yml. A missing file yields an empty

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,6 +89,36 @@ func TestLoad_StateDirPreserved(t *testing.T) {
 	}
 }
 
+func TestLoadStrict_RejectsUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "gates:\n  legacy:\n    hash: git-tree\n    legacy_field: foo\n")
+	if _, err := LoadStrict(dir); err == nil {
+		t.Error("want error for unknown gate field under strict load")
+	}
+	// Default Load is forgiving — same input must parse without error.
+	if _, err := Load(dir); err != nil {
+		t.Errorf("Load should ignore unknown fields, got: %v", err)
+	}
+}
+
+func TestLoadStrict_MissingIsError(t *testing.T) {
+	if _, err := LoadStrict(t.TempDir()); err == nil {
+		t.Error("want error when config is missing under strict load")
+	}
+}
+
+func TestLoadStrict_AcceptsValid(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "gates:\n  check:\n    hash: git-tree\n    state_dir: .mg\n")
+	c, err := LoadStrict(dir)
+	if err != nil {
+		t.Fatalf("strict load on valid config: %v", err)
+	}
+	if g := c.Gate("check"); g.StateDir != ".mg" {
+		t.Errorf("StateDir = %q, want %q", g.StateDir, ".mg")
+	}
+}
+
 func TestGate_DefaultForMissingKey(t *testing.T) {
 	dir := t.TempDir()
 	writeConfig(t, dir, "gates:\n  pre-commit:\n    hash: git-tree\n")

--- a/internal/hasher/files.go
+++ b/internal/hasher/files.go
@@ -49,10 +49,9 @@ func (f Files) Hash(repo *gitutil.Repo) (string, error) {
 // include minus exclude. Directories and matches that disappear between
 // glob and stat are filtered out.
 func (f Files) resolve(topLevel string) ([]string, error) {
-	fsys := os.DirFS(topLevel)
 	seen := make(map[string]struct{})
 	for _, pat := range f.Include {
-		matches, err := doublestar.Glob(fsys, pat)
+		matches, err := MatchGlob(topLevel, pat)
 		if err != nil {
 			return nil, fmt.Errorf("include glob %q: %w", pat, err)
 		}
@@ -74,9 +73,25 @@ func (f Files) resolve(topLevel string) ([]string, error) {
 
 	out := make([]string, 0, len(seen))
 	for p := range seen {
-		info, err := os.Stat(filepath.Join(topLevel, p))
-		if err != nil {
-			// Path vanished between glob and stat — skip.
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// MatchGlob expands pat against topLevel as a doublestar glob and returns
+// the sorted repo-relative paths of matching regular files. Directories
+// and entries that disappear between glob and stat are filtered out.
+func MatchGlob(topLevel, pat string) ([]string, error) {
+	fsys := os.DirFS(topLevel)
+	matches, err := doublestar.Glob(fsys, pat)
+	if err != nil {
+		return nil, fmt.Errorf("invalid glob %q: %w", pat, err)
+	}
+	out := make([]string, 0, len(matches))
+	for _, p := range matches {
+		info, statErr := os.Stat(filepath.Join(topLevel, p))
+		if statErr != nil {
 			continue
 		}
 		if info.IsDir() {


### PR DESCRIPTION
## Summary

`.markgate.yml` typos used to fail silently — an `include` glob that matches
zero files (e.g. `docss/**` after a refactor) leaves the gate invalidating
nothing, and unknown top-level fields are quietly ignored by the YAML
loader. Both bugs only surface days later when someone notices the gate
has stopped going stale.

`markgate config lint` walks `.markgate.yml` and warns on:

- `include` / `exclude` globs that match zero files in the working tree.
- Unknown top-level or per-gate keys (typos, leftovers from renamed
  features).

```
$ markgate config lint
gates.docs.exclude[0]: '*.proto' matches 0 files
gates.docs.include[1]: 'docss/**' matches 0 files
unknown field: gates.legacy.legacy_field
unknown field: weird_top
```

Exit codes match the rest of the CLI: 0 clean, 1 warnings, 2 parse / read
error. `--json` emits a `{path, severity, message}` array (snake_case keys,
matching the spec lock-in for future `--json` outputs).

## What changed

- New `markgate config lint` subcommand under a `config` parent group
  (room to grow with future inspection commands).
- `config.LoadStrict()` — yaml.v3 `KnownFields(true)` decoder for
  callers that want unknown-field rejection. Default `Load()` stays
  forgiving so older binaries can read configs that pick up new keys
  later.
- `hasher.MatchGlob(top, pattern)` — exported so the lint command can
  expand a single glob against the working tree and surface dead
  patterns. The internal `Files.resolve` now reuses this helper so
  there is one glob-expansion path.
- README CLI reference entry for the new command.

`config lint` walks `yaml.Node` directly to map unknown fields back to
their dotted YAML path (`gates.legacy.legacy_field`) — `KnownFields(true)`
errors leak Go type names which are not user-facing.

Closes #26

## Test plan

- [x] `go test ./...` (full suite — 9 new integration tests + 3 strict
      loader unit tests; existing tests untouched).
- [x] `make lint` (golangci-lint clean — shadow / staticcheck / gosec
      enabled per CI).
- [x] Smoke: built binary against a fixture covering all 4 warning kinds
      (dead include, dead exclude, unknown top, unknown gate field) plus
      clean / parse-error / missing-config paths. Exit codes and message
      formatting match the issue spec.