### PR TITLE
fix(cli): TTL propagation through composes/requires chain

### DIFF
--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -344,6 +344,26 @@ EOF
 $MG verify bad >/dev/null 2>&1
 assert_eq "1mo rejected at config load exit=2" "2" "$?"
 
+# TTL propagates through composes chain: child's expired TTL must
+# fail the parent even when parent's own marker is fresh.
+new_repo
+
+cat > .markgate.yml <<'EOF'
+gates:
+  child:
+    hash: git-tree
+    ttl: 2s
+  parent:
+    composes: [child]
+EOF
+$MG set child >/dev/null 2>&1
+$MG set parent >/dev/null 2>&1
+$MG verify parent >/dev/null 2>&1
+assert_eq "parent fresh while child fresh exit=0" "0" "$?"
+sleep 3
+$MG verify parent >/dev/null 2>&1
+assert_eq "parent inherits child TTL expiry exit=1" "1" "$?"
+
 cyan "=== #31 verify --explain ==="
 new_repo
 

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -163,18 +163,20 @@ func (c *gateCtx) child(k string) (*gateCtx, error) {
 
 // evalResult is what evaluate returns to callers (verify, status, run).
 //
-// matched is the freshness verdict (own scope ANDed with every recursive
-// composes/requires child).
+// matched is the freshness verdict (own scope ANDed with TTL ANDed
+// with every recursive composes/requires child).
 //
 // reason / childKey explain why matched is false; childKey names the
 // offending descendant for set-time requires enforcement and #24's
 // --explain output.
 //
-// marker / digest / hashTypeChanged / ownDigestDiff carry the work
-// evaluate already did so callers (status, in particular) don't reload
-// or re-hash. marker is nil when no marker exists. digest is empty
-// when the gate has no own scope. hashTypeChanged and ownDigestDiff
-// are only meaningful when marker is non-nil.
+// marker / digest / hashTypeChanged / ownDigestDiff / ttl carry the
+// work evaluate already did so callers don't reload or re-hash. marker
+// is nil when no marker exists. digest is empty when the gate has no
+// own scope. hashTypeChanged and ownDigestDiff are only meaningful
+// when marker is non-nil. ttl is populated whenever the gate has a
+// TTL configured (regardless of whether it's expired) so status can
+// render "expires in 4d" / "expired 1d ago" notes from one source.
 type evalResult struct {
 	matched         bool
 	reason          string
@@ -183,13 +185,20 @@ type evalResult struct {
 	digest          string
 	hashTypeChanged bool
 	ownDigestDiff   bool
+	ttl             ttlExpiry
 }
 
 // evaluate computes the recursive freshness verdict for c. It loads the
-// marker, optionally compares the own-scope digest, and ANDs in every
-// composes/requires child. Cycles are impossible here because config
-// validation rejects them. The result carries the loaded marker and
-// computed digest so callers don't have to repeat the work.
+// marker, optionally compares the own-scope digest, applies any TTL,
+// and ANDs in every composes/requires child. Cycles are impossible
+// here because config validation rejects them. The result carries the
+// loaded marker, computed digest, and TTL details so callers don't
+// repeat the work.
+//
+// TTL applies to every gate with `ttl:` set (own-scope or deps-only):
+// it caps the marker's wall-clock age. Because evaluate recurses, a
+// child's expired TTL propagates up — the parent's evaluate will
+// receive matched=false from the child and bubble it.
 func (c *gateCtx) evaluate() (evalResult, error) {
 	m, err := state.Load(c.markerPath)
 	if err != nil {
@@ -221,6 +230,17 @@ func (c *gateCtx) evaluate() (evalResult, error) {
 		res.ownDigestDiff = m.Digest != digest
 		if res.hashTypeChanged || res.ownDigestDiff {
 			res.reason = "own digest mismatch"
+			return res, nil
+		}
+	}
+	if c.gate.TTL != "" {
+		ttl, ttlErr := checkTTL(c.gate, m)
+		if ttlErr != nil {
+			return evalResult{}, ttlErr
+		}
+		res.ttl = ttl
+		if ttl.expired {
+			res.reason = "expired by ttl"
 			return res, nil
 		}
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -63,24 +63,6 @@ func runE(cmd *cobra.Command, args []string, overrides *gateFlagValues, explain 
 		return &ExitError{Code: 2, Err: evalErr}
 	}
 
-	// TTL is surfaced only at the parent level (see verify.go for the
-	// rationale; same TODO applies for chain propagation).
-	if res.matched {
-		m, loadErr := state.Load(c.markerPath)
-		if loadErr != nil && !errors.Is(loadErr, state.ErrNotFound) {
-			return &ExitError{Code: 2, Err: loadErr}
-		}
-		if m != nil {
-			ttl, ttlErr := checkTTL(c.gate, m)
-			if ttlErr != nil {
-				return &ExitError{Code: 2, Err: ttlErr}
-			}
-			if ttl.expired {
-				res.matched = false
-			}
-		}
-	}
-
 	label := stateLabel(res)
 	if emitErr := emitExplain(c, explain, cmd.OutOrStdout(), cmd.ErrOrStderr(), label); emitErr != nil {
 		return &ExitError{Code: 2, Err: emitErr}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -217,21 +217,14 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 	case res.ownDigestDiff:
 		fmt.Fprintln(out, "state:      mismatch (digest differs)")
 		return &ExitError{Code: 1}
+	case res.ttl.expired:
+		fmt.Fprintf(out, "state:      mismatch (expired by ttl: %s, marker is %s old)\n", c.gate.TTL, formatAge(res.ttl.age))
+		return &ExitError{Code: 1}
 	case !res.matched:
 		fmt.Fprintf(out, "state:      mismatch (%s)\n", res.reason)
 		return &ExitError{Code: 1}
-	}
-
-	ttl, err := checkTTL(c.gate, m)
-	if err != nil {
-		return &ExitError{Code: 2, Err: err}
-	}
-	switch {
-	case ttl.expired:
-		fmt.Fprintf(out, "state:      mismatch (expired by ttl: %s, marker is %s old)\n", c.gate.TTL, formatAge(ttl.age))
-		return &ExitError{Code: 1}
-	case ttl.configured:
-		fmt.Fprintf(out, "state:      match (expires in %s)\n", formatAge(ttl.ttl-ttl.age))
+	case res.ttl.configured:
+		fmt.Fprintf(out, "state:      match (expires in %s)\n", formatAge(res.ttl.ttl-res.ttl.age))
 		return nil
 	default:
 		fmt.Fprintln(out, "state:      match")

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -1,12 +1,9 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
-
-	"github.com/go-to-k/markgate/internal/state"
 )
 
 func newVerifyCmd() *cobra.Command {
@@ -32,35 +29,14 @@ func newVerifyCmd() *cobra.Command {
 			return &ExitError{Code: 2, Err: evalErr}
 		}
 
-		// TTL is surfaced only at the parent level: a fresh-by-digest parent
-		// can still mismatch when its own marker is older than gate.TTL.
-		// TODO(#28+#29): TTL propagation through composes chain.
-		var ttlMessage string
-		if res.matched {
-			m, loadErr := state.Load(c.markerPath)
-			if loadErr != nil && !errors.Is(loadErr, state.ErrNotFound) {
-				return &ExitError{Code: 2, Err: loadErr}
-			}
-			if m != nil {
-				ttl, ttlErr := checkTTL(c.gate, m)
-				if ttlErr != nil {
-					return &ExitError{Code: 2, Err: ttlErr}
-				}
-				if ttl.expired {
-					res.matched = false
-					ttlMessage = fmt.Sprintf(
-						"markgate: state mismatch (expired by ttl: %s, marker is %s old)\n",
-						c.gate.TTL, formatAge(ttl.age))
-				}
-			}
-		}
-
 		label := stateLabel(res)
 		if emitErr := emitExplain(c, explain, cmd.OutOrStdout(), cmd.ErrOrStderr(), label); emitErr != nil {
 			return &ExitError{Code: 2, Err: emitErr}
 		}
-		if ttlMessage != "" {
-			fmt.Fprint(cmd.ErrOrStderr(), ttlMessage)
+		if res.ttl.expired {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"markgate: state mismatch (expired by ttl: %s, marker is %s old)\n",
+				c.gate.TTL, formatAge(res.ttl.age))
 		}
 		if !res.matched {
 			return &ExitError{Code: 1}


### PR DESCRIPTION
## Summary

Fixes a **behavior bug**: a child gate's expired TTL was not propagating through composes / requires chains. Parent's `verify` reported match even when a child it composed had long since TTL-expired. Removes the two known TODOs (`run.go:67`, `verify.go:37`) that flagged it.

Also collapses two redundancies that fell out of the same fix.

## What was wrong

TTL was checked OUTSIDE `evaluate`, in `verify.go` / `run.go` AFTER the recursive freshness check completed. So:

- `child.evaluate()` returned `matched=true` based on digest only.
- `parent.evaluate()` saw a "fresh" child and marked itself fresh.
- The `verify`/`run` caller checked TTL on the parent's own marker, which was fresh.
- Result: parent was reported fresh while a child was conceptually stale.

Plus: `verify.go` and `run.go` each did their own `state.Load` after `evaluate` already loaded the marker — a redundant read that #40 should have caught but didn't because the duplicate lived in the TTL branch.

## Fix

`evaluate()` is the single source of truth for freshness, including TTL. New field on `evalResult`:

```go
type evalResult struct {
    ...
    ttl ttlExpiry  // populated whenever gate.TTL != ""
}
```

`evaluate` runs `checkTTL` after the digest check. If expired, `matched=false`, `reason="expired by ttl"`, `ttl` populated. Because `evaluate` recurses, child TTL expiry now propagates up automatically — no special-casing.

`verify.go`, `run.go`, and the single-key path of `status.go` drop their post-evaluate TTL handling and read `res.ttl` for the user-facing message.

## Test plan

- [x] `go test ./...` green.
- [x] `make lint` clean.
- [x] `bash .claude/scripts/e2e.sh` → 87 / 87 PASS (was 85; +2 for the two new TTL-propagation assertions).
- [x] Removed TODOs grep clean: `grep -rn "TODO\|FIXME" internal/ cmd/` shows nothing.
- [ ] CI green.
