### PR TITLE
feat: bare 'status' lists all gates with freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,8 @@ naturally:
 markgate set        [key]              Record the current state hash.
 markgate verify     [key]              Exit 0 match, 1 mismatch (incl. ttl
                                        expiry), 2 error.
-markgate status     [key]              Show marker + match status.
+markgate status     [key]              Show marker + match status (bare:
+                                       list every known gate).
 markgate clear      [key]              Delete the marker (idempotent).
 markgate run        [key] -- <cmd>...  Sugar for verify + <cmd> + set.
 markgate init                          Write a starter .markgate.yml.
@@ -652,6 +653,45 @@ markgate completion <shell>            Emit a completion script (bash / zsh / fi
 `verify`, `status`, and `run` accept `--explain` / `-e` to print the
 files currently in scope to stderr (with `--json` for a structured
 form on stdout). See [Debugging a stale gate](#debugging-a-stale-gate).
+
+### `markgate status` (bare): list all gates
+
+Without a `[key]`, `markgate status` prints one row per known gate —
+the union of `gates:` keys in `.markgate.yml` and marker files in the
+state directory:
+
+```text
+$ markgate status
+KEY            STATE        AGE        NOTE
+check          match        3m ago     -
+docs           mismatch     1h ago     digest differs
+integ-destroy  match        2d ago     -
+verify-pr      no marker    -          (configured)
+extra-gate     match        5m ago     (unconfigured)
+```
+
+Notes:
+
+- `(configured)` — gate is in `.markgate.yml` but no marker exists
+  yet (run the check or `markgate set <key>`).
+- `(unconfigured)` — a marker file is present but the gate isn't in
+  `.markgate.yml` (stale from a renamed / deleted gate, or written
+  by a script that bypassed the config).
+
+Exit code: `0` if every row matches, `1` if any row is mismatched or
+missing a marker, `2` on internal error.
+
+`--json` emits a machine-readable array (one object per row) using
+the same `state` / `note` vocabulary as the table; `markgate status
+<key> --json` emits a single object with the same shape.
+
+> **Behavior change in v0.x:** `markgate status` (no key) used to
+> operate on the `default` key. It now lists every gate. Use
+> `markgate status default` to keep the old single-key behavior.
+> `status` deviates from `set` / `verify` / `clear`'s "no-arg =
+> default key" rule on purpose: it's an introspection command (think
+> `git status`), so the bare form is the overview, not a shortcut to
+> one specific gate.
 
 ### Per-invocation overrides
 
@@ -760,6 +800,11 @@ The marker is written at `<dir>/<key>.json` (no extra `markgate/`
 subdirectory). Relative paths resolve against the repo top-level, so
 the location is stable regardless of cwd — identical on every machine
 that checks out the repo.
+
+[Bare `markgate status`](#markgate-status-bare-list-all-gates) honors
+the same precedence: it walks `<dir>/` (with the override applied)
+and lists every `<key>.json` it finds, alongside the `gates:` keys
+in `.markgate.yml`.
 
 ### Two patterns at a glance
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -739,6 +740,253 @@ func TestConfigLint_JSONCleanIsEmptyArray(t *testing.T) {
 	}
 	if len(findings) != 0 {
 		t.Errorf("clean json findings = %d, want 0", len(findings))
+	}
+}
+
+func TestStatus_Default_BackwardsCompat(t *testing.T) {
+	dir := initRepo(t)
+	if code, _ := runCmd(t, "set", "default"); code != 0 {
+		t.Fatalf("set default: %d", code)
+	}
+	code, out := runCmd(t, "status", "default")
+	if code != 0 {
+		t.Errorf("status default after set: code = %d, want 0", code)
+	}
+	if !strings.Contains(out, "state:      match") {
+		t.Errorf("missing match line:\n%s", out)
+	}
+
+	writeRepoFile(t, dir, "seed.txt", "edit")
+	code, out = runCmd(t, "status", "default")
+	if code != 1 {
+		t.Errorf("status default after edit: code = %d, want 1", code)
+	}
+	if !strings.Contains(out, "mismatch") {
+		t.Errorf("missing mismatch line:\n%s", out)
+	}
+}
+
+func TestStatusBareAll_None(t *testing.T) {
+	initRepo(t)
+	code, out := runCmd(t, "status")
+	if code != 0 {
+		t.Errorf("bare status with no gates: code = %d, want 0", code)
+	}
+	if !strings.Contains(out, "KEY") || !strings.Contains(out, "STATE") {
+		t.Errorf("expected header row, got:\n%s", out)
+	}
+	// No data rows — only the header line.
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected only header, got %d lines:\n%s", len(lines), out)
+	}
+}
+
+func TestStatusBareAll_ConfigOnly(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  alpha:\n    hash: git-tree\n  beta:\n    hash: git-tree\n")
+
+	code, out := runCmd(t, "status")
+	if code != 1 {
+		t.Errorf("config-only bare status: code = %d, want 1 (no markers)", code)
+	}
+	for _, want := range []string{"alpha", "beta", "no marker", "(configured)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestStatusBareAll_MarkerOnly(t *testing.T) {
+	initRepo(t)
+	if code, _ := runCmd(t, "set", "stray"); code != 0 {
+		t.Fatalf("set stray: %d", code)
+	}
+	code, out := runCmd(t, "status")
+	if code != 0 {
+		t.Errorf("marker-only bare status: code = %d, want 0", code)
+	}
+	if !strings.Contains(out, "stray") {
+		t.Errorf("missing stray row:\n%s", out)
+	}
+	if !strings.Contains(out, "(unconfigured)") {
+		t.Errorf("expected (unconfigured) note for marker-only row:\n%s", out)
+	}
+}
+
+func TestStatusBareAll_Both(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  configured-only:\n    hash: git-tree\n  match-me:\n    hash: git-tree\n")
+	if code, _ := runCmd(t, "set", "match-me"); code != 0 {
+		t.Fatalf("set match-me: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "stray"); code != 0 {
+		t.Fatalf("set stray: %d", code)
+	}
+
+	code, out := runCmd(t, "status")
+	if code != 1 {
+		// configured-only has no marker, so the run should fail.
+		t.Errorf("mixed bare status: code = %d, want 1", code)
+	}
+	// Sorted alphabetically: configured-only, match-me, stray.
+	idxCO := strings.Index(out, "configured-only")
+	idxMM := strings.Index(out, "match-me")
+	idxSt := strings.Index(out, "stray")
+	if idxCO < 0 || idxMM < 0 || idxSt < 0 {
+		t.Fatalf("missing rows:\n%s", out)
+	}
+	if idxCO >= idxMM || idxMM >= idxSt {
+		t.Errorf("rows not sorted alphabetically:\n%s", out)
+	}
+	if !strings.Contains(out, "(configured)") {
+		t.Errorf("expected (configured) note for configured-only:\n%s", out)
+	}
+	if !strings.Contains(out, "(unconfigured)") {
+		t.Errorf("expected (unconfigured) note for stray:\n%s", out)
+	}
+}
+
+func TestStatusBareAll_MismatchExits1(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  check:\n    hash: git-tree\n")
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	writeRepoFile(t, dir, "seed.txt", "edited")
+
+	code, out := runCmd(t, "status")
+	if code != 1 {
+		t.Errorf("mismatch bare status: code = %d, want 1", code)
+	}
+	if !strings.Contains(out, "mismatch") {
+		t.Errorf("missing mismatch row:\n%s", out)
+	}
+	if !strings.Contains(out, "digest differs") {
+		t.Errorf("expected 'digest differs' note:\n%s", out)
+	}
+}
+
+func TestStatusBareAll_AllMatchExits0(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  one:\n    hash: git-tree\n  two:\n    hash: git-tree\n")
+	if code, _ := runCmd(t, "set", "one"); code != 0 {
+		t.Fatalf("set one: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "two"); code != 0 {
+		t.Fatalf("set two: %d", code)
+	}
+
+	code, out := runCmd(t, "status")
+	if code != 0 {
+		t.Errorf("all-match bare status: code = %d, want 0", code)
+	}
+	if strings.Contains(out, "(configured)") || strings.Contains(out, "(unconfigured)") {
+		t.Errorf("matched-and-configured rows should have no note:\n%s", out)
+	}
+}
+
+func TestStatusBareAll_JSON(t *testing.T) {
+	repoDir := initRepo(t)
+	writeRepoFile(t, repoDir, ".markgate.yml",
+		"gates:\n  configured-only:\n    hash: git-tree\n  matched:\n    hash: git-tree\n")
+	if code, _ := runCmd(t, "set", "matched"); code != 0 {
+		t.Fatalf("set matched: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "stray"); code != 0 {
+		t.Fatalf("set stray: %d", code)
+	}
+
+	code, out := runCmd(t, "status", "--json")
+	if code != 1 {
+		t.Errorf("json bare status: code = %d, want 1", code)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d:\n%s", len(rows), out)
+	}
+	wantOrder := []string{"configured-only", "matched", "stray"}
+	for i, w := range wantOrder {
+		if got, _ := rows[i]["key"].(string); got != w {
+			t.Errorf("row %d key = %q, want %q", i, got, w)
+		}
+	}
+	// configured-only: no marker, configured=true, unconfigured=false.
+	if rows[0]["state"] != "no marker" || rows[0]["note"] != "(configured)" ||
+		rows[0]["configured"] != true || rows[0]["unconfigured"] != false ||
+		rows[0]["marker"] != nil {
+		t.Errorf("configured-only row malformed: %#v", rows[0])
+	}
+	// matched: state=match, note empty, marker populated.
+	if rows[1]["state"] != "match" || rows[1]["note"] != "" {
+		t.Errorf("matched row malformed: %#v", rows[1])
+	}
+	if marker, ok := rows[1]["marker"].(map[string]any); !ok {
+		t.Errorf("matched row missing marker object: %#v", rows[1])
+	} else {
+		if marker["hash_type"] != "git-tree" {
+			t.Errorf("matched marker hash_type = %v, want git-tree", marker["hash_type"])
+		}
+		if _, ok := marker["created_at"].(string); !ok {
+			t.Errorf("matched marker missing created_at: %#v", marker)
+		}
+	}
+	// stray: marker present, configured=false, unconfigured=true.
+	if rows[2]["configured"] != false || rows[2]["unconfigured"] != true ||
+		rows[2]["note"] != "(unconfigured)" {
+		t.Errorf("stray row malformed: %#v", rows[2])
+	}
+}
+
+func TestStatus_SingleKeyJSON(t *testing.T) {
+	initRepo(t)
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	code, out := runCmd(t, "status", "check", "--json")
+	if code != 0 {
+		t.Errorf("single-key json: code = %d, want 0", code)
+	}
+	var row map[string]any
+	if err := json.Unmarshal([]byte(out), &row); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if row["key"] != "check" || row["state"] != "match" {
+		t.Errorf("malformed row: %#v", row)
+	}
+	if marker, ok := row["marker"].(map[string]any); !ok {
+		t.Errorf("missing marker object: %#v", row)
+	} else if marker["hash_type"] != "git-tree" {
+		t.Errorf("marker hash_type = %v, want git-tree", marker["hash_type"])
+	}
+}
+
+func TestStatusBareAll_StateDirOverride(t *testing.T) {
+	initRepo(t)
+	stateDir := t.TempDir()
+
+	if code, _ := runCmd(t, "set", "first", "--state-dir", stateDir); code != 0 {
+		t.Fatalf("set first: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "second", "--state-dir", stateDir); code != 0 {
+		t.Fatalf("set second: %d", code)
+	}
+
+	code, out := runCmd(t, "status", "--state-dir", stateDir)
+	if code != 0 {
+		t.Errorf("bare status with --state-dir: code = %d, want 0", code)
+	}
+	for _, want := range []string{"first", "second"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q row:\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,122 +1,444 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/go-to-k/markgate/internal/config"
+	"github.com/go-to-k/markgate/internal/gitutil"
+	"github.com/go-to-k/markgate/internal/hasher"
+	"github.com/go-to-k/markgate/internal/key"
 	"github.com/go-to-k/markgate/internal/state"
+)
+
+// Note string values are part of the cross-cutting JSON shape (locked
+// alongside #24); changing them is a breaking change for consumers
+// that branch on `note`. The state vocabulary lives in explain.go and
+// is shared across verify / status / run.
+const (
+	noteDigestDiff = "digest differs"
+	noteUnconfig   = "(unconfigured)"
+	noteConfigured = "(configured)"
 )
 
 func newStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "status [key]",
-		Short:             "Show marker information and freshness",
+		Short:             "Show marker information and freshness (bare lists every gate)",
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
 	explain := addExplainFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := explain.validate(); err != nil {
-			return &ExitError{Code: 2, Err: err}
-		}
-		c, err := newGateCtx(resolveKey(args), overrides)
-		if err != nil {
-			return err
-		}
 		out := cmd.OutOrStdout()
 		errOut := cmd.ErrOrStderr()
+		if len(args) == 0 {
+			// --explain is a single-key affordance (per-row scope listing
+			// would multiply stderr output by N gates and confuse pipes).
+			if explain != nil && explain.enabled {
+				return &ExitError{Code: 2, Err: errors.New("--explain is only valid with a single key")}
+			}
+			return statusListAll(out, overrides, explain != nil && explain.json)
+		}
+		return statusSingle(out, errOut, args[0], overrides, explain)
+	}
+	return cmd
+}
 
-		m, err := state.Load(c.markerPath)
-		if err != nil {
-			if errors.Is(err, state.ErrNotFound) {
+type statusMarkerJSON struct {
+	CreatedAt string `json:"created_at"`
+	HashType  string `json:"hash_type"`
+	Head      string `json:"head,omitempty"`
+}
+
+type statusRowJSON struct {
+	Key          string            `json:"key"`
+	State        string            `json:"state"`
+	Marker       *statusMarkerJSON `json:"marker"`
+	Configured   bool              `json:"configured"`
+	Unconfigured bool              `json:"unconfigured"`
+	Note         string            `json:"note"`
+}
+
+type statusRow struct {
+	key          string
+	state        string
+	marker       *state.Marker
+	configured   bool
+	unconfigured bool
+	note         string
+	now          time.Time
+}
+
+func (r statusRow) toJSON() statusRowJSON {
+	row := statusRowJSON{
+		Key:          r.key,
+		State:        r.state,
+		Configured:   r.configured,
+		Unconfigured: r.unconfigured,
+		Note:         r.note,
+	}
+	if r.marker != nil {
+		row.Marker = &statusMarkerJSON{
+			CreatedAt: r.marker.CreatedAt.UTC().Format(time.RFC3339),
+			HashType:  r.marker.HashType,
+			Head:      r.marker.Head,
+		}
+	}
+	return row
+}
+
+func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, explain *explainFlags) error {
+	c, err := newGateCtx(k, overrides)
+	if err != nil {
+		return err
+	}
+
+	jsonOnly := explain != nil && explain.json && !explain.enabled
+
+	m, loadErr := state.Load(c.markerPath)
+	if loadErr != nil {
+		if errors.Is(loadErr, state.ErrNotFound) {
+			if explain != nil && explain.enabled {
 				if emitErr := emitExplain(c, explain, out, errOut, stateNoMarker); emitErr != nil {
 					return &ExitError{Code: 2, Err: emitErr}
 				}
-				if explain != nil && explain.json {
+				if explain.json {
 					return &ExitError{Code: 1}
 				}
 				fmt.Fprintf(out, "key:        %s\nstate:      no marker\n", c.key)
 				return &ExitError{Code: 1}
 			}
-			return &ExitError{Code: 2, Err: err}
-		}
-
-		digest, err := c.hasher.Hash(c.repo)
-		if err != nil {
-			return &ExitError{Code: 2, Err: err}
-		}
-
-		// JSON --explain replaces the textual status block entirely so
-		// stdout stays a single object.
-		if explain != nil && explain.json {
-			label := stateMatch
-			exit := 0
-			switch {
-			case m.HashType != c.hasher.Type(), m.Digest != digest:
-				label = stateMismatch
-				exit = 1
+			if jsonOnly {
+				row := statusRow{
+					key:          c.key,
+					state:        stateNoMarker,
+					configured:   true,
+					unconfigured: false,
+					note:         noteConfigured,
+				}
+				if writeErr := writeJSON(out, row.toJSON()); writeErr != nil {
+					return &ExitError{Code: 2, Err: writeErr}
+				}
+				return &ExitError{Code: 1}
 			}
-			if emitErr := emitExplain(c, explain, out, errOut, label); emitErr != nil {
-				return &ExitError{Code: 2, Err: emitErr}
-			}
-			if exit != 0 {
-				return &ExitError{Code: exit}
-			}
-			return nil
-		}
-
-		// Text --explain: scope listing on stderr first, then the
-		// existing status block on stdout. Recompute the label here so
-		// the stderr line agrees with the detailed stdout line.
-		if explain != nil && explain.enabled {
-			label := stateMatch
-			switch {
-			case m.HashType != c.hasher.Type(), m.Digest != digest:
-				label = stateMismatch
-			}
-			if emitErr := emitExplain(c, explain, out, errOut, label); emitErr != nil {
-				return &ExitError{Code: 2, Err: emitErr}
-			}
-		}
-
-		fmt.Fprintf(out, "key:        %s\n", c.key)
-		fmt.Fprintf(out, "hash type:  %s\n", m.HashType)
-		fmt.Fprintf(out, "created:    %s\n", m.CreatedAt.Format(time.RFC3339))
-		if m.Head != "" {
-			fmt.Fprintf(out, "head:       %s\n", m.Head)
-		}
-		if c.gate.TTL != "" {
-			fmt.Fprintf(out, "ttl:        %s\n", c.gate.TTL)
-		}
-
-		switch {
-		case m.HashType != c.hasher.Type():
-			fmt.Fprintf(out, "state:      mismatch (hash type changed: %s -> %s)\n", m.HashType, c.hasher.Type())
-			return &ExitError{Code: 1}
-		case m.Digest != digest:
-			fmt.Fprintln(out, "state:      mismatch (digest differs)")
+			fmt.Fprintf(out, "key:        %s\nstate:      no marker\n", c.key)
 			return &ExitError{Code: 1}
 		}
+		return &ExitError{Code: 2, Err: loadErr}
+	}
 
-		ttl, err := checkTTL(c.gate, m)
-		if err != nil {
-			return &ExitError{Code: 2, Err: err}
+	digest, err := c.hasher.Hash(c.repo)
+	if err != nil {
+		return &ExitError{Code: 2, Err: err}
+	}
+
+	label := stateMatch
+	switch {
+	case m.HashType != c.hasher.Type(), m.Digest != digest:
+		label = stateMismatch
+	}
+
+	// JSON --explain replaces the textual status block entirely so
+	// stdout stays a single object.
+	if explain != nil && explain.json && explain.enabled {
+		if emitErr := emitExplain(c, explain, out, errOut, label); emitErr != nil {
+			return &ExitError{Code: 2, Err: emitErr}
 		}
-		switch {
-		case ttl.expired:
-			fmt.Fprintf(out, "state:      mismatch (expired by ttl: %s, marker is %s old)\n", c.gate.TTL, formatAge(ttl.age))
+		if label != stateMatch {
 			return &ExitError{Code: 1}
-		case ttl.configured:
-			fmt.Fprintf(out, "state:      match (expires in %s)\n", formatAge(ttl.ttl-ttl.age))
-			return nil
-		default:
-			fmt.Fprintln(out, "state:      match")
-			return nil
+		}
+		return nil
+	}
+
+	if jsonOnly {
+		row := statusRow{
+			key:          c.key,
+			marker:       m,
+			configured:   true,
+			unconfigured: false,
+		}
+		if label == stateMismatch {
+			row.state = stateMismatch
+			row.note = noteDigestDiff
+		} else {
+			row.state = stateMatch
+		}
+		if writeErr := writeJSON(out, row.toJSON()); writeErr != nil {
+			return &ExitError{Code: 2, Err: writeErr}
+		}
+		if row.state != stateMatch {
+			return &ExitError{Code: 1}
+		}
+		return nil
+	}
+
+	// Text --explain: scope listing on stderr first, then the existing
+	// status block on stdout. The label was already computed above so
+	// the stderr line agrees with the detailed stdout line.
+	if explain != nil && explain.enabled {
+		if emitErr := emitExplain(c, explain, out, errOut, label); emitErr != nil {
+			return &ExitError{Code: 2, Err: emitErr}
 		}
 	}
-	return cmd
+
+	fmt.Fprintf(out, "key:        %s\n", c.key)
+	fmt.Fprintf(out, "hash type:  %s\n", m.HashType)
+	fmt.Fprintf(out, "created:    %s\n", m.CreatedAt.Format(time.RFC3339))
+	if m.Head != "" {
+		fmt.Fprintf(out, "head:       %s\n", m.Head)
+	}
+	if c.gate.TTL != "" {
+		fmt.Fprintf(out, "ttl:        %s\n", c.gate.TTL)
+	}
+
+	switch {
+	case m.HashType != c.hasher.Type():
+		fmt.Fprintf(out, "state:      mismatch (hash type changed: %s -> %s)\n", m.HashType, c.hasher.Type())
+		return &ExitError{Code: 1}
+	case m.Digest != digest:
+		fmt.Fprintln(out, "state:      mismatch (digest differs)")
+		return &ExitError{Code: 1}
+	}
+
+	ttl, err := checkTTL(c.gate, m)
+	if err != nil {
+		return &ExitError{Code: 2, Err: err}
+	}
+	switch {
+	case ttl.expired:
+		fmt.Fprintf(out, "state:      mismatch (expired by ttl: %s, marker is %s old)\n", c.gate.TTL, formatAge(ttl.age))
+		return &ExitError{Code: 1}
+	case ttl.configured:
+		fmt.Fprintf(out, "state:      match (expires in %s)\n", formatAge(ttl.ttl-ttl.age))
+		return nil
+	default:
+		fmt.Fprintln(out, "state:      match")
+		return nil
+	}
+}
+
+func statusListAll(out io.Writer, overrides *gateFlagValues, asJSON bool) error {
+	repo := gitutil.New("")
+	top, err := repo.TopLevel()
+	if err != nil {
+		return &ExitError{Code: 2, Err: err}
+	}
+	gitDir, err := repo.GitDir()
+	if err != nil {
+		return &ExitError{Code: 2, Err: err}
+	}
+	cfg, err := config.Load(top)
+	if err != nil {
+		return &ExitError{Code: 2, Err: err}
+	}
+
+	// Use the default key's gate to anchor the state-dir resolution: we
+	// want the directory the per-key path would walk, and per-gate
+	// state_dir is settled later for each row anyway.
+	defaultGate := overrides.override(cfg.Gate(DefaultKey))
+	stateDir := resolveStateDir(overrides, defaultGate, top, gitDir)
+
+	keys, err := discoverKeys(cfg, stateDir)
+	if err != nil {
+		return &ExitError{Code: 2, Err: err}
+	}
+
+	clock := now()
+	rows := make([]statusRow, 0, len(keys))
+	configured := configuredSet(cfg)
+	for _, k := range keys {
+		_, isConfigured := configured[k]
+		gate := overrides.override(cfg.Gate(k))
+		if vErr := validateGate(gate); vErr != nil {
+			return &ExitError{Code: 2, Err: vErr}
+		}
+		h, hErr := hasher.For(gate)
+		if hErr != nil {
+			return &ExitError{Code: 2, Err: hErr}
+		}
+		markerPath := resolveMarkerPath(overrides, gate, top, gitDir, k)
+		row, bErr := buildRow(k, gate, h, repo, markerPath, isConfigured, clock)
+		if bErr != nil {
+			return &ExitError{Code: 2, Err: bErr}
+		}
+		rows = append(rows, row)
+	}
+
+	if asJSON {
+		payload := make([]statusRowJSON, 0, len(rows))
+		for _, r := range rows {
+			payload = append(payload, r.toJSON())
+		}
+		if err := writeJSON(out, payload); err != nil {
+			return &ExitError{Code: 2, Err: err}
+		}
+	} else {
+		writeListPlain(out, rows)
+	}
+
+	for _, r := range rows {
+		if r.state != stateMatch {
+			return &ExitError{Code: 1}
+		}
+	}
+	return nil
+}
+
+// discoverKeys silently skips marker files whose names don't pass key
+// validation: a stray file in the state dir must not poison the listing.
+func discoverKeys(cfg *config.Config, stateDir string) ([]string, error) {
+	seen := make(map[string]struct{})
+	if cfg != nil {
+		for k := range cfg.Gates {
+			seen[k] = struct{}{}
+		}
+	}
+	entries, err := os.ReadDir(stateDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		k := strings.TrimSuffix(name, ".json")
+		if err := key.Validate(k); err != nil {
+			continue
+		}
+		seen[k] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func configuredSet(cfg *config.Config) map[string]struct{} {
+	out := map[string]struct{}{}
+	if cfg != nil {
+		for k := range cfg.Gates {
+			out[k] = struct{}{}
+		}
+	}
+	return out
+}
+
+// buildRow skips the digest computation when no marker is present —
+// config-only keys (which dominate "fresh repo" output) shouldn't pay
+// the hash cost. TTL is folded into the note column when the gate
+// matches and a TTL is configured: "expires in 4d" while fresh,
+// "expired 1d ago" once the deadline has passed (the latter also
+// flips state to mismatch).
+func buildRow(k string, gate config.Gate, h hasher.Hasher, repo *gitutil.Repo, markerPath string, configured bool, clock time.Time) (statusRow, error) {
+	row := statusRow{
+		key:          k,
+		configured:   configured,
+		unconfigured: !configured,
+		now:          clock,
+	}
+	m, err := state.Load(markerPath)
+	if err != nil {
+		if !errors.Is(err, state.ErrNotFound) {
+			return row, err
+		}
+		row.state = stateNoMarker
+		if configured {
+			row.note = noteConfigured
+		}
+		return row, nil
+	}
+	row.marker = m
+	digest, hashErr := h.Hash(repo)
+	if hashErr != nil {
+		return row, hashErr
+	}
+	if m.HashType != h.Type() || m.Digest != digest {
+		row.state = stateMismatch
+		row.note = noteDigestDiff
+	} else {
+		row.state = stateMatch
+		if gate.TTL != "" {
+			ttl, ttlErr := checkTTL(gate, m)
+			if ttlErr != nil {
+				return row, ttlErr
+			}
+			switch {
+			case ttl.expired:
+				row.state = stateMismatch
+				row.note = fmt.Sprintf("expired %s ago", formatAge(ttl.age-ttl.ttl))
+			case ttl.configured:
+				row.note = fmt.Sprintf("expires in %s", formatAge(ttl.ttl-ttl.age))
+			}
+		}
+	}
+	if !configured {
+		// (unconfigured) wins over digest / ttl notes: a stray marker
+		// is the more actionable signal — fix the listing first.
+		row.note = noteUnconfig
+	}
+	return row, nil
+}
+
+// resolveStateDir mirrors resolveMarkerPath's precedence chain but
+// returns just the directory, key-independent. Keep these two helpers
+// in lockstep — the bare-status listing must walk the same dir the
+// per-key path writes into.
+func resolveStateDir(overrides *gateFlagValues, gate config.Gate, topLevel, gitDir string) string {
+	dir := ""
+	switch {
+	case overrides != nil && overrides.stateDir != "":
+		dir = overrides.stateDir
+	case os.Getenv(EnvStateDir) != "":
+		dir = os.Getenv(EnvStateDir)
+	case gate.StateDir != "":
+		dir = gate.StateDir
+	}
+	if dir == "" {
+		return filepath.Join(gitDir, "markgate")
+	}
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(topLevel, dir)
+	}
+	return dir
+}
+
+func writeJSON(out io.Writer, v any) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func writeListPlain(out io.Writer, rows []statusRow) {
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "KEY\tSTATE\tAGE\tNOTE")
+	for _, r := range rows {
+		age := "-"
+		if r.marker != nil {
+			age = formatAge(r.now.Sub(r.marker.CreatedAt)) + " ago"
+		}
+		note := r.note
+		if note == "" {
+			note = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", r.key, r.state, age, note)
+	}
+	_ = tw.Flush()
 }


### PR DESCRIPTION
## Summary

- Bare `markgate status` now lists every known gate (union of `gates:` keys in `.markgate.yml` and marker files in the state directory), sorted alphabetically, with state / age / note columns. `markgate status <key>` continues to operate on a single gate.
- Both forms support `--json`, emitting the cross-cutting JSON shape locked alongside #24 (`state`, `marker.created_at`, `configured`, `unconfigured`, `note`).
- Operators of multi-gate setups previously had no way to see freshness across gates without invoking `verify` against each one; the bare overview fills that gap.

## Behavior change

Bare `markgate status` previously operated on the `default` key. It now lists every gate. Use `markgate status default` to keep the old single-key behavior. README explains the rationale: `status` is introspection (think `git status`), so the bare form is the overview, not a shortcut to one specific gate.

## Exit codes

- Single-key form: unchanged (0 match, 1 mismatch / no marker, 2 error).
- Bare form: 0 if every row matches, 1 if any row is mismatched or has no marker, 2 on internal error.

## Test plan

- [x] `go test ./...`
- [x] `make lint`
- [x] Manual smoke: bare empty, bare with markers (match / mismatch), `--json`, single-key plain + JSON, `--state-dir` override.

Closes #23.
