### PR TITLE
chore: post-batch follow-ups (drop LoadStrict, surface glob errors, README notes)

### DIFF
--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -303,6 +303,17 @@ out=$($MG config lint --json 2>&1)
 assert_contains "lint --json has path field"     '"path"'     "$out"
 assert_contains "lint --json has severity field" '"severity"' "$out"
 
+# Malformed glob (unmatched `[`) is a config error, not a finding —
+# must surface as exit 2, not silently pass.
+cat > .markgate.yml <<'EOF'
+gates:
+  bad:
+    hash: files
+    include: ["src/[unclosed"]
+EOF
+$MG config lint >/dev/null 2>&1
+assert_eq "lint malformed glob exit=2" "2" "$?"
+
 cyan "=== #34 TTL ==="
 new_repo
 

--- a/README.md
+++ b/README.md
@@ -724,6 +724,19 @@ markgate completion <shell>            Emit a completion script (bash / zsh / fi
 files currently in scope to stderr (with `--json` for a structured
 form on stdout). See [Debugging a stale gate](#debugging-a-stale-gate).
 
+> When a gate sets [`ttl:`](#wall-clock-expiry-ttl), `verify` is no
+> longer a pure function of the file tree — it also depends on the
+> wall clock, returning mismatch once `now - marker.created_at >
+> ttl` even if the digest still matches.
+>
+> `markgate run --explain --json` is only stdout-clean on the skip
+> path (when the gate matches). On mismatch the child runs with
+> `Stdout = os.Stdout`, so its output concatenates after the JSON
+> object and `jq` will choke. Use plain `--explain` (text form,
+> stderr) when you want explain output alongside a real run, or
+> compose with `markgate verify <key> --explain --json` ahead of
+> the child.
+
 ### `markgate status` (bare): list all gates
 
 Without a `[key]`, `markgate status` prints one row per known gate —

--- a/internal/cli/config_lint.go
+++ b/internal/cli/config_lint.go
@@ -84,16 +84,19 @@ func runConfigLint(out io.Writer, jsonOut bool) error {
 	}
 
 	var root yaml.Node
-	if err := yaml.Unmarshal(data, &root); err != nil {
+	if err = yaml.Unmarshal(data, &root); err != nil {
 		return &ExitError{Code: 2, Err: fmt.Errorf("parse %s: %w", config.Filename, err)}
 	}
 
 	var cfg config.Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err = yaml.Unmarshal(data, &cfg); err != nil {
 		return &ExitError{Code: 2, Err: fmt.Errorf("parse %s: %w", config.Filename, err)}
 	}
 
-	findings := collectFindings(top, &root, &cfg)
+	findings, err := collectFindings(top, &root, &cfg)
+	if err != nil {
+		return &ExitError{Code: 2, Err: err}
+	}
 	sortFindings(findings)
 
 	if jsonOut {
@@ -111,11 +114,17 @@ func runConfigLint(out io.Writer, jsonOut bool) error {
 }
 
 // collectFindings walks the YAML tree for unknown keys and the typed
-// config for dead include/exclude globs, returning the merged warning set.
-func collectFindings(topLevel string, root *yaml.Node, cfg *config.Config) []lintFinding {
+// config for dead include/exclude globs, returning the merged warning
+// set. A non-nil error means a glob pattern was malformed (config
+// error, not finding) — caller surfaces it as exit 2.
+func collectFindings(topLevel string, root *yaml.Node, cfg *config.Config) ([]lintFinding, error) {
 	findings := unknownFieldFindings(root)
-	findings = append(findings, deadGlobFindings(topLevel, cfg)...)
-	return findings
+	dead, err := deadGlobFindings(topLevel, cfg)
+	if err != nil {
+		return nil, err
+	}
+	findings = append(findings, dead...)
+	return findings, nil
 }
 
 // unknownFieldFindings reports keys that are not defined on Config or Gate.
@@ -178,8 +187,11 @@ func unknownGateFieldFindings(gates *yaml.Node) []lintFinding {
 // the working tree. The check expands each pattern against the FS so
 // typos (`docss/**`) and patterns left over after refactors surface
 // immediately rather than waiting for someone to notice the gate has
-// stopped invalidating.
-func deadGlobFindings(topLevel string, cfg *config.Config) []lintFinding {
+// stopped invalidating. A glob with malformed syntax (unmatched
+// bracket, etc.) is a config error, not a finding — surface it as
+// an error so the lint command exits 2 rather than silently passing
+// the broken pattern.
+func deadGlobFindings(topLevel string, cfg *config.Config) ([]lintFinding, error) {
 	var out []lintFinding
 	names := make([]string, 0, len(cfg.Gates))
 	for name := range cfg.Gates {
@@ -189,8 +201,12 @@ func deadGlobFindings(topLevel string, cfg *config.Config) []lintFinding {
 	for _, name := range names {
 		g := cfg.Gates[name]
 		for i, pat := range g.Include {
-			if dead, _ := isDeadGlob(topLevel, pat); dead {
-				path := fmt.Sprintf("gates.%s.include[%d]", name, i)
+			path := fmt.Sprintf("gates.%s.include[%d]", name, i)
+			matches, err := hasher.MatchGlob(topLevel, pat)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", path, err)
+			}
+			if len(matches) == 0 {
 				out = append(out, lintFinding{
 					Path:     path,
 					Severity: "warning",
@@ -199,8 +215,12 @@ func deadGlobFindings(topLevel string, cfg *config.Config) []lintFinding {
 			}
 		}
 		for i, pat := range g.Exclude {
-			if dead, _ := isDeadGlob(topLevel, pat); dead {
-				path := fmt.Sprintf("gates.%s.exclude[%d]", name, i)
+			path := fmt.Sprintf("gates.%s.exclude[%d]", name, i)
+			matches, err := hasher.MatchGlob(topLevel, pat)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", path, err)
+			}
+			if len(matches) == 0 {
 				out = append(out, lintFinding{
 					Path:     path,
 					Severity: "warning",
@@ -209,15 +229,7 @@ func deadGlobFindings(topLevel string, cfg *config.Config) []lintFinding {
 			}
 		}
 	}
-	return out
-}
-
-func isDeadGlob(topLevel, pat string) (bool, error) {
-	matches, err := hasher.MatchGlob(topLevel, pat)
-	if err != nil {
-		return false, err
-	}
-	return len(matches) == 0, nil
+	return out, nil
 }
 
 func sortFindings(f []lintFinding) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,6 @@
 package config
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -82,26 +81,6 @@ func (g Gate) Children() []string {
 	out = append(out, g.Composes...)
 	out = append(out, g.Requires...)
 	return out
-}
-
-// LoadStrict is like Load but rejects unknown YAML fields, surfacing typos
-// or leftover keys via the returned error. Default Load stays forgiving so
-// older binaries can read configs that pick up new keys later. A missing
-// file is an error here: strict callers want explicit feedback, not the
-// silent empty-config default Load returns.
-func LoadStrict(topLevel string) (*Config, error) {
-	path := filepath.Join(topLevel, Filename)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	dec := yaml.NewDecoder(bytes.NewReader(data))
-	dec.KnownFields(true)
-	var c Config
-	if err := dec.Decode(&c); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", Filename, err)
-	}
-	return &c, nil
 }
 
 // Load reads topLevel/.markgate.yml. A missing file yields an empty

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,36 +89,6 @@ func TestLoad_StateDirPreserved(t *testing.T) {
 	}
 }
 
-func TestLoadStrict_RejectsUnknownField(t *testing.T) {
-	dir := t.TempDir()
-	writeConfig(t, dir, "gates:\n  legacy:\n    hash: git-tree\n    legacy_field: foo\n")
-	if _, err := LoadStrict(dir); err == nil {
-		t.Error("want error for unknown gate field under strict load")
-	}
-	// Default Load is forgiving — same input must parse without error.
-	if _, err := Load(dir); err != nil {
-		t.Errorf("Load should ignore unknown fields, got: %v", err)
-	}
-}
-
-func TestLoadStrict_MissingIsError(t *testing.T) {
-	if _, err := LoadStrict(t.TempDir()); err == nil {
-		t.Error("want error when config is missing under strict load")
-	}
-}
-
-func TestLoadStrict_AcceptsValid(t *testing.T) {
-	dir := t.TempDir()
-	writeConfig(t, dir, "gates:\n  check:\n    hash: git-tree\n    state_dir: .mg\n")
-	c, err := LoadStrict(dir)
-	if err != nil {
-		t.Fatalf("strict load on valid config: %v", err)
-	}
-	if g := c.Gate("check"); g.StateDir != ".mg" {
-		t.Errorf("StateDir = %q, want %q", g.StateDir, ".mg")
-	}
-}
-
 func TestLoad_DepsBothFields(t *testing.T) {
 	dir := t.TempDir()
 	writeConfig(t, dir,


### PR DESCRIPTION
## Summary

Post-batch cleanup from the 2026-05-09 6-PR merge wave. Four small items the per-PR review agents flagged as "merge-as-is, follow up later":

- **drop `config.LoadStrict()`** — added in #32 with the intent that `config lint` would consume it, but `config_lint.go` ended up doing its own permissive `yaml.Node` walk and `LoadStrict` was never called. Two parallel mechanisms for the same job; deleted with its three unit tests.
- **fix silent invalid-glob in `config lint`** — `isDeadGlob` was discarding `hasher.MatchGlob` errors via `_`, so a malformed glob pattern (unmatched `[`, etc.) silently passed lint. Now propagates as exit 2 with the offending path, matching the documented "2 = config error" semantics. New `.claude/scripts/e2e.sh` assertion locks it.
- **README: TTL wall-clock note** — #29's spec asked for an explicit note on the verify CLI reference saying "under TTL, verify is no longer a pure function of files — it depends on the wall clock." Was implied at the TTL subsection but missing on verify itself.
- **README: `run --explain --json` limitation** — #24 / #31's flagged minor: on the mismatch path the child runs with `Stdout = os.Stdout`, so `markgate run --explain --json -- some-cmd` produces JSON followed by child output and `jq` chokes. Documented (no behavior change — guides users toward `markgate verify <key> --explain --json` ahead of the child instead).

## What's NOT in this PR (deliberately deferred)

- `resolveStateDir` / `resolveMarkerPath` precedence-chain duplication (#33 nit) — works, lockstep documented in code, refactor risk > benefit.
- `hashTypeDepsOnly` sentinel value (#35 nit) — needs a `Marker.Kind` design discussion + schema bump.
- Redundant `state.Load` in status path (#35 nit) — pure perf, no observable impact.

## Test plan

- [x] `go test ./...` green (LoadStrict tests removed; one new e2e assertion).
- [x] `make lint` green.
- [x] `bash .claude/scripts/e2e.sh` → 85 PASS / 0 FAIL.
- [ ] CI green.
