### PR TITLE
refactor(cli): single state.Load + hasher.Hash per status invocation

### DIFF
--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -162,61 +162,77 @@ func (c *gateCtx) child(k string) (*gateCtx, error) {
 }
 
 // evalResult is what evaluate returns to callers (verify, status, run).
-// Reason is populated when matched is false so callers can render context.
-// childKey, when set, names the first descendant whose mismatch caused this
-// gate to fail — useful for #24's --explain output and for set-time
-// requires-enforcement messaging.
+//
+// matched is the freshness verdict (own scope ANDed with every recursive
+// composes/requires child).
+//
+// reason / childKey explain why matched is false; childKey names the
+// offending descendant for set-time requires enforcement and #24's
+// --explain output.
+//
+// marker / digest / hashTypeChanged / ownDigestDiff carry the work
+// evaluate already did so callers (status, in particular) don't reload
+// or re-hash. marker is nil when no marker exists. digest is empty
+// when the gate has no own scope. hashTypeChanged and ownDigestDiff
+// are only meaningful when marker is non-nil.
 type evalResult struct {
-	matched  bool
-	reason   string
-	childKey string
+	matched         bool
+	reason          string
+	childKey        string
+	marker          *state.Marker
+	digest          string
+	hashTypeChanged bool
+	ownDigestDiff   bool
 }
 
 // evaluate computes the recursive freshness verdict for c. It loads the
 // marker, optionally compares the own-scope digest, and ANDs in every
 // composes/requires child. Cycles are impossible here because config
-// validation rejects them.
+// validation rejects them. The result carries the loaded marker and
+// computed digest so callers don't have to repeat the work.
 func (c *gateCtx) evaluate() (evalResult, error) {
+	m, err := state.Load(c.markerPath)
+	if err != nil {
+		if errors.Is(err, state.ErrNotFound) {
+			return evalResult{reason: "no marker"}, nil
+		}
+		return evalResult{}, err
+	}
+	res := evalResult{marker: m}
 	if c.gate.HasOwnScope() {
-		m, err := state.Load(c.markerPath)
-		if err != nil {
-			if errors.Is(err, state.ErrNotFound) {
-				return evalResult{matched: false, reason: "no marker"}, nil
-			}
-			return evalResult{}, err
+		digest, hashErr := c.hasher.Hash(c.repo)
+		if hashErr != nil {
+			return evalResult{}, hashErr
 		}
-		digest, err := c.hasher.Hash(c.repo)
-		if err != nil {
-			return evalResult{}, err
-		}
-		if m.HashType != c.hasher.Type() || m.Digest != digest {
-			return evalResult{matched: false, reason: "own digest mismatch"}, nil
-		}
-	} else {
-		// Deps-only gates still need an explicit set to count as fresh: a
-		// brand-new gate with no marker must not pass on first verify just
-		// because all its children happen to be fresh.
-		if _, err := state.Load(c.markerPath); err != nil {
-			if errors.Is(err, state.ErrNotFound) {
-				return evalResult{matched: false, reason: "no marker"}, nil
-			}
-			return evalResult{}, err
+		res.digest = digest
+		res.hashTypeChanged = m.HashType != c.hasher.Type()
+		res.ownDigestDiff = m.Digest != digest
+		if res.hashTypeChanged || res.ownDigestDiff {
+			res.reason = "own digest mismatch"
+			return res, nil
 		}
 	}
+	// Deps-only path falls through with marker loaded but no digest
+	// work — the marker's mere presence is what proves an explicit set
+	// happened (otherwise a brand-new deps-only gate would pass on first
+	// verify just because its children happen to be fresh).
 	for _, childKey := range c.gate.Children() {
-		cc, err := c.child(childKey)
-		if err != nil {
-			return evalResult{}, err
+		cc, ccErr := c.child(childKey)
+		if ccErr != nil {
+			return evalResult{}, ccErr
 		}
-		res, err := cc.evaluate()
-		if err != nil {
-			return evalResult{}, err
+		childRes, childErr := cc.evaluate()
+		if childErr != nil {
+			return evalResult{}, childErr
 		}
-		if !res.matched {
-			return evalResult{matched: false, reason: "child " + childKey + " is stale", childKey: childKey}, nil
+		if !childRes.matched {
+			res.reason = "child " + childKey + " is stale"
+			res.childKey = childKey
+			return res, nil
 		}
 	}
-	return evalResult{matched: true}, nil
+	res.matched = true
+	return res, nil
 }
 
 // staleRequiredChild returns the key of the first direct requires child

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -106,60 +106,44 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 
 	jsonOnly := explain != nil && explain.json && !explain.enabled
 
-	m, loadErr := state.Load(c.markerPath)
-	if loadErr != nil {
-		if errors.Is(loadErr, state.ErrNotFound) {
-			if explain != nil && explain.enabled {
-				if emitErr := emitExplain(c, explain, out, errOut, stateNoMarker); emitErr != nil {
-					return &ExitError{Code: 2, Err: emitErr}
-				}
-				if explain.json {
-					return &ExitError{Code: 1}
-				}
-				fmt.Fprintf(out, "key:        %s\nstate:      no marker\n", c.key)
-				return &ExitError{Code: 1}
-			}
-			if jsonOnly {
-				row := statusRow{
-					key:          c.key,
-					state:        stateNoMarker,
-					configured:   true,
-					unconfigured: false,
-					note:         noteConfigured,
-				}
-				if writeErr := writeJSON(out, row.toJSON()); writeErr != nil {
-					return &ExitError{Code: 2, Err: writeErr}
-				}
-				return &ExitError{Code: 1}
-			}
-			fmt.Fprintf(out, "key:        %s\nstate:      no marker\n", c.key)
-			return &ExitError{Code: 1}
-		}
-		return &ExitError{Code: 2, Err: loadErr}
-	}
-
-	// ownDigestDiff is true when the marker's own-scope digest disagrees
-	// with the current state. Deps-only gates (no own scope) skip the
-	// computation entirely: their freshness is purely a function of
-	// children (see evaluate()).
-	hashTypeChanged := false
-	ownDigestDiff := false
-	if c.gate.HasOwnScope() {
-		digest, hashErr := c.hasher.Hash(c.repo)
-		if hashErr != nil {
-			return &ExitError{Code: 2, Err: hashErr}
-		}
-		hashTypeChanged = m.HashType != c.hasher.Type()
-		ownDigestDiff = m.Digest != digest
-	}
-
 	res, evalErr := c.evaluate()
 	if evalErr != nil {
 		return &ExitError{Code: 2, Err: evalErr}
 	}
 
+	if res.marker == nil {
+		// No marker on disk — evaluate already mapped this to
+		// reason="no marker"; honor explain/json variants.
+		if explain != nil && explain.enabled {
+			if emitErr := emitExplain(c, explain, out, errOut, stateNoMarker); emitErr != nil {
+				return &ExitError{Code: 2, Err: emitErr}
+			}
+			if explain.json {
+				return &ExitError{Code: 1}
+			}
+			fmt.Fprintf(out, "key:        %s\nstate:      no marker\n", c.key)
+			return &ExitError{Code: 1}
+		}
+		if jsonOnly {
+			row := statusRow{
+				key:          c.key,
+				state:        stateNoMarker,
+				configured:   true,
+				unconfigured: false,
+				note:         noteConfigured,
+			}
+			if writeErr := writeJSON(out, row.toJSON()); writeErr != nil {
+				return &ExitError{Code: 2, Err: writeErr}
+			}
+			return &ExitError{Code: 1}
+		}
+		fmt.Fprintf(out, "key:        %s\nstate:      no marker\n", c.key)
+		return &ExitError{Code: 1}
+	}
+
+	m := res.marker
 	label := stateMatch
-	if !res.matched || hashTypeChanged || ownDigestDiff {
+	if !res.matched {
 		label = stateMismatch
 	}
 
@@ -183,7 +167,7 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 			unconfigured: false,
 		}
 		switch {
-		case hashTypeChanged, ownDigestDiff:
+		case res.hashTypeChanged, res.ownDigestDiff:
 			row.state = stateMismatch
 			row.note = noteDigestDiff
 		case !res.matched:
@@ -221,10 +205,10 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 	}
 
 	switch {
-	case hashTypeChanged:
+	case res.hashTypeChanged:
 		fmt.Fprintf(out, "state:      mismatch (hash type changed: %s -> %s)\n", m.HashType, c.hasher.Type())
 		return &ExitError{Code: 1}
-	case ownDigestDiff:
+	case res.ownDigestDiff:
 		fmt.Fprintln(out, "state:      mismatch (digest differs)")
 		return &ExitError{Code: 1}
 	case !res.matched:


### PR DESCRIPTION
## Summary

`statusSingle` was duplicating `evaluate`'s work. It loaded the marker, computed the digest, then called `evaluate` which loaded the marker AGAIN and recomputed the digest AGAIN. For a default `git-tree` gate that's a re-walk of every tracked file via `git ls-files` + `git hash-object` — observable on large repos (100ms+ per call), invisible on small ones.

This PR makes `evaluate` the single source of truth for both. `evalResult` now carries the loaded marker, computed digest, and the two derived flags (`hashTypeChanged`, `ownDigestDiff`). `statusSingle` consumes those instead of recomputing.

## What changes

```go
type evalResult struct {
    matched         bool
    reason          string
    childKey        string
    marker          *state.Marker  // new
    digest          string         // new
    hashTypeChanged bool           // new
    ownDigestDiff   bool           // new
}
```

`evaluate` populates the new fields as it goes; `statusSingle` reads them. `verify` and `run` ignore the additions and stay byte-identical.

## What stays the same

- Exit codes (0 / 1 / 2) — identical.
- Output text (status block, --explain, --json) — identical.
- ErrNotFound → `state: no marker` mapping, exit 1 — identical.
- Deps-only path: marker still required, no digest computed for the parent itself, freshness comes from children — identical.

## Test plan

- [x] `go test ./...` green (existing `TestStatus_*`, `TestVerify_*`, `TestComposes_*`, `TestRequires_*`, `TestParentScope_*` clusters cover the changed paths).
- [x] `make lint` clean.
- [x] `bash .claude/scripts/e2e.sh` → 85 / 85 PASS.
- [ ] CI green.
