### PR TITLE
refactor(cli): dedupe resolveStateDir / resolveMarkerPath

### DIFF
--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -239,14 +239,14 @@ func (c *gateCtx) staleRequiredChild() (string, error) {
 	return "", nil
 }
 
-// resolveMarkerPath picks the marker file location based on precedence:
+// resolveStateDir picks the marker storage directory based on precedence:
 // --state-dir flag > MARKGATE_STATE_DIR env > gate.StateDir (from
-// .markgate.yml) > default (<gitDir>/markgate). When an override is
-// used, the "markgate" subdirectory is not injected: the user-specified
+// .markgate.yml) > default (<gitDir>/markgate). When an override is used,
+// the "markgate" subdirectory is not injected: the user-specified
 // directory is treated as the final storage location. Relative override
 // paths resolve against the repo top-level so the location is stable
 // across cwds (e.g. when invoked from a git hook).
-func resolveMarkerPath(overrides *gateFlagValues, gate config.Gate, topLevel, gitDir, k string) string {
+func resolveStateDir(overrides *gateFlagValues, gate config.Gate, topLevel, gitDir string) string {
 	dir := ""
 	switch {
 	case overrides != nil && overrides.stateDir != "":
@@ -257,12 +257,20 @@ func resolveMarkerPath(overrides *gateFlagValues, gate config.Gate, topLevel, gi
 		dir = gate.StateDir
 	}
 	if dir == "" {
-		return state.Path(gitDir, k)
+		return filepath.Join(gitDir, "markgate")
 	}
 	if !filepath.IsAbs(dir) {
 		dir = filepath.Join(topLevel, dir)
 	}
-	return state.PathIn(dir, k)
+	return dir
+}
+
+// resolveMarkerPath returns the marker file path for key k. Thin wrapper
+// over resolveStateDir so per-key callers and the bare-status walker
+// share one precedence-resolution path (no lockstep invariant to
+// maintain by hand).
+func resolveMarkerPath(overrides *gateFlagValues, gate config.Gate, topLevel, gitDir, k string) string {
+	return state.PathIn(resolveStateDir(overrides, gate, topLevel, gitDir), k)
 }
 
 // validateGate enforces the invariants that config.validate also enforces,

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -416,29 +415,6 @@ func buildRow(k string, gate config.Gate, h hasher.Hasher, repo *gitutil.Repo, m
 		row.note = noteUnconfig
 	}
 	return row, nil
-}
-
-// resolveStateDir mirrors resolveMarkerPath's precedence chain but
-// returns just the directory, key-independent. Keep these two helpers
-// in lockstep — the bare-status listing must walk the same dir the
-// per-key path writes into.
-func resolveStateDir(overrides *gateFlagValues, gate config.Gate, topLevel, gitDir string) string {
-	dir := ""
-	switch {
-	case overrides != nil && overrides.stateDir != "":
-		dir = overrides.stateDir
-	case os.Getenv(EnvStateDir) != "":
-		dir = os.Getenv(EnvStateDir)
-	case gate.StateDir != "":
-		dir = gate.StateDir
-	}
-	if dir == "" {
-		return filepath.Join(gitDir, "markgate")
-	}
-	if !filepath.IsAbs(dir) {
-		dir = filepath.Join(topLevel, dir)
-	}
-	return dir
 }
 
 func writeJSON(out io.Writer, v any) error {


### PR DESCRIPTION
## Summary

Removes the documented "lockstep" invariant between `resolveStateDir` (in `status.go`) and `resolveMarkerPath` (in `helper.go`).

Both helpers walked the same precedence chain — flag > env > config > default `<gitDir>/markgate` — for the same purpose (one returns the dir, the other the file path). They were in different files and a comment was the only thing keeping them aligned ("Keep these two helpers in lockstep — the bare-status listing must walk the same dir the per-key path writes into"). That's a linter-invisible invariant; if either drifted, bare `status` would walk a different directory than per-key `set`/`verify` write into and silently miss markers.

After this PR, `resolveStateDir` is the single source of truth (now in `helper.go`) and `resolveMarkerPath` is a one-liner: `state.PathIn(resolveStateDir(...), key)`.

## Scope

- No behavior change. Default location, override precedence, marker layout — all unchanged.
- Existing `TestStateDir_*` and `TestStatusBareAll_StateDirOverride` cover the affected paths and continue to pass.

## Test plan

- [x] `go test ./...` green
- [x] `make lint` green
- [x] `bash .claude/scripts/e2e.sh` → 85 PASS / 0 FAIL (covers core precedence + bare-status walk)
- [ ] CI green
