### PR TITLE
feat: TTL on markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Per-gate fields:
 | `include` | glob list; required for `hash: files` |
 | `exclude` | glob list |
 | `state_dir` | optional override of marker storage location — see [Sharing markers](#sharing-markers-across-machines-ci--teammates) |
+| `ttl` | optional wall-clock expiry for the marker — see [Wall-clock expiry (`ttl`)](#wall-clock-expiry-ttl) |
 
 Example:
 
@@ -334,6 +335,48 @@ match `[a-z0-9][a-z0-9-]*` (kebab-case ASCII). `default` is what
 markgate set               # same as `markgate set default`
 markgate set pre-pr        # a second, independent gate
 ```
+
+### Wall-clock expiry (`ttl`)
+
+By default, a marker stays valid until something in the gate's scope
+changes. Some checks verify against **state outside the repo** that
+drifts on its own — a real-cloud destroy test that depends on AWS
+behaviour, a vulnerability database that gains new CVEs, an SDK
+that's revved upstream. For those, "nothing in the repo changed"
+isn't enough; you also want the marker to expire after a fixed
+amount of wall-clock time.
+
+`ttl:` adds that expiry, **per gate**:
+
+```yaml
+gates:
+  integ-destroy:
+    hash: git-tree
+    ttl: 7d
+```
+
+When `ttl` is set, `markgate verify` (and the verify pre-flight inside
+`markgate run`) treats the marker as a mismatch (exit 1) once
+`now - marker.created_at > ttl`, even if the digest still matches.
+`markgate set` always writes a fresh marker, so the countdown
+restarts on every successful run. Omitting `ttl` (the default)
+preserves existing behaviour exactly — markers never expire on time
+alone.
+
+**Duration syntax** is `time.ParseDuration` extended with `d` and `w`:
+
+| unit | meaning |
+| --- | --- |
+| `s` | seconds |
+| `m` | **minutes** (Go-standard, **not** months) |
+| `h` | hours |
+| `d` | days (24h) |
+| `w` | weeks (168h) |
+
+Mixed units compose: `1h30m`, `1d12h`, `2w3d`. Months (`mo`) and
+years (`y`) are intentionally **not supported** — month length is
+ambiguous (28-31 days) and year length varies with leap years, so
+neither rounds to a fixed duration. Use `d`/`w` for stable expiries.
 
 ### Hashing strategies: `git-tree` vs `files`
 
@@ -584,14 +627,15 @@ naturally:
 | exit | meaning                                                   |
 | ---- | --------------------------------------------------------- |
 | 0    | verified — state matches the marker, safe to skip         |
-| 1    | not verified — no marker, or state differs                |
+| 1    | not verified — no marker, state differs, or TTL expired   |
 | 2    | error — not in a repo, bad config, bad key, etc.          |
 
 ## CLI reference
 
 ```text
 markgate set        [key]              Record the current state hash.
-markgate verify     [key]              Exit 0 match, 1 mismatch, 2 error.
+markgate verify     [key]              Exit 0 match, 1 mismatch (incl. ttl
+                                       expiry), 2 error.
 markgate status     [key]              Show marker + match status.
 markgate clear      [key]              Delete the marker (idempotent).
 markgate run        [key] -- <cmd>...  Sugar for verify + <cmd> + set.
@@ -857,6 +901,15 @@ markers where commit-access already implies trust in the signal.
 - **Can the marker be tampered with?** Yes — it's a JSON file under
   `.git/` (or wherever `--state-dir` points). Trust whoever can write
   to that location. Signed markers are still a future consideration.
+- **My check verifies external state (cloud APIs, vuln DB, …) — how
+  do I force re-runs even when the repo is unchanged?** Add
+  [`ttl:`](#wall-clock-expiry-ttl) to the gate. The marker is treated
+  as a mismatch once it's older than the TTL, even if the digest still
+  matches.
+- **Why isn't `1mo` (months) a valid TTL?** Month length is ambiguous
+  (28-31 days) and would make `now - created_at > 1mo` non-deterministic.
+  Use `30d` or `4w` to be explicit. Same reasoning rules out `1y`.
+  (See [Wall-clock expiry](#wall-clock-expiry-ttl).)
 
 ## License
 

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -4,15 +4,22 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/go-to-k/markgate/internal/config"
+	"github.com/go-to-k/markgate/internal/duration"
 	"github.com/go-to-k/markgate/internal/gitutil"
 	"github.com/go-to-k/markgate/internal/hasher"
 	"github.com/go-to-k/markgate/internal/key"
 	"github.com/go-to-k/markgate/internal/state"
 )
+
+// now is the package's clock. Tests override it to advance time without
+// waiting; production code MUST go through this indirection rather than
+// calling time.Now directly.
+var now = time.Now
 
 // EnvStateDir overrides the directory that stores marker files.
 // Precedence: --state-dir flag > this env > gate.StateDir in
@@ -162,16 +169,88 @@ func validateGate(g config.Gate) error {
 	}
 }
 
+// ttlExpiry holds the verdict of a TTL check: when expired, age and ttl
+// describe the offence (used in --explain-style messages and status
+// output). When the gate has no TTL configured or the marker is fresh,
+// expired is false and the other fields are zero.
+type ttlExpiry struct {
+	configured bool
+	expired    bool
+	ttl        time.Duration
+	age        time.Duration
+}
+
+// checkTTL parses gate.TTL (if any) and compares it against the marker's
+// age. Returns a non-nil error only on a malformed TTL string; that error
+// path is unreachable when the marker came from a config that already
+// passed config.Load's validation, but CLI overrides bypass that path so
+// we still defend here.
+func checkTTL(gate config.Gate, m *state.Marker) (ttlExpiry, error) {
+	if gate.TTL == "" {
+		return ttlExpiry{}, nil
+	}
+	ttl, err := duration.Parse(gate.TTL)
+	if err != nil {
+		return ttlExpiry{}, err
+	}
+	age := now().Sub(m.CreatedAt)
+	return ttlExpiry{
+		configured: true,
+		expired:    age > ttl,
+		ttl:        ttl,
+		age:        age,
+	}, nil
+}
+
+// formatAge renders d in the d/h/m/s shape used in TTL messages and
+// status output (e.g. "8d3h", "4h7m", "12s"). The two largest non-zero
+// components are kept; smaller ones are dropped to stay readable.
+func formatAge(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	days := d / (24 * time.Hour)
+	d -= days * 24 * time.Hour
+	hours := d / time.Hour
+	d -= hours * time.Hour
+	mins := d / time.Minute
+	d -= mins * time.Minute
+	secs := d / time.Second
+	switch {
+	case days > 0:
+		if hours > 0 {
+			return fmt.Sprintf("%dd%dh", days, hours)
+		}
+		return fmt.Sprintf("%dd", days)
+	case hours > 0:
+		if mins > 0 {
+			return fmt.Sprintf("%dh%dm", hours, mins)
+		}
+		return fmt.Sprintf("%dh", hours)
+	case mins > 0:
+		if secs > 0 {
+			return fmt.Sprintf("%dm%ds", mins, secs)
+		}
+		return fmt.Sprintf("%dm", mins)
+	default:
+		return fmt.Sprintf("%ds", secs)
+	}
+}
+
 // newMarker computes the current digest and returns a marker ready to save.
-// HEAD is recorded only for git-tree, to aid status output.
+// HEAD is recorded only for git-tree, to aid status output. CreatedAt is
+// stamped here (via the package's now indirection) rather than left for
+// state.Save to fill in, so tests that pin the clock for TTL coverage
+// observe the pinned value.
 func newMarker(c *gateCtx) (*state.Marker, error) {
 	digest, err := c.hasher.Hash(c.repo)
 	if err != nil {
 		return nil, err
 	}
 	m := &state.Marker{
-		HashType: c.hasher.Type(),
-		Digest:   digest,
+		HashType:  c.hasher.Type(),
+		Digest:    digest,
+		CreatedAt: now().UTC(),
 	}
 	if _, ok := c.hasher.(hasher.GitTree); ok {
 		if head, err := c.repo.HeadSHA(); err == nil {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -50,6 +50,13 @@ gates:
   #   include:
   #     - "docs/**"
   #     - "README.md"
+
+  # Example: wall-clock expiry for gates that verify external state
+  # (cloud APIs, vuln DB, ...). Units: s/m/h/d/w (m is minutes, not
+  # months; mo and y are intentionally rejected).
+  # integ-destroy:
+  #   hash: git-tree
+  #   ttl: 7d
 `
 
 func newInitCmd() *cobra.Command {

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -9,7 +9,17 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 )
+
+// withClock pins the package's clock to a fixed instant for the duration
+// of t and restores the real clock when t finishes.
+func withClock(t *testing.T, instant time.Time) {
+	t.Helper()
+	prev := now
+	now = func() time.Time { return instant }
+	t.Cleanup(func() { now = prev })
+}
 
 // runCmd drives the root command with the given args and returns the exit
 // code (0 match, 1 mismatch, 2 error) plus captured stdout.
@@ -781,5 +791,108 @@ func TestCompletion_NoConfigSilent(t *testing.T) {
 	// so neither an alpha-style key nor an error string should appear.
 	if bytes.Contains([]byte(out), []byte("Error")) {
 		t.Errorf("completion errored on missing config:\n%s", out)
+	}
+}
+
+func TestTTL_ExpiredVerifyFails(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  integ-destroy:\n    hash: git-tree\n    ttl: 7d\n")
+
+	t0 := time.Now().UTC()
+	withClock(t, t0)
+	if code, _ := runCmd(t, "set", "integ-destroy"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+
+	withClock(t, t0.Add(8*24*time.Hour+3*time.Hour))
+	if code, _ := runCmd(t, "verify", "integ-destroy"); code != 1 {
+		t.Errorf("verify after ttl expiry: code = %d, want 1", code)
+	}
+}
+
+func TestTTL_FreshVerifyPasses(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  integ-destroy:\n    hash: git-tree\n    ttl: 7d\n")
+
+	t0 := time.Now().UTC()
+	withClock(t, t0)
+	if code, _ := runCmd(t, "set", "integ-destroy"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+
+	withClock(t, t0.Add(3*24*time.Hour))
+	if code, _ := runCmd(t, "verify", "integ-destroy"); code != 0 {
+		t.Errorf("verify within ttl: code = %d, want 0", code)
+	}
+}
+
+func TestTTL_SetResets(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  integ-destroy:\n    hash: git-tree\n    ttl: 7d\n")
+
+	t0 := time.Now().UTC()
+	withClock(t, t0)
+	if code, _ := runCmd(t, "set", "integ-destroy"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	// Advance past the TTL...
+	t1 := t0.Add(8 * 24 * time.Hour)
+	withClock(t, t1)
+	// ...re-set restarts the countdown.
+	if code, _ := runCmd(t, "set", "integ-destroy"); code != 0 {
+		t.Fatalf("re-set: %d", code)
+	}
+	if code, _ := runCmd(t, "verify", "integ-destroy"); code != 0 {
+		t.Errorf("verify just after re-set: code = %d, want 0", code)
+	}
+	// Still within the new TTL window.
+	withClock(t, t1.Add(6*24*time.Hour))
+	if code, _ := runCmd(t, "verify", "integ-destroy"); code != 0 {
+		t.Errorf("verify within renewed ttl: code = %d, want 0", code)
+	}
+}
+
+func TestTTL_ParseFormats(t *testing.T) {
+	for _, s := range []string{"7d", "2w", "12h", "1h30m", "1d12h"} {
+		dir := initRepo(t)
+		writeRepoFile(t, dir, ".markgate.yml",
+			"gates:\n  g:\n    hash: git-tree\n    ttl: "+s+"\n")
+		if code, _ := runCmd(t, "set", "g"); code != 0 {
+			t.Errorf("ttl=%q: set: code = %d, want 0", s, code)
+		}
+		if code, _ := runCmd(t, "verify", "g"); code != 0 {
+			t.Errorf("ttl=%q: verify: code = %d, want 0", s, code)
+		}
+	}
+}
+
+func TestTTL_RejectsMonths(t *testing.T) {
+	dir := initRepo(t)
+
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  g:\n    hash: git-tree\n    ttl: 1m\n")
+	if code, _ := runCmd(t, "set", "g"); code != 0 {
+		t.Errorf("ttl=1m (minutes, Go-standard): code = %d, want 0", code)
+	}
+
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  g:\n    hash: git-tree\n    ttl: 1mo\n")
+	if code, _ := runCmd(t, "set", "g"); code != 2 {
+		t.Errorf("ttl=1mo (months, unsupported): code = %d, want 2", code)
+	}
+}
+
+func TestTTL_MalformedRejectedAtConfigLoad(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  g:\n    hash: git-tree\n    ttl: foo\n")
+	if code, _ := runCmd(t, "set", "g"); code != 2 {
+		t.Errorf("malformed ttl: code = %d, want 2", code)
+	}
+	if code, _ := runCmd(t, "verify", "g"); code != 2 {
+		t.Errorf("malformed ttl on verify: code = %d, want 2", code)
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -62,7 +62,13 @@ func runE(cmd *cobra.Command, args []string, overrides *gateFlagValues) error {
 			return &ExitError{Code: 2, Err: hashErr}
 		}
 		if m.HashType == c.hasher.Type() && m.Digest == digest {
-			return nil
+			ttl, ttlErr := checkTTL(c.gate, m)
+			if ttlErr != nil {
+				return &ExitError{Code: 2, Err: ttlErr}
+			}
+			if !ttl.expired {
+				return nil
+			}
 		}
 	case errors.Is(loadErr, state.ErrNotFound):
 		// fall through to execution

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -45,6 +45,9 @@ func newStatusCmd() *cobra.Command {
 		if m.Head != "" {
 			fmt.Fprintf(out, "head:       %s\n", m.Head)
 		}
+		if c.gate.TTL != "" {
+			fmt.Fprintf(out, "ttl:        %s\n", c.gate.TTL)
+		}
 
 		switch {
 		case m.HashType != c.hasher.Type():
@@ -53,6 +56,19 @@ func newStatusCmd() *cobra.Command {
 		case m.Digest != digest:
 			fmt.Fprintln(out, "state:      mismatch (digest differs)")
 			return &ExitError{Code: 1}
+		}
+
+		ttl, err := checkTTL(c.gate, m)
+		if err != nil {
+			return &ExitError{Code: 2, Err: err}
+		}
+		switch {
+		case ttl.expired:
+			fmt.Fprintf(out, "state:      mismatch (expired by ttl: %s, marker is %s old)\n", c.gate.TTL, formatAge(ttl.age))
+			return &ExitError{Code: 1}
+		case ttl.configured:
+			fmt.Fprintf(out, "state:      match (expires in %s)\n", formatAge(ttl.ttl-ttl.age))
+			return nil
 		default:
 			fmt.Fprintln(out, "state:      match")
 			return nil

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -16,7 +17,7 @@ func newVerifyCmd() *cobra.Command {
 		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
-	cmd.RunE = func(_ *cobra.Command, args []string) error {
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		c, err := newGateCtx(resolveKey(args), overrides)
 		if err != nil {
 			return err
@@ -33,6 +34,16 @@ func newVerifyCmd() *cobra.Command {
 			return &ExitError{Code: 2, Err: err}
 		}
 		if m.HashType != c.hasher.Type() || m.Digest != digest {
+			return &ExitError{Code: 1}
+		}
+		ttl, err := checkTTL(c.gate, m)
+		if err != nil {
+			return &ExitError{Code: 2, Err: err}
+		}
+		if ttl.expired {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"markgate: state mismatch (expired by ttl: %s, marker is %s old)\n",
+				c.gate.TTL, formatAge(ttl.age))
 			return &ExitError{Code: 1}
 		}
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/go-to-k/markgate/internal/duration"
 	"github.com/go-to-k/markgate/internal/key"
 )
 
@@ -41,6 +42,12 @@ type Gate struct {
 	// the --state-dir flag). Committing an absolute path is an anti-pattern
 	// because it won't exist on other machines; prefer a relative path.
 	StateDir string `yaml:"state_dir,omitempty"`
+	// TTL, if non-empty, makes verify treat a marker older than this
+	// duration as a mismatch even when the digest still matches. Useful
+	// for gates that verify external state (e.g. cloud APIs) that drift
+	// independently of the repo. Format is the union of time.ParseDuration
+	// and the d/w extension (see internal/duration).
+	TTL string `yaml:"ttl,omitempty"`
 }
 
 // LoadStrict is like Load but rejects unknown YAML fields, surfacing typos
@@ -99,6 +106,11 @@ func (c *Config) validate() error {
 			}
 		default:
 			return fmt.Errorf("gates.%s: unknown hash %q (want %q or %q)", k, g.Hash, HashGitTree, HashFiles)
+		}
+		if g.TTL != "" {
+			if _, err := duration.Parse(g.TTL); err != nil {
+				return fmt.Errorf("gates.%s.ttl: %w", k, err)
+			}
 		}
 	}
 	return nil

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -1,0 +1,73 @@
+// Package duration parses TTL strings on top of time.ParseDuration with
+// added support for d (24h) and w (168h) units.
+//
+// Months and years are intentionally not supported: month length is
+// ambiguous (28-31 days) and a "year" varies with leap years, so neither
+// rounds to a fixed number of hours. Use d/w/h for stable durations.
+package duration
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+	"unicode"
+)
+
+// Parse accepts every form time.ParseDuration accepts plus d (=24h) and
+// w (=168h) units. Mixed units are allowed (e.g. "1d12h", "2w3d").
+//
+// Each segment is parsed independently and summed, so day/week segments
+// are folded to time.Duration directly; the remaining segments are passed
+// through to time.ParseDuration, which handles every other unit including
+// fractional and signed mantissas.
+func Parse(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+
+	var total time.Duration
+	i := 0
+	for i < len(s) {
+		j := i
+		if j < len(s) && (s[j] == '+' || s[j] == '-') {
+			j++
+		}
+		for j < len(s) && (unicode.IsDigit(rune(s[j])) || s[j] == '.') {
+			j++
+		}
+		if j == i || (j == i+1 && (s[i] == '+' || s[i] == '-')) {
+			return 0, fmt.Errorf("invalid duration %q: missing number before unit", s)
+		}
+		num := s[i:j]
+
+		k := j
+		for k < len(s) && unicode.IsLetter(rune(s[k])) {
+			k++
+		}
+		if k == j {
+			return 0, fmt.Errorf("invalid duration %q: missing unit after %q", s, num)
+		}
+		unit := s[j:k]
+
+		switch unit {
+		case "d", "w":
+			n, err := strconv.ParseFloat(num, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+			}
+			factor := 24 * time.Hour
+			if unit == "w" {
+				factor = 168 * time.Hour
+			}
+			total += time.Duration(n * float64(factor))
+		default:
+			d, err := time.ParseDuration(num + unit)
+			if err != nil {
+				return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+			}
+			total += d
+		}
+		i = k
+	}
+	return total, nil
+}

--- a/internal/duration/duration_test.go
+++ b/internal/duration/duration_test.go
@@ -1,0 +1,82 @@
+package duration
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParse_StandardUnits(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"90s", 90 * time.Second},
+		{"30m", 30 * time.Minute},
+		{"12h", 12 * time.Hour},
+		{"1h30m", time.Hour + 30*time.Minute},
+	}
+	for _, c := range cases {
+		got, err := Parse(c.in)
+		if err != nil {
+			t.Errorf("Parse(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("Parse(%q) = %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParse_DaysAndWeeks(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"7d", 7 * 24 * time.Hour},
+		{"2w", 2 * 168 * time.Hour},
+		{"1d12h", 24*time.Hour + 12*time.Hour},
+		{"1w1d", 168*time.Hour + 24*time.Hour},
+	}
+	for _, c := range cases {
+		got, err := Parse(c.in)
+		if err != nil {
+			t.Errorf("Parse(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("Parse(%q) = %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParse_MIsMinutesNotMonths(t *testing.T) {
+	got, err := Parse("1m")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != time.Minute {
+		t.Errorf("Parse(\"1m\") = %s, want 1m (Go-standard minutes)", got)
+	}
+}
+
+func TestParse_MonthsRejected(t *testing.T) {
+	for _, s := range []string{"1mo", "1mon", "2months", "1y", "1yr"} {
+		if _, err := Parse(s); err == nil {
+			t.Errorf("Parse(%q): expected error, got nil", s)
+		}
+	}
+}
+
+func TestParse_Empty(t *testing.T) {
+	if _, err := Parse(""); err == nil {
+		t.Error("Parse(\"\"): expected error")
+	}
+}
+
+func TestParse_Garbage(t *testing.T) {
+	for _, s := range []string{"abc", "1", "d", "1.2.3h"} {
+		if _, err := Parse(s); err == nil {
+			t.Errorf("Parse(%q): expected error, got nil", s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #29.

Adds an optional wall-clock expiry per gate (`gates.<key>.ttl`). Default off — when omitted, behaviour is identical to today.

### Why

Some gates verify against **state outside the repo** that drifts even when the repo doesn't:

- `integ-destroy` against real-AWS — AWS or SDK behaviour can change without any commit landing.
- vulnerability scans rooted on a lockfile — new CVEs land in the upstream DB independently of `package-lock.json`.

For these, "nothing in the repo changed" isn't enough; the marker also needs to expire on a schedule. `ttl` adds that without leaking to other gates and without requiring any change to existing zero-config gates.

### Behaviour

```yaml
gates:
  integ-destroy:
    hash: git-tree
    ttl: 7d
```

- `verify` (and `run`'s verify pre-flight) returns mismatch (exit 1) once `now - marker.created_at > ttl`, even when the digest still matches. A parenthetical line on stderr distinguishes it from a digest mismatch:

  ```
  markgate: state mismatch (expired by ttl: 7d, marker is 8d3h old)
  ```

  (#24's `--explain` will layer a polished version of this on top.)

- `set` is unchanged. Every successful `set` writes a fresh marker, so the TTL countdown restarts.
- `status` shows the TTL field and either `expires in <d>` (match) or the same `expired by ttl` line (mismatch).

### Duration syntax

`time.ParseDuration` plus `d` (24h) and `w` (168h):

| unit | meaning |
| --- | --- |
| `s` | seconds |
| `m` | **minutes** (Go-standard, **not** months) |
| `h` | hours |
| `d` | days |
| `w` | weeks |

Mixed units compose: `1h30m`, `1d12h`, `2w3d`.

Intentionally **not** supported:

- `mo` / months — month length is ambiguous (28-31 days), making expiry non-deterministic.
- `y` / years — leap-year drift, same reasoning.

Malformed TTLs are rejected at config load.

### Implementation notes

- New `internal/duration` package — small wrapper that parses each segment, folds `d`/`w` to hours, and delegates the rest to `time.ParseDuration`.
- `Marker.CreatedAt` already existed — no schema bump.
- Time injection: package-level `var now = time.Now` in `internal/cli` so tests advance the clock without `sleep`. Production code goes through the indirection.
- TTL check is wired in `verify` and `run`'s pre-flight; `set` and `clear` are untouched.

### Cross-cutting

- **#24 (`--explain`)**: I emit a parenthetical `(expired by ttl: ..., marker is ... old)` on stderr today; #24's PR can replace the wording with the polished `--explain`-aware version.
- **#23 (bare `status`)**: at the time of writing, `status` here is single-key only, so the per-gate NOTE column wiring isn't applicable yet. The single-key `status` does already report the TTL field and `expires in / expired by` line, which #23 can lift into its NOTE column directly.

## Test plan

- [x] `go test ./...` (added 6 new TTL tests in `internal/cli/integration_test.go` plus duration package tests covering `7d`, `2w`, `12h`, `1h30m`, `1d12h`, `1m` (minutes), `1mo` (rejected), and malformed input)
- [x] `make lint` (golangci-lint, 0 issues)
- [x] Smoke-tested the built binary end-to-end: `set` → `verify` (match within TTL) → wait → `verify` (exit 1, expiry message on stderr) → `status` (shows ttl field + expiry line) → `run` (skips fresh, re-executes after TTL).
