### PR TITLE
chore: add e2e CLI smoke + pre-merge hook + verify-e2e skill

### DIFF
--- a/.claude/hooks/e2e-pre-merge.sh
+++ b/.claude/hooks/e2e-pre-merge.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# PreToolUse hook: run the full E2E verification before `gh pr merge`.
+#
+# Dogfoods markgate itself: the script is wrapped in `markgate run` so
+# unchanged repos skip the run entirely (~0.1s skip), and a real run
+# only happens when the source has changed since the last successful
+# E2E pass. The marker key is `hook-e2e-pre-merge`, scoped under
+# `.git/markgate/` (default state-dir, git-ignored).
+#
+# Triggers on Bash invocations whose command starts with `gh pr merge`.
+# On test failure, prints a summary to stderr and exits 2 so Claude
+# Code surfaces it as blocking feedback. On unmatched commands or a
+# clean E2E (incl. cached skip), exits 0 silently.
+#
+# Input (stdin): the tool-use JSON from Claude Code; we need
+# .tool_input.command.
+
+set -u
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+
+case "$command" in
+  "gh pr merge"*) ;;
+  *) exit 0 ;;
+esac
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+if ! go run ./cmd/markgate run hook-e2e-pre-merge -- \
+     bash .claude/scripts/e2e.sh 1>&2; then
+  printf '\n[claude hook] E2E suite failed before `%s`. ' "$command" >&2
+  printf 'Fix the failures above (or rerun the e2e skill) before merging.\n' >&2
+  exit 2
+fi
+exit 0

--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+# End-to-end verification of the markgate CLI surface.
+#
+# Covers (a) the original primitives — set / verify / clear / run /
+# init / version, default key, --hash files + --include, --state-dir
+# override, env-var override — and (b) the six features added in the
+# 2026-05-09 batch: shell completion, config lint, TTL, --explain,
+# bare status, and gate dependencies (composes / requires).
+#
+# This script is invoked manually via the `verify-e2e` skill and
+# automatically by the e2e-pre-merge hook (which wraps it in
+# `markgate run` so unchanged repos skip the run).
+#
+# Usage:
+#   bash .claude/scripts/e2e.sh           # full run, verbose
+#   QUIET=1 bash .claude/scripts/e2e.sh   # only print summary + failures
+#
+# Exit code: 0 on all-pass, non-zero = number of failed assertions.
+
+set -u
+
+ROOT=${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}
+BUILD_DIR=$(mktemp -d /tmp/markgate-e2e-build.XXXXXX)
+SANDBOX=$(mktemp -d /tmp/markgate-e2e.XXXXXX)
+trap 'rm -rf "$BUILD_DIR" "$SANDBOX"' EXIT
+
+PASS=0
+FAIL=0
+FAIL_LOG=()
+
+cyan()  { printf "\033[36m%s\033[0m\n" "$*"; }
+green() { [ "${QUIET:-0}" = "1" ] || printf "\033[32m%s\033[0m\n" "$*"; }
+red()   { printf "\033[31m%s\033[0m\n" "$*"; }
+
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  if [[ "$got" == "$want" ]]; then
+    PASS=$((PASS+1)); green "  PASS  $label  (got=$got)"
+  else
+    FAIL=$((FAIL+1)); red "  FAIL  $label  want=$want got=$got"
+    FAIL_LOG+=("$label: want=$want got=$got")
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" hay="$3"
+  if [[ "$hay" == *"$needle"* ]]; then
+    PASS=$((PASS+1)); green "  PASS  $label  (contains: $needle)"
+  else
+    FAIL=$((FAIL+1)); red "  FAIL  $label  missing: $needle"
+    red "    hay: ${hay:0:200}"
+    FAIL_LOG+=("$label: missing $needle")
+  fi
+}
+
+assert_file() {
+  local label="$1" path="$2"
+  if [[ -f "$path" ]]; then
+    PASS=$((PASS+1)); green "  PASS  $label  (file exists)"
+  else
+    FAIL=$((FAIL+1)); red "  FAIL  $label  missing file: $path"
+    FAIL_LOG+=("$label: missing file $path")
+  fi
+}
+
+# Build once, reuse for all assertions.
+cyan "=== build ==="
+cd "$ROOT"
+if ! go build -o "$BUILD_DIR/markgate" ./cmd/markgate 2>&1; then
+  red "build failed"
+  exit 1
+fi
+MG="$BUILD_DIR/markgate"
+green "  built $MG"
+
+# Fresh repo per section; markers from one section never leak into the next.
+new_repo() {
+  cd /tmp
+  rm -rf "$SANDBOX"
+  mkdir -p "$SANDBOX"
+  cd "$SANDBOX"
+  git init -q -b main
+  git config user.email t@e
+  git config user.name T
+  mkdir -p src docs
+  echo "package main" > src/a.go
+  echo "x" > docs/README.md
+  git add . && git commit -qm init
+}
+
+# ─────────────────────────────────────────────────────────────────
+# Pre-existing CLI surface — verify the basics still work after the
+# batch of 6 features. Regression-detection net.
+# ─────────────────────────────────────────────────────────────────
+
+cyan "=== core: set / verify / clear cycle ==="
+new_repo
+
+$MG verify check >/dev/null 2>&1
+assert_eq "verify before set exit=1 (no marker)" "1" "$?"
+
+$MG set check >/dev/null 2>&1
+assert_eq "set exit=0" "0" "$?"
+
+$MG verify check >/dev/null 2>&1
+assert_eq "verify after set exit=0 (match)" "0" "$?"
+
+echo "edited" > src/a.go
+$MG verify check >/dev/null 2>&1
+assert_eq "verify after edit exit=1 (mismatch)" "1" "$?"
+
+$MG clear check >/dev/null 2>&1
+assert_eq "clear exit=0" "0" "$?"
+
+$MG verify check >/dev/null 2>&1
+assert_eq "verify after clear exit=1 (no marker)" "1" "$?"
+
+# clear is idempotent
+$MG clear check >/dev/null 2>&1
+assert_eq "clear-of-missing is idempotent exit=0" "0" "$?"
+
+cyan "=== core: default key (no positional arg) ==="
+new_repo
+
+$MG set >/dev/null 2>&1
+assert_eq "set with no key uses 'default' exit=0" "0" "$?"
+$MG verify >/dev/null 2>&1
+assert_eq "verify with no key exit=0" "0" "$?"
+out=$($MG status default 2>&1)
+assert_contains "status default produces match line" "match" "$out"
+
+cyan "=== core: --hash files + --include ==="
+new_repo
+
+# files hasher requires --include
+$MG set check --hash files >/dev/null 2>&1
+assert_eq "files hash without include exit=2" "2" "$?"
+
+$MG set check --hash files --include "src/**" >/dev/null 2>&1
+assert_eq "files hash with include exit=0" "0" "$?"
+
+$MG verify check --hash files --include "src/**" >/dev/null 2>&1
+assert_eq "files hash verify exit=0" "0" "$?"
+
+# Edit outside scope: still match
+echo "outside scope" > docs/README.md
+$MG verify check --hash files --include "src/**" >/dev/null 2>&1
+assert_eq "files hash ignores out-of-scope edits exit=0" "0" "$?"
+
+# Edit inside scope: mismatch
+echo "in scope" > src/a.go
+$MG verify check --hash files --include "src/**" >/dev/null 2>&1
+assert_eq "files hash detects in-scope edit exit=1" "1" "$?"
+
+cyan "=== core: --state-dir override ==="
+new_repo
+STATE_DIR=$(mktemp -d /tmp/markgate-e2e-state.XXXXXX)
+
+$MG set check --state-dir "$STATE_DIR" >/dev/null 2>&1
+assert_file "marker written to --state-dir" "$STATE_DIR/check.json"
+
+# Default state-dir should NOT have the marker
+[ ! -f .git/markgate/check.json ]
+assert_eq "marker NOT in default location when --state-dir set" "0" "$?"
+
+$MG verify check --state-dir "$STATE_DIR" >/dev/null 2>&1
+assert_eq "verify finds marker in --state-dir" "0" "$?"
+rm -rf "$STATE_DIR"
+
+cyan "=== core: env var MARKGATE_STATE_DIR ==="
+new_repo
+STATE_DIR=$(mktemp -d /tmp/markgate-e2e-state.XXXXXX)
+
+MARKGATE_STATE_DIR="$STATE_DIR" $MG set check >/dev/null 2>&1
+assert_file "marker written when MARKGATE_STATE_DIR set" "$STATE_DIR/check.json"
+MARKGATE_STATE_DIR="$STATE_DIR" $MG verify check >/dev/null 2>&1
+assert_eq "verify reads marker from env-var dir" "0" "$?"
+rm -rf "$STATE_DIR"
+
+cyan "=== core: precedence (flag > env > config > default) ==="
+new_repo
+FLAG_DIR=$(mktemp -d /tmp/markgate-e2e-flag.XXXXXX)
+ENV_DIR=$(mktemp -d /tmp/markgate-e2e-env.XXXXXX)
+cat > .markgate.yml <<EOF
+gates:
+  check:
+    hash: git-tree
+    state_dir: ".cfg-state"
+EOF
+
+# flag wins over env wins over config
+MARKGATE_STATE_DIR="$ENV_DIR" $MG set check --state-dir "$FLAG_DIR" >/dev/null 2>&1
+assert_file "flag wins: marker in --state-dir"  "$FLAG_DIR/check.json"
+[ ! -f "$ENV_DIR/check.json" ]
+assert_eq "flag wins: marker NOT in env dir" "0" "$?"
+[ ! -f .cfg-state/check.json ]
+assert_eq "flag wins: marker NOT in config dir" "0" "$?"
+
+# env wins over config
+MARKGATE_STATE_DIR="$ENV_DIR" $MG set check >/dev/null 2>&1
+assert_file "env wins: marker in env dir" "$ENV_DIR/check.json"
+
+# config wins over default
+$MG set check >/dev/null 2>&1
+assert_file "config wins: marker in config-relative dir" ".cfg-state/check.json"
+rm -rf "$FLAG_DIR" "$ENV_DIR"
+
+cyan "=== core: run (verify + child + set sugar) ==="
+new_repo
+
+# First call: no marker → child runs → on success set
+out=$($MG run check -- echo hello 2>&1)
+assert_eq "run no-marker exit=0" "0" "$?"
+assert_contains "run executes child on miss" "hello" "$out"
+
+# Second call: matched → child must NOT run
+out=$($MG run check -- echo SHOULD-NOT-PRINT 2>&1)
+assert_eq "run match exit=0 (skip)" "0" "$?"
+[[ "$out" != *"SHOULD-NOT-PRINT"* ]]
+assert_eq "run skips child on match" "0" "$?"
+
+# Mutation → child runs again
+echo "edit" > src/a.go
+out=$($MG run check -- echo ran-again 2>&1)
+assert_eq "run after edit exit=0" "0" "$?"
+assert_contains "run executes child on mismatch" "ran-again" "$out"
+
+# Child failure: exit propagates, marker NOT updated
+echo "edit2" > src/a.go
+$MG run check -- bash -c "exit 7" >/dev/null 2>&1
+assert_eq "run propagates child exit code" "7" "$?"
+$MG verify check >/dev/null 2>&1
+assert_eq "marker NOT advanced on child failure (verify still mismatch)" "1" "$?"
+
+cyan "=== core: init / version ==="
+new_repo
+
+$MG init >/dev/null 2>&1
+assert_eq "init exit=0" "0" "$?"
+assert_file "init writes .markgate.yml" ".markgate.yml"
+
+# init is non-clobbering
+echo "# user customization" >> .markgate.yml
+out_before=$(cat .markgate.yml)
+$MG init >/dev/null 2>&1
+out_after=$(cat .markgate.yml)
+assert_eq "init does not clobber existing config" "$out_before" "$out_after"
+
+out=$($MG version 2>&1)
+assert_contains "version prints something non-empty" "." "$out"
+
+# ─────────────────────────────────────────────────────────────────
+# Features added 2026-05-09 (new batch)
+# ─────────────────────────────────────────────────────────────────
+
+cyan "=== #25 shell completion ==="
+new_repo
+
+out=$($MG completion bash 2>/dev/null | head -3)
+assert_contains "completion bash emits script" "bash completion" "$out"
+
+$MG completion totallybogus >/dev/null 2>&1
+assert_eq "completion unknown shell exit=2" "2" "$?"
+
+cat > .markgate.yml <<'EOF'
+gates:
+  alpha: { hash: git-tree }
+  beta:  { hash: git-tree }
+EOF
+out=$($MG __complete verify "" 2>/dev/null)
+assert_contains "completion lists alpha" "alpha" "$out"
+assert_contains "completion lists beta"  "beta"  "$out"
+
+cyan "=== #26 config lint ==="
+new_repo
+
+cat > .markgate.yml <<'EOF'
+gates:
+  check:
+    hash: files
+    include: ["src/**"]
+EOF
+$MG config lint >/dev/null 2>&1
+assert_eq "lint clean exit=0" "0" "$?"
+
+cat > .markgate.yml <<'EOF'
+gates:
+  docs:
+    hash: files
+    include: ["README.md", "docss/**"]
+    legacy_field: 1
+weird_top: 1
+EOF
+echo x > README.md
+out=$($MG config lint 2>&1)
+code=$?
+assert_eq "lint dirty exit=1" "1" "$code"
+assert_contains "lint flags dead glob"      "docss/**"     "$out"
+assert_contains "lint flags unknown gate"   "legacy_field" "$out"
+assert_contains "lint flags unknown top"    "weird_top"    "$out"
+
+out=$($MG config lint --json 2>&1)
+assert_contains "lint --json has path field"     '"path"'     "$out"
+assert_contains "lint --json has severity field" '"severity"' "$out"
+
+cyan "=== #34 TTL ==="
+new_repo
+
+cat > .markgate.yml <<'EOF'
+gates:
+  integ:
+    hash: git-tree
+    ttl: 2s
+EOF
+$MG set integ >/dev/null 2>&1
+$MG verify integ >/dev/null 2>&1
+assert_eq "fresh marker verify exit=0" "0" "$?"
+
+sleep 3
+out=$($MG verify integ 2>&1)
+code=$?
+assert_eq "expired marker verify exit=1" "1" "$code"
+assert_contains "expired marker stderr message" "expired by ttl" "$out"
+
+$MG set integ >/dev/null 2>&1
+$MG verify integ >/dev/null 2>&1
+assert_eq "set resets countdown verify exit=0" "0" "$?"
+
+cat > .markgate.yml <<'EOF'
+gates:
+  bad: { ttl: 1mo }
+EOF
+$MG verify bad >/dev/null 2>&1
+assert_eq "1mo rejected at config load exit=2" "2" "$?"
+
+cyan "=== #31 verify --explain ==="
+new_repo
+
+cat > .markgate.yml <<'EOF'
+gates:
+  check:
+    hash: files
+    include: ["src/**"]
+    exclude: ["**/*_test.go"]
+EOF
+
+stderr_file=$(mktemp)
+$MG verify check -e 2>"$stderr_file" >/dev/null
+code=$?
+err=$(cat "$stderr_file")
+rm -f "$stderr_file"
+assert_eq "explain exit code unchanged on no-marker" "1" "$code"
+assert_contains "explain prints scope: header" "scope:"   "$err"
+assert_contains "explain lists src/a.go"       "src/a.go" "$err"
+assert_contains "explain prints state line"    "state:"   "$err"
+
+$MG set check >/dev/null 2>&1
+out=$($MG verify check --explain --json 2>/dev/null)
+# JSON is pretty-printed; match including the space after `:`.
+assert_contains "explain --json has key field"    '"key": "check"'    "$out"
+assert_contains "explain --json has hasher field" '"hasher": "files"' "$out"
+assert_contains "explain --json has scope array"  '"scope"'           "$out"
+assert_contains "explain --json reports match"    '"state": "match"'  "$out"
+
+cyan "=== #33 bare status ==="
+new_repo
+
+cat > .markgate.yml <<'EOF'
+gates:
+  alpha: { hash: git-tree }
+  beta:  { hash: git-tree }
+EOF
+$MG set alpha >/dev/null 2>&1
+$MG set stray >/dev/null 2>&1   # marker for an unconfigured key
+
+out=$($MG status 2>&1)
+code=$?
+assert_eq "bare status exit=1 (beta missing)" "1" "$code"
+assert_contains "bare status header KEY"        "KEY"            "$out"
+assert_contains "bare status header STATE"      "STATE"          "$out"
+assert_contains "bare status lists alpha"       "alpha"          "$out"
+assert_contains "bare status lists beta"        "beta"           "$out"
+assert_contains "bare status lists stray"       "stray"          "$out"
+assert_contains "beta has (configured) note"    "(configured)"   "$out"
+assert_contains "stray has (unconfigured) note" "(unconfigured)" "$out"
+
+out=$($MG status --json 2>/dev/null)
+assert_contains "bare status --json is array"          '['          "$out"
+assert_contains "bare status --json snake_case key"    '"key"'      "$out"
+assert_contains "bare status --json snake_case marker" '"marker"'   "$out"
+assert_contains "bare status --json hash_type"         '"hash_type"' "$out"
+
+# Single-key path still works (backwards compat).
+$MG status alpha >/dev/null 2>&1
+assert_eq "status alpha (single-key) exit=0" "0" "$?"
+
+cyan "=== #28 composes (loose) ==="
+new_repo
+
+cat > .markgate.yml <<'EOF'
+gates:
+  child-a: { hash: files, include: ["src/**"] }
+  child-b: { hash: files, include: ["docs/**"] }
+  pr:
+    composes: [child-a, child-b]
+EOF
+$MG set child-a >/dev/null 2>&1
+$MG set child-b >/dev/null 2>&1
+$MG set pr >/dev/null 2>&1
+assert_eq "composes parent set is unconditional" "0" "$?"
+
+$MG verify pr >/dev/null 2>&1
+assert_eq "composes parent verify all-match exit=0" "0" "$?"
+
+echo y >> docs/README.md
+$MG verify pr >/dev/null 2>&1
+assert_eq "composes parent verify child-stale exit=1" "1" "$?"
+
+cyan "=== #28 requires (strict) ==="
+new_repo
+
+cat > .markgate.yml <<'EOF'
+gates:
+  migration: { hash: files, include: ["src/**"] }
+  deploy:
+    requires: [migration]
+EOF
+$MG set migration >/dev/null 2>&1
+$MG set deploy >/dev/null 2>&1
+assert_eq "requires set passes when child fresh" "0" "$?"
+
+echo "package main // edit" > src/a.go
+out=$($MG set deploy 2>&1)
+code=$?
+assert_eq "requires set refuses stale-child exit=2" "2" "$code"
+assert_contains "requires error names offending child" "migration" "$out"
+
+cyan "=== #28 config-load errors ==="
+
+cat > .markgate.yml <<'EOF'
+gates:
+  a: { composes: [b] }
+  b: { composes: [a] }
+EOF
+out=$($MG verify a 2>&1)
+code=$?
+assert_eq "cycle rejected at config load exit=2" "2" "$code"
+assert_contains "cycle error message" "cycle" "$out"
+
+cat > .markgate.yml <<'EOF'
+gates:
+  a: { composes: [missing] }
+EOF
+$MG verify a >/dev/null 2>&1
+assert_eq "missing-child rejected exit=2" "2" "$?"
+
+cat > .markgate.yml <<'EOF'
+gates:
+  a:
+    composes: [b]
+    requires: [c]
+  b: {}
+  c: {}
+EOF
+$MG verify a >/dev/null 2>&1
+assert_eq "composes+requires rejected exit=2" "2" "$?"
+
+# ─────────────────────────────────────────────────────────────────
+echo
+cyan "=== summary ==="
+green "PASS: $PASS"
+if (( FAIL > 0 )); then
+  red "FAIL: $FAIL"
+  printf '\nFailures:\n'
+  for f in "${FAIL_LOG[@]}"; do red "  - $f"; done
+else
+  green "FAIL: 0"
+fi
+exit "$FAIL"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-main-branch.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/e2e-pre-merge.sh"
           }
         ]
       }

--- a/.claude/skills/verify-e2e/SKILL.md
+++ b/.claude/skills/verify-e2e/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: verify-e2e
+description: Run the markgate end-to-end CLI verification script (`.claude/scripts/e2e.sh`). It exercises the full CLI surface — original primitives (set / verify / clear / run / init / version, default key, --hash files + --include, --state-dir, env-var, precedence) plus every feature added in the 2026-05-09 batch (completion, config lint, TTL, --explain, bare status, composes / requires). Wraps the script in `markgate run` so unchanged repos skip the run. Use whenever you want to confirm "all features still work" before declaring done, opening a PR, or merging — or when your changes touch the CLI surface and you want a quick smoke before pushing.
+---
+
+# verify-e2e
+
+End-to-end smoke of the whole markgate CLI. The companion to
+`make lint` (static) and `go test ./...` (unit / integration); this
+one is the **black-box** layer that drives the built binary against
+real `git init` sandboxes the way a user would.
+
+## When to invoke
+
+- After a non-trivial change anywhere under `cmd/` or
+  `internal/cli/` — the unit tests cover most of this, but the
+  black-box harness catches wiring regressions (cobra command
+  registration, flag exposure, exit-code mapping in `Execute`).
+- Before opening a PR for a CLI-touching change. Faster than
+  waiting on CI.
+- Before declaring a multi-PR merge wave done.
+- When the user asks "is everything still working?".
+
+The PreToolUse hook `e2e-pre-merge.sh` runs the same script
+automatically before any `gh pr merge ...`, so you usually do not
+need to invoke this skill *immediately* before merging — but it is
+the manual entry point and a good rehearsal step before pushing.
+
+## What it covers
+
+84 assertions across two layers:
+
+**Pre-existing primitives (33 assertions)**
+
+- `set` / `verify` / `clear` cycle including `clear` idempotency
+- Default key (no positional arg) → `default`
+- `--hash files` requires `--include`; respects scope
+- `--state-dir` flag override; marker NOT in default location
+- `MARKGATE_STATE_DIR` env override
+- Precedence chain: flag > env > `state_dir:` > default
+- `run`: child runs on miss, skips on match, exit propagates,
+  marker NOT advanced on child failure
+- `init` writes `.markgate.yml` and is non-clobbering
+- `version` prints something
+
+**2026-05-09 batch features (51 assertions)**
+
+- `completion`: bash script emit, unknown-shell exit=2, dynamic
+  gate-key completion via `__complete`
+- `config lint`: clean exit=0, dirty exit=1, dead glob /
+  unknown-field detection, `--json` shape
+- TTL: fresh→0, expired→1 with stderr message, set resets,
+  `1mo` rejected at config load
+- `--explain` / `-e`: scope to stderr, exit code unchanged,
+  pretty-printed JSON shape `{key, scope, hasher, state}`
+- Bare `status`: header, all rows, `(configured)` /
+  `(unconfigured)` notes, single-key backward compat,
+  snake_case `--json`
+- `composes` (loose): unconditional set, verify-time propagation
+- `requires` (strict): set refused exit=2 naming offending child
+- Config-load errors: cycle / missing child / both fields set
+  all reject at exit=2
+
+## How it caches
+
+The hook wraps the script in `go run ./cmd/markgate run
+hook-e2e-pre-merge -- bash .claude/scripts/e2e.sh`, so:
+
+- **First run after a source change**: full ~10–15s execution
+  (build + 84 assertions, the script does its own `go build` to
+  the temp dir).
+- **Repeat run with no source change**: ~0.1s skip, marker hit.
+
+The marker lives at `.git/markgate/hook-e2e-pre-merge.json`
+(default state-dir, git-ignored). Default `git-tree` hash means
+any source change invalidates it.
+
+## Running it
+
+```sh
+bash .claude/scripts/e2e.sh             # full run, 84 PASS lines + summary
+QUIET=1 bash .claude/scripts/e2e.sh     # only print section headers + failures
+```
+
+Exit code = number of failed assertions (0 on all-pass).
+
+## When this skill is NOT enough
+
+- The script does not exercise marker-file *atomicity* under
+  concurrent writes — that's covered by `internal/state` unit
+  tests, and re-testing it from a black-box harness is unreliable.
+- It does not run `make lint` or `go test ./...`. Those remain
+  the static / unit gates and are independent. Run them separately
+  when introducing new code (the `audit-before-done` skill is the
+  canonical pre-push checklist).
+- It uses a temp sandbox under `/tmp` and does not exercise the
+  user's actual `.markgate.yml` or shared state-dir. If you
+  changed sharing / multi-host behavior, smoke that path manually
+  too.
+
+## Adding a new assertion
+
+When a new feature lands in the markgate CLI:
+
+1. Add a section to `.claude/scripts/e2e.sh` (mirror the existing
+   `cyan "=== feature ==="` + `new_repo` + `assert_*` pattern).
+2. Run `bash .claude/scripts/e2e.sh` once and confirm the new
+   assertions pass.
+3. Update the "what it covers" list in this SKILL.md so the
+   description stays honest.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,18 @@ message to a temp file first sidesteps all shell escaping.
   push time but only after the commit has already landed locally
   (expensive to unwind). Exits 2 with a message pointing at the fix
   (`git checkout -b <feature-branch>`).
+- `hooks/e2e-pre-merge.sh` is a PreToolUse hook on Bash: before any
+  `gh pr merge ...` it runs `.claude/scripts/e2e.sh` (the full 84-
+  assertion CLI smoke), wrapped in `markgate run` so unchanged
+  repos skip in ~0.1s. Failure exits 2 and blocks the merge. The
+  same script is invokable manually via the `verify-e2e` skill.
+- `scripts/e2e.sh` is the black-box CLI smoke (built binary +
+  `git init` sandboxes per section). Covers original primitives
+  (set / verify / clear / run / init / version, default key,
+  `--hash files`, `--state-dir`, env-var, precedence) and every
+  feature added in the 2026-05-09 batch (completion, config lint,
+  TTL, `--explain`, bare status, composes / requires). 84 PASS on
+  green; exit code = number of failures.
 
 ### How the dogfood works (no install needed)
 
@@ -177,5 +189,6 @@ globally installed binary. Benefits:
   after `go clean -cache` is slow (~2–3s).
 - Nothing lands outside the repo.
 
-Marker for this hook lives at `.git/markgate/hook-vet.json` (default
-location, git-ignored by virtue of being inside `.git/`).
+Markers for these hooks live at `.git/markgate/hook-vet.json` and
+`.git/markgate/hook-e2e-pre-merge.json` (default location, git-
+ignored by virtue of being inside `.git/`).


### PR DESCRIPTION
## Summary

- New `.claude/scripts/e2e.sh` — 84-assertion black-box smoke covering the full CLI surface: pre-existing primitives (set / verify / clear / run / init / version, default key, --hash files, --state-dir, env-var, full precedence chain) and every feature added in the 2026-05-09 batch (completion, config lint, TTL, --explain, bare status, composes / requires).
- New `.claude/hooks/e2e-pre-merge.sh` — PreToolUse hook that fires before `gh pr merge ...` and runs the script wrapped in `markgate run` so unchanged repos skip in ~0.1s. Failure exits 2, blocking the merge.
- New `.claude/skills/verify-e2e/SKILL.md` — manual entry point for the same script (when you want to confirm "all features still work" before pushing).
- `CLAUDE.md` Harness section updated to document the new pieces alongside the existing `go-vet-on-edit` and `guard-main-branch` hooks.

The hook reuses the dogfood pattern from `go-vet-on-edit.sh` — `go run ./cmd/markgate run hook-e2e-pre-merge -- bash .claude/scripts/e2e.sh` — so it always reflects current source and never needs `go install`.

## Why

The 2026-05-09 6-PR merge wave shipped end-to-end-correct features (the user manually walked through every command) but the manual smoke was a one-shot, not repeatable. This formalizes that smoke into a script that the harness runs automatically before merge and that humans can run via the skill.

## Test plan

- [x] `bash .claude/scripts/e2e.sh` — 84 PASS, 0 FAIL
- [x] Hook fires on `gh pr merge ...`, silent on `git status` etc.
- [x] First run after source change: ~10s. Cached repeat: ~0.1s.
- [x] Marker lands at `.git/markgate/hook-e2e-pre-merge.json`.
- [ ] CI green (`make lint` + `go test ./...` unaffected — script is .sh only).