### PR TITLE
feat: gate dependencies (composes / requires)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ Per-gate fields:
 | `exclude` | glob list |
 | `state_dir` | optional override of marker storage location — see [Sharing markers](#sharing-markers-across-machines-ci--teammates) |
 | `ttl` | optional wall-clock expiry for the marker — see [Wall-clock expiry (`ttl`)](#wall-clock-expiry-ttl) |
+| `composes` | child gate keys whose freshness is ANDed into this one — see [Gate dependencies](#gate-dependencies-composes-vs-requires) |
+| `requires` | like `composes`, but `set` of this gate is refused unless every required child is fresh — see [Gate dependencies](#gate-dependencies-composes-vs-requires) |
 
 Example:
 
@@ -403,6 +405,74 @@ When to use which:
 Rule of thumb: start with `git-tree` (add `exclude` if needed).
 Reach for `files` only when you specifically want the "ignore
 commits that don't touch these paths" semantics.
+
+### Gate dependencies: `composes` vs `requires`
+
+A gate can declare child gates whose freshness is ANDed into its
+own. Two shapes are available:
+
+- **`composes`** (loose) — `verify` of the parent is mismatch when
+  any child (recursively) is mismatch. `set` of the parent is
+  unconditional: marking the parent doesn't care whether children
+  are fresh.
+- **`requires`** (strict) — same `verify` propagation, *and* `set`
+  of the parent is refused (exit 2) unless every required child is
+  fresh. The error names the offending child.
+
+A gate may use one keyword but not both (config load error). Cycles
+and references to undeclared gates are also load errors.
+
+```yaml
+gates:
+  # composes: parent fails verify if any composed child is stale,
+  # but `markgate set verify-pr` is always allowed.
+  verify-pr:
+    composes: [check, docs]
+
+  # requires: same propagation plus `markgate set deploy` is refused
+  # if `migration` is stale.
+  deploy:
+    requires: [migration]
+
+  check:
+    hash: files
+    include: ["src/**", "tests/**"]
+  docs:
+    hash: files
+    include: ["docs/**", "README.md"]
+  migration:
+    hash: files
+    include: ["db/migrations/**"]
+```
+
+#### Parent's own scope
+
+If the parent declares its own `include:`, the parent's digest is
+computed and ANDed with children — both must match. If the parent
+omits `include:` (and only has `composes`/`requires`), there is *no*
+own scope: the parent's freshness is purely the AND of its
+children. This is the right default — without it, a parent gate
+without `include:` would inherit the `git-tree` default and become
+almost always stale.
+
+A `markgate set <parent>` on a deps-only gate still records a
+marker, so `markgate clear <parent>` keeps working as the user
+expects.
+
+#### Which one should I use?
+
+- Reach for **`composes`** when the parent is a *summary* gate that
+  records "all the pieces I care about are currently fresh." Useful
+  for `verify-pr` shaped gates that combine independent checks; you
+  set each child gate as that check finishes, and the parent's
+  verdict tracks them automatically.
+- Reach for **`requires`** when the parent represents an action
+  that *must not happen* unless the children are demonstrably
+  fresh. Deploy after a passed migration, image push after a passed
+  vuln scan, release tag after a passed e2e suite.
+- If unsure, start with `composes`. It's the looser of the two and
+  doesn't change `set` semantics; you can promote to `requires`
+  once you know you want `set` to refuse.
 
 ## Use cases
 
@@ -1015,6 +1085,15 @@ markers where commit-access already implies trust in the signal.
   single hash, so "which files changed since `set`" can't be
   reconstructed. See
   [Debugging a stale gate](#debugging-a-stale-gate).
+- **When should I use `composes` vs `requires`?** Use `composes`
+  when the parent is a *summary* gate ("all the pieces I care about
+  are currently fresh") — `set` of the parent is allowed regardless
+  of child state, but `verify` propagates. Use `requires` when the
+  parent represents an action that must not happen unless every
+  child is demonstrably fresh (deploy after migration, image push
+  after vuln scan): `set` is refused with exit 2 if a required
+  child is stale. See
+  [Gate dependencies](#gate-dependencies-composes-vs-requires).
 
 ## License
 

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -7,8 +7,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-
-	"github.com/go-to-k/markgate/internal/state"
 )
 
 // State labels for the --explain output. Match exactly across text and
@@ -66,7 +64,7 @@ type explainPayload struct {
 //
 // markerState is one of stateMatch / stateMismatch / stateNoMarker and
 // reflects what verify would return for the same context. Callers that
-// already loaded the marker pass the result of explainStateForVerify.
+// already loaded the marker pass the result of gateCtx.evaluate.
 func emitExplain(c *gateCtx, flags *explainFlags, out, errOut io.Writer, markerState string) error {
 	if flags == nil || !flags.enabled {
 		return nil
@@ -99,27 +97,4 @@ func emitExplain(c *gateCtx, flags *explainFlags, out, errOut io.Writer, markerS
 	}
 	fmt.Fprintf(errOut, "state: %s\n", markerState)
 	return nil
-}
-
-// explainStateForVerify computes the state label that --explain should
-// report for c, using the same rules as `verify`: missing marker yields
-// "no marker"; a hash-type or digest mismatch yields "mismatch";
-// otherwise "match". The boolean tracks whether the marker matched, so
-// `run` can decide whether to skip the child without re-loading.
-func explainStateForVerify(c *gateCtx) (label string, matched bool, marker *state.Marker, err error) {
-	m, loadErr := state.Load(c.markerPath)
-	if loadErr != nil {
-		if errors.Is(loadErr, state.ErrNotFound) {
-			return stateNoMarker, false, nil, nil
-		}
-		return "", false, nil, loadErr
-	}
-	digest, hashErr := c.hasher.Hash(c.repo)
-	if hashErr != nil {
-		return "", false, nil, hashErr
-	}
-	if m.HashType != c.hasher.Type() || m.Digest != digest {
-		return stateMismatch, false, m, nil
-	}
-	return stateMatch, true, m, nil
 }

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -89,6 +90,9 @@ type gateCtx struct {
 	gate       config.Gate
 	hasher     hasher.Hasher
 	markerPath string
+	// cfg is retained so child gates referenced via composes/requires can be
+	// resolved without re-loading .markgate.yml.
+	cfg *config.Config
 }
 
 func newGateCtx(k string, overrides *gateFlagValues) (*gateCtx, error) {
@@ -124,7 +128,115 @@ func newGateCtx(k string, overrides *gateFlagValues) (*gateCtx, error) {
 		gate:       gate,
 		hasher:     h,
 		markerPath: resolveMarkerPath(overrides, gate, top, gitDir, k),
+		cfg:        cfg,
 	}, nil
+}
+
+// child builds a gateCtx for a child gate referenced via composes/requires.
+// Per-invocation overrides do NOT propagate to children — each child is
+// resolved purely from .markgate.yml so its scope is what its own entry
+// declares. State-dir override flags are also intentionally dropped: the
+// child's storage location follows the child's own state_dir (or default).
+func (c *gateCtx) child(k string) (*gateCtx, error) {
+	if err := key.Validate(k); err != nil {
+		return nil, err
+	}
+	gate := c.cfg.Gate(k)
+	if vErr := validateGate(gate); vErr != nil {
+		return nil, vErr
+	}
+	h, err := hasher.For(gate)
+	if err != nil {
+		return nil, err
+	}
+	return &gateCtx{
+		key:        k,
+		repo:       c.repo,
+		topLevel:   c.topLevel,
+		gitDir:     c.gitDir,
+		gate:       gate,
+		hasher:     h,
+		markerPath: resolveMarkerPath(nil, gate, c.topLevel, c.gitDir, k),
+		cfg:        c.cfg,
+	}, nil
+}
+
+// evalResult is what evaluate returns to callers (verify, status, run).
+// Reason is populated when matched is false so callers can render context.
+// childKey, when set, names the first descendant whose mismatch caused this
+// gate to fail — useful for #24's --explain output and for set-time
+// requires-enforcement messaging.
+type evalResult struct {
+	matched  bool
+	reason   string
+	childKey string
+}
+
+// evaluate computes the recursive freshness verdict for c. It loads the
+// marker, optionally compares the own-scope digest, and ANDs in every
+// composes/requires child. Cycles are impossible here because config
+// validation rejects them.
+func (c *gateCtx) evaluate() (evalResult, error) {
+	if c.gate.HasOwnScope() {
+		m, err := state.Load(c.markerPath)
+		if err != nil {
+			if errors.Is(err, state.ErrNotFound) {
+				return evalResult{matched: false, reason: "no marker"}, nil
+			}
+			return evalResult{}, err
+		}
+		digest, err := c.hasher.Hash(c.repo)
+		if err != nil {
+			return evalResult{}, err
+		}
+		if m.HashType != c.hasher.Type() || m.Digest != digest {
+			return evalResult{matched: false, reason: "own digest mismatch"}, nil
+		}
+	} else {
+		// Deps-only gates still need an explicit set to count as fresh: a
+		// brand-new gate with no marker must not pass on first verify just
+		// because all its children happen to be fresh.
+		if _, err := state.Load(c.markerPath); err != nil {
+			if errors.Is(err, state.ErrNotFound) {
+				return evalResult{matched: false, reason: "no marker"}, nil
+			}
+			return evalResult{}, err
+		}
+	}
+	for _, childKey := range c.gate.Children() {
+		cc, err := c.child(childKey)
+		if err != nil {
+			return evalResult{}, err
+		}
+		res, err := cc.evaluate()
+		if err != nil {
+			return evalResult{}, err
+		}
+		if !res.matched {
+			return evalResult{matched: false, reason: "child " + childKey + " is stale", childKey: childKey}, nil
+		}
+	}
+	return evalResult{matched: true}, nil
+}
+
+// staleRequiredChild returns the key of the first direct requires child
+// whose recursive evaluate is mismatch — for set-time enforcement.
+// Returns "" when every required child is fresh.
+func (c *gateCtx) staleRequiredChild() (string, error) {
+	for _, k := range c.gate.Requires {
+		cc, err := c.child(k)
+		if err != nil {
+			return "", err
+		}
+		res, err := cc.evaluate()
+		if err != nil {
+			return "", err
+		}
+		if !res.matched {
+			return k, nil
+		}
+	}
+	return "", nil
 }
 
 // resolveMarkerPath picks the marker file location based on precedence:
@@ -241,8 +353,13 @@ func formatAge(d time.Duration) string {
 // HEAD is recorded only for git-tree, to aid status output. CreatedAt is
 // stamped here (via the package's now indirection) rather than left for
 // state.Save to fill in, so tests that pin the clock for TTL coverage
-// observe the pinned value.
+// observe the pinned value. Deps-only gates (no own scope) get a sentinel
+// marker so their freshness is purely a function of children but `set`
+// still leaves a record that an explicit `markgate set <key>` happened.
 func newMarker(c *gateCtx) (*state.Marker, error) {
+	if !c.gate.HasOwnScope() {
+		return &state.Marker{HashType: hashTypeDepsOnly}, nil
+	}
 	digest, err := c.hasher.Hash(c.repo)
 	if err != nil {
 		return nil, err
@@ -259,3 +376,8 @@ func newMarker(c *gateCtx) (*state.Marker, error) {
 	}
 	return m, nil
 }
+
+// hashTypeDepsOnly is the sentinel HashType written for gates that have
+// composes/requires but no include of their own. The digest field stays
+// empty: there is nothing to hash. Status output recognises this value.
+const hashTypeDepsOnly = "deps-only"

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -990,6 +990,227 @@ func TestStatusBareAll_StateDirOverride(t *testing.T) {
 	}
 }
 
+// composesConfig is the YAML body for a parent gate using composes:
+// parent depends on src/ and docs/, each with its own files-hash include.
+const composesConfig = `gates:
+  parent:
+    composes: [src, docs]
+  src:
+    hash: files
+    include:
+      - "src/**"
+  docs:
+    hash: files
+    include:
+      - "docs/**"
+`
+
+// requiresConfig mirrors composesConfig but with requires semantics.
+const requiresConfig = `gates:
+  parent:
+    requires: [src, docs]
+  src:
+    hash: files
+    include:
+      - "src/**"
+  docs:
+    hash: files
+    include:
+      - "docs/**"
+`
+
+func TestComposes_VerifyTimePropagation(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.ts", "a")
+	writeRepoFile(t, dir, "docs/x.md", "x")
+	writeRepoFile(t, dir, ".markgate.yml", composesConfig)
+
+	if code, _ := runCmd(t, "set", "src"); code != 0 {
+		t.Fatalf("set src: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "docs"); code != 0 {
+		t.Fatalf("set docs: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "parent"); code != 0 {
+		t.Fatalf("set parent: %d", code)
+	}
+	if code, _ := runCmd(t, "verify", "parent"); code != 0 {
+		t.Errorf("verify parent (all fresh): %d, want 0", code)
+	}
+
+	// Mutate one child's scope: parent must now mismatch.
+	writeRepoFile(t, dir, "docs/x.md", "edited")
+	if code, _ := runCmd(t, "verify", "docs"); code != 1 {
+		t.Errorf("verify docs after edit: %d, want 1", code)
+	}
+	if code, _ := runCmd(t, "verify", "parent"); code != 1 {
+		t.Errorf("verify parent (composed child stale): %d, want 1", code)
+	}
+}
+
+func TestComposes_SetUnchecked(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.ts", "a")
+	writeRepoFile(t, dir, "docs/x.md", "x")
+	writeRepoFile(t, dir, ".markgate.yml", composesConfig)
+
+	// Only src is fresh; docs has never been set. composes must NOT block
+	// `set parent`.
+	if code, _ := runCmd(t, "set", "src"); code != 0 {
+		t.Fatalf("set src: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "parent"); code != 0 {
+		t.Errorf("set parent (composes is loose): %d, want 0", code)
+	}
+}
+
+func TestRequires_SetTimeEnforcement(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.ts", "a")
+	writeRepoFile(t, dir, "docs/x.md", "x")
+	writeRepoFile(t, dir, ".markgate.yml", requiresConfig)
+
+	// docs has no marker yet; set parent must be refused with exit 2 and a
+	// message naming the offending child.
+	code, _ := runCmd(t, "set", "parent")
+	if code != 2 {
+		t.Fatalf("set parent (requires unmet): %d, want 2", code)
+	}
+
+	if code, _ := runCmd(t, "set", "src"); code != 0 {
+		t.Fatalf("set src: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "docs"); code != 0 {
+		t.Fatalf("set docs: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "parent"); code != 0 {
+		t.Errorf("set parent (all required fresh): %d, want 0", code)
+	}
+
+	// Make a required child stale again, then verify that `set parent` is
+	// once more refused.
+	writeRepoFile(t, dir, "src/a.ts", "edited")
+	if code, _ := runCmd(t, "set", "parent"); code != 2 {
+		t.Errorf("set parent (required child stale again): %d, want 2", code)
+	}
+}
+
+func TestRequires_VerifyTimePropagation(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.ts", "a")
+	writeRepoFile(t, dir, "docs/x.md", "x")
+	writeRepoFile(t, dir, ".markgate.yml", requiresConfig)
+
+	if code, _ := runCmd(t, "set", "src"); code != 0 {
+		t.Fatalf("set src: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "docs"); code != 0 {
+		t.Fatalf("set docs: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "parent"); code != 0 {
+		t.Fatalf("set parent: %d", code)
+	}
+	if code, _ := runCmd(t, "verify", "parent"); code != 0 {
+		t.Errorf("verify parent (all fresh): %d, want 0", code)
+	}
+
+	writeRepoFile(t, dir, "src/a.ts", "edited")
+	if code, _ := runCmd(t, "verify", "parent"); code != 1 {
+		t.Errorf("verify parent (required child stale): %d, want 1", code)
+	}
+}
+
+func TestDependency_Cycle(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  a:\n    composes: [b]\n  b:\n    composes: [a]\n")
+	if code, _ := runCmd(t, "verify", "a"); code != 2 {
+		t.Errorf("cycle should produce config load error: %d, want 2", code)
+	}
+}
+
+func TestDependency_MissingChild(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  parent:\n    composes: [ghost]\n")
+	if code, _ := runCmd(t, "verify", "parent"); code != 2 {
+		t.Errorf("missing child should produce config load error: %d, want 2", code)
+	}
+}
+
+func TestDependency_BothFieldsSet(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  child:\n    hash: git-tree\n  parent:\n    composes: [child]\n    requires: [child]\n")
+	if code, _ := runCmd(t, "verify", "parent"); code != 2 {
+		t.Errorf("composes+requires should produce config load error: %d, want 2", code)
+	}
+}
+
+func TestParentScope_None(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.ts", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  parent:\n    composes: [src]\n  src:\n    hash: files\n    include:\n      - \"src/**\"\n")
+
+	if code, _ := runCmd(t, "set", "src"); code != 0 {
+		t.Fatalf("set src: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "parent"); code != 0 {
+		t.Fatalf("set parent (deps-only): %d", code)
+	}
+
+	// Out-of-scope edits MUST NOT invalidate the parent (no own scope =
+	// no git-tree-default freshness).
+	writeRepoFile(t, dir, "unrelated.txt", "noise")
+	if code, _ := runCmd(t, "verify", "parent"); code != 0 {
+		t.Errorf("verify parent (deps-only, unrelated edit): %d, want 0", code)
+	}
+
+	// In-scope edit (child src) propagates.
+	writeRepoFile(t, dir, "src/a.ts", "edited")
+	if code, _ := runCmd(t, "verify", "parent"); code != 1 {
+		t.Errorf("verify parent after src edit: %d, want 1", code)
+	}
+}
+
+func TestParentScope_WithInclude(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.ts", "a")
+	writeRepoFile(t, dir, "rfc/r.md", "rfc")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n"+
+			"  parent:\n    hash: files\n    include:\n      - \"rfc/**\"\n    composes: [src]\n"+
+			"  src:\n    hash: files\n    include:\n      - \"src/**\"\n")
+
+	if code, _ := runCmd(t, "set", "src"); code != 0 {
+		t.Fatalf("set src: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "parent"); code != 0 {
+		t.Fatalf("set parent: %d", code)
+	}
+
+	if code, _ := runCmd(t, "verify", "parent"); code != 0 {
+		t.Errorf("verify parent (all fresh): %d, want 0", code)
+	}
+
+	// Own-scope edit (rfc/) → mismatch.
+	writeRepoFile(t, dir, "rfc/r.md", "edited rfc")
+	if code, _ := runCmd(t, "verify", "parent"); code != 1 {
+		t.Errorf("verify parent after own-scope edit: %d, want 1", code)
+	}
+
+	// Re-set parent (own scope), then mutate a child to confirm child
+	// propagation also fires.
+	if code, _ := runCmd(t, "set", "parent"); code != 0 {
+		t.Fatalf("re-set parent: %d", code)
+	}
+	writeRepoFile(t, dir, "src/a.ts", "edited src")
+	if code, _ := runCmd(t, "verify", "parent"); code != 1 {
+		t.Errorf("verify parent after child edit: %d, want 1", code)
+	}
+}
+
 func TestVersion_PrintsInjected(t *testing.T) {
 	root := newRootCmd("v1.2.3")
 	var stdout bytes.Buffer

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -57,24 +58,34 @@ func runE(cmd *cobra.Command, args []string, overrides *gateFlagValues, explain 
 		return err
 	}
 
-	label, matched, m, stateErr := explainStateForVerify(c)
-	if stateErr != nil {
-		return &ExitError{Code: 2, Err: stateErr}
+	res, evalErr := c.evaluate()
+	if evalErr != nil {
+		return &ExitError{Code: 2, Err: evalErr}
 	}
-	if matched {
-		ttl, ttlErr := checkTTL(c.gate, m)
-		if ttlErr != nil {
-			return &ExitError{Code: 2, Err: ttlErr}
+
+	// TTL is surfaced only at the parent level (see verify.go for the
+	// rationale; same TODO applies for chain propagation).
+	if res.matched {
+		m, loadErr := state.Load(c.markerPath)
+		if loadErr != nil && !errors.Is(loadErr, state.ErrNotFound) {
+			return &ExitError{Code: 2, Err: loadErr}
 		}
-		if ttl.expired {
-			label = stateMismatch
-			matched = false
+		if m != nil {
+			ttl, ttlErr := checkTTL(c.gate, m)
+			if ttlErr != nil {
+				return &ExitError{Code: 2, Err: ttlErr}
+			}
+			if ttl.expired {
+				res.matched = false
+			}
 		}
 	}
+
+	label := stateLabel(res)
 	if emitErr := emitExplain(c, explain, cmd.OutOrStdout(), cmd.ErrOrStderr(), label); emitErr != nil {
 		return &ExitError{Code: 2, Err: emitErr}
 	}
-	if matched {
+	if res.matched {
 		return nil
 	}
 
@@ -86,7 +97,12 @@ func runE(cmd *cobra.Command, args []string, overrides *gateFlagValues, explain 
 		return &ExitError{Code: code}
 	}
 
-	// Success: record a fresh marker.
+	if stale, sErr := c.staleRequiredChild(); sErr != nil {
+		return &ExitError{Code: 2, Err: sErr}
+	} else if stale != "" {
+		return &ExitError{Code: 2, Err: fmt.Errorf("run %s: required child %q is stale", c.key, stale)}
+	}
+
 	newM, err := newMarker(c)
 	if err != nil {
 		return &ExitError{Code: 2, Err: err}

--- a/internal/cli/set.go
+++ b/internal/cli/set.go
@@ -21,6 +21,11 @@ func newSetCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
+		if stale, sErr := c.staleRequiredChild(); sErr != nil {
+			return &ExitError{Code: 2, Err: sErr}
+		} else if stale != "" {
+			return &ExitError{Code: 2, Err: fmt.Errorf("set %s: required child %q is stale", c.key, stale)}
+		}
 		m, err := newMarker(c)
 		if err != nil {
 			return &ExitError{Code: 2, Err: err}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -139,14 +139,28 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 		return &ExitError{Code: 2, Err: loadErr}
 	}
 
-	digest, err := c.hasher.Hash(c.repo)
-	if err != nil {
-		return &ExitError{Code: 2, Err: err}
+	// ownDigestDiff is true when the marker's own-scope digest disagrees
+	// with the current state. Deps-only gates (no own scope) skip the
+	// computation entirely: their freshness is purely a function of
+	// children (see evaluate()).
+	hashTypeChanged := false
+	ownDigestDiff := false
+	if c.gate.HasOwnScope() {
+		digest, hashErr := c.hasher.Hash(c.repo)
+		if hashErr != nil {
+			return &ExitError{Code: 2, Err: hashErr}
+		}
+		hashTypeChanged = m.HashType != c.hasher.Type()
+		ownDigestDiff = m.Digest != digest
+	}
+
+	res, evalErr := c.evaluate()
+	if evalErr != nil {
+		return &ExitError{Code: 2, Err: evalErr}
 	}
 
 	label := stateMatch
-	switch {
-	case m.HashType != c.hasher.Type(), m.Digest != digest:
+	if !res.matched || hashTypeChanged || ownDigestDiff {
 		label = stateMismatch
 	}
 
@@ -169,10 +183,14 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 			configured:   true,
 			unconfigured: false,
 		}
-		if label == stateMismatch {
+		switch {
+		case hashTypeChanged, ownDigestDiff:
 			row.state = stateMismatch
 			row.note = noteDigestDiff
-		} else {
+		case !res.matched:
+			row.state = stateMismatch
+			row.note = "child " + res.childKey + " is stale"
+		default:
 			row.state = stateMatch
 		}
 		if writeErr := writeJSON(out, row.toJSON()); writeErr != nil {
@@ -204,11 +222,14 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 	}
 
 	switch {
-	case m.HashType != c.hasher.Type():
+	case hashTypeChanged:
 		fmt.Fprintf(out, "state:      mismatch (hash type changed: %s -> %s)\n", m.HashType, c.hasher.Type())
 		return &ExitError{Code: 1}
-	case m.Digest != digest:
+	case ownDigestDiff:
 		fmt.Fprintln(out, "state:      mismatch (digest differs)")
+		return &ExitError{Code: 1}
+	case !res.matched:
+		fmt.Fprintf(out, "state:      mismatch (%s)\n", res.reason)
 		return &ExitError{Code: 1}
 	}
 

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/go-to-k/markgate/internal/state"
 )
 
 func newVerifyCmd() *cobra.Command {
@@ -23,32 +26,60 @@ func newVerifyCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		label, matched, m, err := explainStateForVerify(c)
-		if err != nil {
-			return &ExitError{Code: 2, Err: err}
+
+		res, evalErr := c.evaluate()
+		if evalErr != nil {
+			return &ExitError{Code: 2, Err: evalErr}
 		}
-		if matched {
-			ttl, ttlErr := checkTTL(c.gate, m)
-			if ttlErr != nil {
-				return &ExitError{Code: 2, Err: ttlErr}
+
+		// TTL is surfaced only at the parent level: a fresh-by-digest parent
+		// can still mismatch when its own marker is older than gate.TTL.
+		// TODO(#28+#29): TTL propagation through composes chain.
+		var ttlMessage string
+		if res.matched {
+			m, loadErr := state.Load(c.markerPath)
+			if loadErr != nil && !errors.Is(loadErr, state.ErrNotFound) {
+				return &ExitError{Code: 2, Err: loadErr}
 			}
-			if ttl.expired {
-				if emitErr := emitExplain(c, explain, cmd.OutOrStdout(), cmd.ErrOrStderr(), stateMismatch); emitErr != nil {
-					return &ExitError{Code: 2, Err: emitErr}
+			if m != nil {
+				ttl, ttlErr := checkTTL(c.gate, m)
+				if ttlErr != nil {
+					return &ExitError{Code: 2, Err: ttlErr}
 				}
-				fmt.Fprintf(cmd.ErrOrStderr(),
-					"markgate: state mismatch (expired by ttl: %s, marker is %s old)\n",
-					c.gate.TTL, formatAge(ttl.age))
-				return &ExitError{Code: 1}
+				if ttl.expired {
+					res.matched = false
+					ttlMessage = fmt.Sprintf(
+						"markgate: state mismatch (expired by ttl: %s, marker is %s old)\n",
+						c.gate.TTL, formatAge(ttl.age))
+				}
 			}
 		}
+
+		label := stateLabel(res)
 		if emitErr := emitExplain(c, explain, cmd.OutOrStdout(), cmd.ErrOrStderr(), label); emitErr != nil {
 			return &ExitError{Code: 2, Err: emitErr}
 		}
-		if !matched {
+		if ttlMessage != "" {
+			fmt.Fprint(cmd.ErrOrStderr(), ttlMessage)
+		}
+		if !res.matched {
 			return &ExitError{Code: 1}
 		}
 		return nil
 	}
 	return cmd
+}
+
+// stateLabel maps an evalResult to the explain-vocabulary label.
+// Reasons starting with "no marker" are mapped to stateNoMarker so --explain
+// reports the same "no marker" string as before; everything else collapses
+// to stateMismatch / stateMatch.
+func stateLabel(res evalResult) string {
+	if res.matched {
+		return stateMatch
+	}
+	if res.reason == "no marker" {
+		return stateNoMarker
+	}
+	return stateMismatch
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -48,6 +50,38 @@ type Gate struct {
 	// independently of the repo. Format is the union of time.ParseDuration
 	// and the d/w extension (see internal/duration).
 	TTL string `yaml:"ttl,omitempty"`
+	// Composes / Requires list child gate keys this gate depends on.
+	// composes (loose): parent is mismatch if any child is mismatch, but
+	//   `set` of the parent is unconditional.
+	// requires (strict): same propagation, plus `set` of the parent is
+	//   refused if any required child is stale.
+	// A gate may set at most one of the two; using both is a load error.
+	Composes []string `yaml:"composes,omitempty"`
+	Requires []string `yaml:"requires,omitempty"`
+}
+
+// HasDeps reports whether this gate has any composes or requires children.
+func (g Gate) HasDeps() bool {
+	return len(g.Composes) > 0 || len(g.Requires) > 0
+}
+
+// HasOwnScope reports whether the gate computes its own digest. Gates with
+// dependencies but no explicit include omit the own-scope check so they
+// don't inherit the git-tree default and become almost always stale.
+func (g Gate) HasOwnScope() bool {
+	if g.HasDeps() && len(g.Include) == 0 {
+		return false
+	}
+	return true
+}
+
+// Children returns the union of composes and requires (in that order).
+// At most one is set thanks to validation, so the order is deterministic.
+func (g Gate) Children() []string {
+	out := make([]string, 0, len(g.Composes)+len(g.Requires))
+	out = append(out, g.Composes...)
+	out = append(out, g.Requires...)
+	return out
 }
 
 // LoadStrict is like Load but rejects unknown YAML fields, surfacing typos
@@ -112,8 +146,94 @@ func (c *Config) validate() error {
 				return fmt.Errorf("gates.%s.ttl: %w", k, err)
 			}
 		}
+		if len(g.Composes) > 0 && len(g.Requires) > 0 {
+			return fmt.Errorf("gates.%s: composes and requires cannot both be set", k)
+		}
+		for _, child := range g.Children() {
+			if _, ok := c.Gates[child]; !ok {
+				return fmt.Errorf("gates.%s: references undeclared gate %q", k, child)
+			}
+			if child == k {
+				return fmt.Errorf("gates.%s: cycle detected (self-reference)", k)
+			}
+		}
+	}
+	if cycle := c.findCycle(); cycle != "" {
+		return fmt.Errorf("gates: cycle detected (%s)", cycle)
 	}
 	return nil
+}
+
+// findCycle returns a human-readable cycle path (e.g. "a -> b -> a") if any
+// composes/requires edges form one, or "" when the graph is acyclic.
+// Iterative DFS keeps the stack bounded for arbitrarily deep configs.
+func (c *Config) findCycle() string {
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(c.Gates))
+	parent := make(map[string]string, len(c.Gates))
+
+	keys := make([]string, 0, len(c.Gates))
+	for k := range c.Gates {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	type frame struct {
+		node string
+		idx  int
+		kids []string
+	}
+
+	for _, root := range keys {
+		if color[root] != white {
+			continue
+		}
+		stack := []frame{{node: root, idx: 0, kids: c.Gates[root].Children()}}
+		color[root] = gray
+		for len(stack) > 0 {
+			top := &stack[len(stack)-1]
+			if top.idx >= len(top.kids) {
+				color[top.node] = black
+				stack = stack[:len(stack)-1]
+				continue
+			}
+			child := top.kids[top.idx]
+			top.idx++
+			switch color[child] {
+			case white:
+				parent[child] = top.node
+				color[child] = gray
+				stack = append(stack, frame{node: child, idx: 0, kids: c.Gates[child].Children()})
+			case gray:
+				return formatCycle(parent, top.node, child)
+			}
+		}
+	}
+	return ""
+}
+
+// formatCycle reconstructs the cycle path "child -> ... -> from -> child"
+// from the DFS parent map for use in error messages.
+func formatCycle(parent map[string]string, from, child string) string {
+	rev := []string{from}
+	for n := from; n != child; {
+		p, ok := parent[n]
+		if !ok {
+			break
+		}
+		rev = append(rev, p)
+		n = p
+	}
+	path := make([]string, 0, len(rev)+1)
+	for i := len(rev) - 1; i >= 0; i-- {
+		path = append(path, rev[i])
+	}
+	path = append(path, child)
+	return strings.Join(path, " -> ")
 }
 
 // Gate returns the configuration for k, defaulting to hash=git-tree when

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -119,6 +119,58 @@ func TestLoadStrict_AcceptsValid(t *testing.T) {
 	}
 }
 
+func TestLoad_DepsBothFields(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir,
+		"gates:\n  child:\n    hash: git-tree\n  parent:\n    composes: [child]\n    requires: [child]\n")
+	if _, err := Load(dir); err == nil {
+		t.Error("want error when composes and requires are both set")
+	}
+}
+
+func TestLoad_DepsMissingChild(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir,
+		"gates:\n  parent:\n    composes: [ghost]\n")
+	if _, err := Load(dir); err == nil {
+		t.Error("want error when child gate is undeclared")
+	}
+}
+
+func TestLoad_DepsCycle(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir,
+		"gates:\n  a:\n    composes: [b]\n  b:\n    requires: [c]\n  c:\n    composes: [a]\n")
+	if _, err := Load(dir); err == nil {
+		t.Error("want error for a -> b -> c -> a cycle")
+	}
+}
+
+func TestLoad_DepsSelfReference(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir,
+		"gates:\n  a:\n    composes: [a]\n")
+	if _, err := Load(dir); err == nil {
+		t.Error("want error for self-reference")
+	}
+}
+
+func TestLoad_DepsValid(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir,
+		"gates:\n"+
+			"  parent:\n    composes: [a, b]\n"+
+			"  a:\n    hash: git-tree\n"+
+			"  b:\n    hash: git-tree\n")
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+	if got := c.Gate("parent").Composes; len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("parent.Composes = %v, want [a b]", got)
+	}
+}
+
 func TestGate_DefaultForMissingKey(t *testing.T) {
 	dir := t.TempDir()
 	writeConfig(t, dir, "gates:\n  pre-commit:\n    hash: git-tree\n")


### PR DESCRIPTION
## Why

Gate composition currently has to be expressed in the hook layer.
`.markgate.yml` has no way to declare dependencies between gates,
so users who want a "verify-pr" parent that ANDs in independent
checks, or a "deploy" parent that *must not* run unless prereqs are
fresh, end up writing `markgate verify a && markgate verify b && ...`
in shell. That logic is invisible to `markgate status` and `run`,
and there is no way to enforce ordering at `set` time.

## Semantics

Two new YAML fields under `gates.<key>`:

```yaml
gates:
  verify-pr:
    composes: [check, docs]
  deploy:
    requires: [migration]
```

- **`composes` (loose)** — `verify` of the parent is mismatch when
  any composed child (recursively) is mismatch. `set` of the parent
  is unconditional.
- **`requires` (strict)** — same `verify` propagation. `set` of the
  parent is refused with exit 2 when any required child is stale,
  with a message naming the offender.

A gate may use one keyword but not both (config load error).

### Parent's own scope

If the parent declares `include:`, the parent's digest is computed
and ANDed with children. If `include:` is omitted, there is no own
scope — freshness is purely the AND of children. This avoids
inheriting the `git-tree` default and going almost-always-stale on
every commit. Even deps-only gates still write a sentinel marker on
`set` so `clear` / lifecycle behaviour is unchanged.

### Cycle / integrity checks

Config load rejects:

- a gate with both `composes` and `requires`
- references to undeclared gates
- self-references
- cycles across the union of both relations (iterative DFS, error
  reports the cycle path: `a -> b -> c -> a`)

## Implementation

- `config.Gate` gains `Composes`, `Requires`, plus `HasDeps`,
  `HasOwnScope`, `Children` helpers.
- New shared helper `gateCtx.evaluate` does the recursive verify-time
  propagation; `verify`, `status`, and `run`'s pre-flight all go
  through it. Returns `evalResult{matched, reason, childKey}` so the
  helper is reusable for #23 / #24 / #29 without re-doing work.
- `gateCtx.staleRequiredChild` does set-time enforcement; called
  from `set` and `run`'s post-success path.
- Marker schema unchanged on disk; deps-only parents store
  `HashType: "deps-only"` with empty digest. No `state.SchemaVersion`
  bump.

## Tests

All nine acceptance-criteria tests:

- `TestComposes_VerifyTimePropagation`
- `TestComposes_SetUnchecked`
- `TestRequires_SetTimeEnforcement`
- `TestRequires_VerifyTimePropagation`
- `TestDependency_Cycle`
- `TestDependency_MissingChild`
- `TestDependency_BothFieldsSet`
- `TestParentScope_None`
- `TestParentScope_WithInclude`

Plus config-level coverage for valid deps, self-reference, and
multi-hop cycles.

## Test plan

- [x] `go test ./...` passes
- [x] `make lint` passes (golangci-lint with shadow / staticcheck /
  gosec / etc.)
- [x] Manual smoke: composes propagation across edits, requires
  refusal at set, cycle/missing/both-fields error messages

Closes #28
