### PR TITLE
refactor(state): replace hash_type 'deps-only' sentinel with Marker.Kind

### DIFF
--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -199,6 +199,18 @@ func (c *gateCtx) evaluate() (evalResult, error) {
 		return evalResult{}, err
 	}
 	res := evalResult{marker: m}
+	expectedKind := state.KindHash
+	if !c.gate.HasOwnScope() {
+		expectedKind = state.KindDepsOnly
+	}
+	if m.Kind != expectedKind {
+		// Gate flipped between own-scope and deps-only since last set;
+		// the marker is from a different freshness model. Treat it as
+		// stale so the next set rewrites it under the current model.
+		res.hashTypeChanged = true
+		res.reason = "marker kind changed"
+		return res, nil
+	}
 	if c.gate.HasOwnScope() {
 		digest, hashErr := c.hasher.Hash(c.repo)
 		if hashErr != nil {
@@ -377,12 +389,13 @@ func formatAge(d time.Duration) string {
 // HEAD is recorded only for git-tree, to aid status output. CreatedAt is
 // stamped here (via the package's now indirection) rather than left for
 // state.Save to fill in, so tests that pin the clock for TTL coverage
-// observe the pinned value. Deps-only gates (no own scope) get a sentinel
-// marker so their freshness is purely a function of children but `set`
-// still leaves a record that an explicit `markgate set <key>` happened.
+// observe the pinned value. Deps-only gates (no own scope) get a marker
+// tagged Kind=KindDepsOnly with no hash_type/digest: their freshness is
+// purely a function of children, but `set` still leaves a record that an
+// explicit `markgate set <key>` happened.
 func newMarker(c *gateCtx) (*state.Marker, error) {
 	if !c.gate.HasOwnScope() {
-		return &state.Marker{HashType: hashTypeDepsOnly}, nil
+		return &state.Marker{Kind: state.KindDepsOnly, CreatedAt: now().UTC()}, nil
 	}
 	digest, err := c.hasher.Hash(c.repo)
 	if err != nil {
@@ -400,8 +413,3 @@ func newMarker(c *gateCtx) (*state.Marker, error) {
 	}
 	return m, nil
 }
-
-// hashTypeDepsOnly is the sentinel HashType written for gates that have
-// composes/requires but no include of their own. The digest field stays
-// empty: there is nothing to hash. Status output recognises this value.
-const hashTypeDepsOnly = "deps-only"

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -57,7 +57,8 @@ func newStatusCmd() *cobra.Command {
 
 type statusMarkerJSON struct {
 	CreatedAt string `json:"created_at"`
-	HashType  string `json:"hash_type"`
+	Kind      string `json:"kind,omitempty"`
+	HashType  string `json:"hash_type,omitempty"`
 	Head      string `json:"head,omitempty"`
 }
 
@@ -91,6 +92,7 @@ func (r statusRow) toJSON() statusRowJSON {
 	if r.marker != nil {
 		row.Marker = &statusMarkerJSON{
 			CreatedAt: r.marker.CreatedAt.UTC().Format(time.RFC3339),
+			Kind:      r.marker.Kind,
 			HashType:  r.marker.HashType,
 			Head:      r.marker.Head,
 		}
@@ -195,7 +197,11 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 	}
 
 	fmt.Fprintf(out, "key:        %s\n", c.key)
-	fmt.Fprintf(out, "hash type:  %s\n", m.HashType)
+	if m.Kind == state.KindDepsOnly {
+		fmt.Fprintln(out, "kind:       deps-only")
+	} else {
+		fmt.Fprintf(out, "hash type:  %s\n", m.HashType)
+	}
 	fmt.Fprintf(out, "created:    %s\n", m.CreatedAt.Format(time.RFC3339))
 	if m.Head != "" {
 		fmt.Fprintf(out, "head:       %s\n", m.Head)
@@ -370,11 +376,21 @@ func buildRow(k string, gate config.Gate, h hasher.Hasher, repo *gitutil.Repo, m
 		return row, nil
 	}
 	row.marker = m
-	digest, hashErr := h.Hash(repo)
-	if hashErr != nil {
-		return row, hashErr
+	mismatch := false
+	if m.Kind == state.KindDepsOnly {
+		// Deps-only marker: no own scope to hash, so freshness depends
+		// on children alone. Bare status doesn't recurse into children
+		// (cost / surprise), so report match here and let the user run
+		// `markgate verify <key>` for the full propagation if it
+		// matters. The presence of the marker proves an explicit set.
+	} else {
+		digest, hashErr := h.Hash(repo)
+		if hashErr != nil {
+			return row, hashErr
+		}
+		mismatch = m.HashType != h.Type() || m.Digest != digest
 	}
-	if m.HashType != h.Type() || m.Digest != digest {
+	if mismatch {
 		row.state = stateMismatch
 		row.note = noteDigestDiff
 	} else {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -22,13 +22,29 @@ import (
 var ErrNotFound = errors.New("marker not found")
 
 // SchemaVersion tags the on-disk format. Bump on breaking changes.
-const SchemaVersion = 1
+// v1 wrote a sentinel `hash_type: "deps-only"` for gates without their
+// own scope; v2 splits that out into a dedicated `kind` field so
+// hash_type stays semantically clean (the actual hashing algorithm).
+// state.Load treats wrong-version markers as ErrNotFound, so old v1
+// markers are silently re-generated on first verify after upgrade.
+const SchemaVersion = 2
+
+// Marker kinds. KindHash (the empty string default) is a normal
+// hash-and-digest marker. KindDepsOnly records that an explicit `set`
+// happened on a gate whose freshness is purely the AND of its
+// composes/requires children — no own scope to hash, no digest
+// recorded.
+const (
+	KindHash     = ""
+	KindDepsOnly = "deps-only"
+)
 
 // Marker is the serialized form of a recorded state hash.
 type Marker struct {
 	Version   int       `json:"version"`
-	HashType  string    `json:"hash_type"`
-	Digest    string    `json:"digest"`
+	Kind      string    `json:"kind,omitempty"`
+	HashType  string    `json:"hash_type,omitempty"`
+	Digest    string    `json:"digest,omitempty"`
 	Head      string    `json:"head,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 }


### PR DESCRIPTION
## Summary

Replaces the `hash_type: "deps-only"` sentinel value (introduced in #35) with a dedicated `kind` field on the marker. `hash_type` now only carries the actual hashing algorithm (`git-tree` / `files`), as its name implies.

## Why

`hash_type` was overloaded: for normal gates it identified the hashing algorithm; for deps-only parent gates (composes/requires with no own include) it carried the literal string `"deps-only"` as a sentinel meaning "no hash was computed." A category error in the data model — `kind: "deps-only"` is what was actually being expressed.

## What

| | Old (v1) | New (v2) |
| --- | --- | --- |
| Hash marker | `{version: 1, hash_type: "git-tree", digest: "...", ...}` | `{version: 2, hash_type: "git-tree", digest: "...", ...}` |
| Deps-only marker | `{version: 1, hash_type: "deps-only", digest: "", ...}` | `{version: 2, kind: "deps-only", ...}` (no hash_type, no digest) |

- `state.Marker` gains a `Kind string` field (`omitempty`).
- `state.KindHash = ""` and `state.KindDepsOnly = "deps-only"` constants.
- `hash_type` and `digest` are now `omitempty` so deps-only markers are clean.
- `hashTypeDepsOnly` constant in `internal/cli/helper.go` is gone.
- `evaluate` now also detects "gate kind flipped between deps-only and own-scope since last `set`" via Kind comparison and reports it as a mismatch (was previously silently incorrect for the own→deps direction).
- `markgate status <key>` for a deps-only gate now reads `kind: deps-only` instead of `hash type: deps-only`.

## Migration

Automatic. `state.Load` already treats wrong-version markers as `ErrNotFound`, so v1 markers (with the old sentinel) silently re-generate on first verify after upgrade. Markers are caches; cost is one extra invocation per gate, once.

## Test plan

- [x] `go test ./...` green — `TestParentScope_None` / `TestParentScope_WithInclude` cover deps-only set + verify; `TestComposes_*` / `TestRequires_*` cover dependency propagation with the new marker shape.
- [x] `make lint` clean.
- [x] `bash .claude/scripts/e2e.sh` → 85 / 85 PASS.
- [x] Smoke on a real composes parent confirms the new marker JSON `{version: 2, kind: "deps-only", created_at: "..."}` and the new status text.
- [ ] CI green.
