### PR TITLE
fix: address three bug reports from cdkd against v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,10 @@ Notes:
 - `(unconfigured)` — a marker file is present but the gate isn't in
   `.markgate.yml` (stale from a renamed / deleted gate, or written
   by a script that bypassed the config).
+- `child <key> is stale` — this gate `composes` / `requires` the
+  named child, and the child's own row is mismatch. The bare list
+  recurses through dependencies, so the parent's verdict here always
+  agrees with `markgate verify <parent>`.
 
 Exit code: `0` if every row matches, `1` if any row is mismatched or
 missing a marker, `2` on internal error.

--- a/internal/cli/config_lint.go
+++ b/internal/cli/config_lint.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -24,20 +26,34 @@ type lintFinding struct {
 	Message  string `json:"message"`
 }
 
-// gateFields lists the YAML keys recognized inside a gate. Kept in sync
-// with config.Gate's yaml tags; the lint command treats anything else as
-// an unknown field.
-var gateFields = map[string]struct{}{
-	"hash":      {},
-	"include":   {},
-	"exclude":   {},
-	"state_dir": {},
-}
+// gateFields lists the YAML keys recognized inside a gate. Derived
+// from config.Gate's yaml tags via reflection so adding a field to
+// Gate automatically teaches lint about it — no second allowlist to
+// keep in sync (which is how ttl/composes/requires originally drifted).
+var gateFields = yamlFieldNames(reflect.TypeOf(config.Gate{}))
 
-// topFields lists the YAML keys recognized at the document root. Mirrors
-// config.Config's yaml tags.
-var topFields = map[string]struct{}{
-	"gates": {},
+// topFields lists the YAML keys recognized at the document root,
+// derived the same way as gateFields.
+var topFields = yamlFieldNames(reflect.TypeOf(config.Config{}))
+
+// yamlFieldNames returns the set of YAML keys declared on t via
+// `yaml:"name,..."` struct tags. Anonymous tags (e.g. `yaml:"-"`) and
+// fields without a tag are skipped. t must be a struct type; callers
+// pass reflect.TypeOf(SomeStruct{}).
+func yamlFieldNames(t reflect.Type) map[string]struct{} {
+	out := make(map[string]struct{}, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.SplitN(tag, ",", 2)[0]
+		if name == "" {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	return out
 }
 
 func newConfigCmd() *cobra.Command {

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -132,6 +132,24 @@ func newGateCtx(k string, overrides *gateFlagValues) (*gateCtx, error) {
 	}, nil
 }
 
+// newGateCtxWithConfig builds a gateCtx from already-resolved
+// components, skipping the config / git / hasher I/O newGateCtx does.
+// Used by callers that walk multiple keys (bare `status`) to avoid
+// re-loading .markgate.yml per row. The caller is responsible for
+// applying overrides and validating the gate before calling.
+func newGateCtxWithConfig(k string, gate config.Gate, h hasher.Hasher, repo *gitutil.Repo, top, gitDir, markerPath string, cfg *config.Config) *gateCtx {
+	return &gateCtx{
+		key:        k,
+		repo:       repo,
+		topLevel:   top,
+		gitDir:     gitDir,
+		gate:       gate,
+		hasher:     h,
+		markerPath: markerPath,
+		cfg:        cfg,
+	}
+}
+
 // child builds a gateCtx for a child gate referenced via composes/requires.
 // Per-invocation overrides do NOT propagate to children — each child is
 // resolved purely from .markgate.yml so its scope is what its own entry

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -1587,3 +1587,141 @@ func TestExplain_RunJSONOnSkip(t *testing.T) {
 		t.Errorf("state = %q, want match", doc.State)
 	}
 }
+
+// TestVerify_ReadsLegacyV1Marker covers the cdkd bug report: a v1
+// marker written by 0.3.0 must not be silently treated as missing by
+// 0.3.1+. Load auto-migrates the schema; verify should report match
+// without anyone touching the on-disk file.
+func TestVerify_ReadsLegacyV1Marker(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "x")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  check:\n    hash: files\n    include: [\"src/**\"]\n")
+
+	// Pin the digest the way 0.3.0 would have written it: we let 0.3.1
+	// `set` write a marker, then rewrite the file in v1 shape using
+	// the same digest. This isolates the schema-version test from the
+	// hash algorithm itself.
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: %d", code)
+	}
+	markerPath := filepath.Join(dir, ".git", "markgate", "check.json")
+	current, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("read v2 marker: %v", err)
+	}
+	var v2 struct {
+		HashType  string `json:"hash_type"`
+		Digest    string `json:"digest"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := json.Unmarshal(current, &v2); err != nil {
+		t.Fatalf("parse v2: %v", err)
+	}
+	v1 := []byte(`{"version":1,"hash_type":"` + v2.HashType +
+		`","digest":"` + v2.Digest +
+		`","created_at":"` + v2.CreatedAt + `"}`)
+	if err := os.WriteFile(markerPath, v1, 0o600); err != nil {
+		t.Fatalf("downgrade marker: %v", err)
+	}
+
+	if code, _ := runCmd(t, "verify", "check"); code != 0 {
+		t.Errorf("verify against v1 marker: code = %d, want 0", code)
+	}
+	if code, out := runCmd(t, "status", "check"); code != 0 {
+		t.Errorf("status against v1 marker: code = %d, out:\n%s", code, out)
+	}
+}
+
+// TestConfigLint_KnowsAllGateFields covers the cdkd report that lint
+// flagged ttl / composes / requires as unknown fields. The allowlist is
+// derived from config.Gate via reflection so any field the parser
+// accepts is recognized as known.
+func TestConfigLint_KnowsAllGateFields(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "foo.txt", "x")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n"+
+			"  parent:\n"+
+			"    requires: [child]\n"+
+			"  child:\n"+
+			"    hash: files\n"+
+			"    include: [\"*.txt\"]\n"+
+			"    ttl: 14d\n"+
+			"  alt:\n"+
+			"    composes: [child]\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 0 {
+		t.Errorf("config lint: code = %d, want 0; output:\n%s", code, out)
+	}
+	for _, field := range []string{"ttl", "requires", "composes"} {
+		if strings.Contains(out, "unknown field: gates."+field) ||
+			strings.Contains(out, "."+field+":") && strings.Contains(out, "unknown field") {
+			t.Errorf("lint reported %q as unknown:\n%s", field, out)
+		}
+	}
+}
+
+// TestStatus_BareRecursesThroughRequires covers the cdkd report:
+// single-key status correctly recurses through requires/composes,
+// but bare `status` (list form) used to skip the recursion and showed
+// the parent as match while the child was stale. The two views must
+// agree.
+func TestStatus_BareRecursesThroughRequires(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "foo.txt", "x")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n"+
+			"  parent:\n"+
+			"    requires: [child]\n"+
+			"  child:\n"+
+			"    hash: files\n"+
+			"    include: [\"*.txt\"]\n")
+
+	if code, _ := runCmd(t, "set", "child"); code != 0 {
+		t.Fatalf("set child: %d", code)
+	}
+	if code, _ := runCmd(t, "set", "parent"); code != 0 {
+		t.Fatalf("set parent: %d", code)
+	}
+
+	// Single-key form: parent must already see the freshness picture.
+	if code, single := runCmd(t, "status", "parent"); code != 0 {
+		t.Errorf("status parent (after both set): code=%d\n%s", code, single)
+	}
+
+	if code, _ := runCmd(t, "clear", "child"); code != 0 {
+		t.Fatalf("clear child: %d", code)
+	}
+
+	codeSingle, single := runCmd(t, "status", "parent")
+	if codeSingle != 1 {
+		t.Errorf("single-key status: code=%d, want 1\n%s", codeSingle, single)
+	}
+	if !strings.Contains(single, "child child is stale") {
+		t.Errorf("single-key status missing child-stale note:\n%s", single)
+	}
+
+	codeBare, bare := runCmd(t, "status")
+	if codeBare != 1 {
+		t.Errorf("bare status: code=%d, want 1 (parent must propagate)\n%s", codeBare, bare)
+	}
+	// Find the parent row. With tabwriter, columns are space-padded.
+	var parentLine string
+	for _, line := range strings.Split(bare, "\n") {
+		if strings.HasPrefix(line, "parent ") {
+			parentLine = line
+			break
+		}
+	}
+	if parentLine == "" {
+		t.Fatalf("parent row missing from bare status:\n%s", bare)
+	}
+	if !strings.Contains(parentLine, "mismatch") {
+		t.Errorf("parent row state should be mismatch, got: %q", parentLine)
+	}
+	if !strings.Contains(parentLine, "child child is stale") {
+		t.Errorf("parent row note should mention stale child, got: %q", parentLine)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -272,7 +272,8 @@ func statusListAll(out io.Writer, overrides *gateFlagValues, asJSON bool) error 
 			return &ExitError{Code: 2, Err: hErr}
 		}
 		markerPath := resolveMarkerPath(overrides, gate, top, gitDir, k)
-		row, bErr := buildRow(k, gate, h, repo, markerPath, isConfigured, clock)
+		gctx := newGateCtxWithConfig(k, gate, h, repo, top, gitDir, markerPath, cfg)
+		row, bErr := buildRow(gctx, isConfigured, clock)
 		if bErr != nil {
 			return &ExitError{Code: 2, Err: bErr}
 		}
@@ -344,63 +345,55 @@ func configuredSet(cfg *config.Config) map[string]struct{} {
 	return out
 }
 
-// buildRow skips the digest computation when no marker is present —
-// config-only keys (which dominate "fresh repo" output) shouldn't pay
-// the hash cost. TTL is folded into the note column when the gate
-// matches and a TTL is configured: "expires in 4d" while fresh,
+// buildRow runs the same recursive evaluator that single-key `status`
+// and `verify` use, so the bare list view agrees with them on every
+// gate's freshness. Previously this path skipped composes/requires
+// entirely (deps-only markers always reported match, hash markers
+// only checked their own digest) which made the two views disagree.
+//
+// TTL folds into the note column: "expires in 4d" while fresh,
 // "expired 1d ago" once the deadline has passed (the latter also
 // flips state to mismatch).
-func buildRow(k string, gate config.Gate, h hasher.Hasher, repo *gitutil.Repo, markerPath string, configured bool, clock time.Time) (statusRow, error) {
+func buildRow(c *gateCtx, configured bool, clock time.Time) (statusRow, error) {
 	row := statusRow{
-		key:          k,
+		key:          c.key,
 		configured:   configured,
 		unconfigured: !configured,
 		now:          clock,
 	}
-	m, err := state.Load(markerPath)
+	res, err := c.evaluate()
 	if err != nil {
-		if !errors.Is(err, state.ErrNotFound) {
-			return row, err
-		}
+		return row, err
+	}
+	if res.marker == nil {
 		row.state = stateNoMarker
 		if configured {
 			row.note = noteConfigured
 		}
+		if !configured {
+			row.note = noteUnconfig
+		}
 		return row, nil
 	}
-	row.marker = m
-	mismatch := false
-	if m.Kind == state.KindDepsOnly {
-		// Deps-only marker: no own scope to hash, so freshness depends
-		// on children alone. Bare status doesn't recurse into children
-		// (cost / surprise), so report match here and let the user run
-		// `markgate verify <key>` for the full propagation if it
-		// matters. The presence of the marker proves an explicit set.
-	} else {
-		digest, hashErr := h.Hash(repo)
-		if hashErr != nil {
-			return row, hashErr
-		}
-		mismatch = m.HashType != h.Type() || m.Digest != digest
-	}
-	if mismatch {
+	row.marker = res.marker
+	switch {
+	case res.hashTypeChanged, res.ownDigestDiff:
 		row.state = stateMismatch
 		row.note = noteDigestDiff
-	} else {
+	case res.ttl.expired:
+		row.state = stateMismatch
+		row.note = fmt.Sprintf("expired %s ago", formatAge(res.ttl.age-res.ttl.ttl))
+	case res.childKey != "":
+		row.state = stateMismatch
+		row.note = "child " + res.childKey + " is stale"
+	case res.matched:
 		row.state = stateMatch
-		if gate.TTL != "" {
-			ttl, ttlErr := checkTTL(gate, m)
-			if ttlErr != nil {
-				return row, ttlErr
-			}
-			switch {
-			case ttl.expired:
-				row.state = stateMismatch
-				row.note = fmt.Sprintf("expired %s ago", formatAge(ttl.age-ttl.ttl))
-			case ttl.configured:
-				row.note = fmt.Sprintf("expires in %s", formatAge(ttl.ttl-ttl.age))
-			}
+		if res.ttl.configured {
+			row.note = fmt.Sprintf("expires in %s", formatAge(res.ttl.ttl-res.ttl.age))
 		}
+	default:
+		row.state = stateMismatch
+		row.note = res.reason
 	}
 	if !configured {
 		// (unconfigured) wins over digest / ttl notes: a stray marker

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -25,9 +25,17 @@ var ErrNotFound = errors.New("marker not found")
 // v1 wrote a sentinel `hash_type: "deps-only"` for gates without their
 // own scope; v2 splits that out into a dedicated `kind` field so
 // hash_type stays semantically clean (the actual hashing algorithm).
-// state.Load treats wrong-version markers as ErrNotFound, so old v1
-// markers are silently re-generated on first verify after upgrade.
+// state.Load auto-migrates v1 markers in memory so a 0.3.0 → 0.3.1
+// upgrade does not invalidate every existing marker. The on-disk
+// file is rewritten as v2 only on the next Save (typically the next
+// `set` after a real digest change). Wrong-version markers from any
+// schema we don't know how to migrate are surfaced as ErrNotFound.
 const SchemaVersion = 2
+
+// legacyKindHashTypeDepsOnly is the v1 sentinel that the deps-only
+// kind used to live under (`hash_type: "deps-only"`). Kept here so the
+// migration in Load() has a named reference rather than a magic string.
+const legacyKindHashTypeDepsOnly = "deps-only"
 
 // Marker kinds. KindHash (the empty string default) is a normal
 // hash-and-digest marker. KindDepsOnly records that an explicit `set`
@@ -79,13 +87,32 @@ func Load(path string) (*Marker, error) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf("parse marker %s: %w", path, err)
 	}
-	// Forward-compat: a marker written by a different schema version is
-	// treated as absent so the caller re-runs and rewrites with the
-	// current schema. Prevents cross-version digest comparisons.
-	if m.Version != SchemaVersion {
+	switch m.Version {
+	case SchemaVersion:
+		return &m, nil
+	case 1:
+		migrateV1(&m)
+		return &m, nil
+	default:
+		// Unknown / future schema: treat as absent so the caller re-runs
+		// and rewrites with the current schema. Prevents cross-version
+		// digest comparisons.
 		return nil, ErrNotFound
 	}
-	return &m, nil
+}
+
+// migrateV1 promotes an in-memory v1 marker to the current schema. The
+// only v1→v2 difference is the `hash_type: "deps-only"` sentinel,
+// which moves into the dedicated Kind field; everything else (digest,
+// head, created_at) is byte-identical. The Version is updated so the
+// next Save writes back as v2. Pure mutation, no I/O.
+func migrateV1(m *Marker) {
+	if m.HashType == legacyKindHashTypeDepsOnly {
+		m.Kind = KindDepsOnly
+		m.HashType = ""
+		m.Digest = ""
+	}
+	m.Version = SchemaVersion
 }
 
 // Save writes a marker atomically: CreateTemp in the destination directory,

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -52,6 +52,48 @@ func TestLoad_SchemaVersionMismatch(t *testing.T) {
 	}
 }
 
+func TestLoad_MigratesV1HashMarker(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "v1.json")
+	body := []byte(`{"version":1,"hash_type":"files","digest":"deadbeef","created_at":"2026-01-01T00:00:00Z"}`)
+	if err := os.WriteFile(p, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(p)
+	if err != nil {
+		t.Fatalf("v1 marker should migrate, got err: %v", err)
+	}
+	if got.Version != SchemaVersion {
+		t.Errorf("Version = %d, want %d (migrated)", got.Version, SchemaVersion)
+	}
+	if got.HashType != "files" || got.Digest != "deadbeef" {
+		t.Errorf("digest fields lost on migration: %+v", got)
+	}
+	if got.Kind != KindHash {
+		t.Errorf("Kind = %q, want %q (hash markers stay KindHash)", got.Kind, KindHash)
+	}
+}
+
+func TestLoad_MigratesV1DepsOnlySentinel(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "v1deps.json")
+	body := []byte(`{"version":1,"hash_type":"deps-only","digest":"","created_at":"2026-01-01T00:00:00Z"}`)
+	if err := os.WriteFile(p, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(p)
+	if err != nil {
+		t.Fatalf("v1 deps-only marker should migrate, got err: %v", err)
+	}
+	if got.Version != SchemaVersion {
+		t.Errorf("Version = %d, want %d", got.Version, SchemaVersion)
+	}
+	if got.Kind != KindDepsOnly {
+		t.Errorf("Kind = %q, want %q (deps-only sentinel must promote)", got.Kind, KindDepsOnly)
+	}
+	if got.HashType != "" || got.Digest != "" {
+		t.Errorf("HashType / Digest must be cleared on deps-only migration, got %+v", got)
+	}
+}
+
 func TestLoad_CorruptJSON(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "bad.json")
 	if err := os.WriteFile(p, []byte("not json"), 0o600); err != nil {


### PR DESCRIPTION
Three bugs surfaced together when cdkd integrated v0.3.1. They are independent in code but related in cause (each is a regression introduced by one of the v0.3 feature PRs). Bundled into one PR because they share the test scaffolding and a release.

## Issue 1 (high): schema bump silently invalidates v0.3.0 markers

PR #41 took the marker schema from v1 to v2. `state.Load` returned `ErrNotFound` for any version it did not recognize, so:

- A team mixing 0.3.0 (Homebrew) and 0.3.1 (mise) installs sees markers continually appear missing to whichever binary did not write them.
- Every gate re-runs its check unnecessarily, with no error to investigate. Worst possible failure mode for a stale-detection tool.

**Fix.** `state.Load` migrates v1 markers in memory: the legacy `hash_type:"deps-only"` sentinel becomes `Kind:KindDepsOnly` with `hash_type` cleared, every other field is byte-identical. The on-disk file is rewritten as v2 only on the next `Save` (typically the next `set` after a digest change), so reads stay non-mutating.

Cross-version compat is one-way only: 0.3.1+ reads 0.3.0's v1 markers; 0.3.0 still cannot read v2. That is the best we can do for an already-released binary.

## Issue 2 (medium): lint flags valid v0.3 fields as unknown

`markgate config lint` reported `ttl`, `composes`, and `requires` as `unknown field`, even though the runtime parser fully accepted them. The lint command had its own hand-maintained allowlist (`gateFields`, `topFields`) that drifted when PRs #34 / #35 added the new YAML keys.

**Fix.** Allowlists are now derived from `config.Gate` / `config.Config` via reflection on `yaml:` struct tags. Any field the parser accepts is automatically recognized as known by lint — no second list to keep in sync.

## Issue 3 (low): bare `status` does not propagate `requires` / `composes`

`markgate status <key>` (single-key form) routes through `gateCtx.evaluate`, the recursive freshness evaluator. Bare `markgate status` (list form) had its own `buildRow` path that skipped the recursion: parent gates always reported match while their children were stale. The two views disagreed.

**Fix.** `buildRow` now constructs a `gateCtx` per row and consumes `evaluate`'s result for state and note. Bare status surfaces `child <key> is stale` in the NOTE column for the parent row. Both forms share one source of truth.

A new helper `newGateCtxWithConfig` keeps the per-row construction cheap (no re-load of `.markgate.yml`).

## Test plan

- [x] state package: v1 hash marker and v1 deps-only sentinel both migrate correctly under `Load`.
- [x] cli integration: a v0.3.0-shaped marker is read by `verify`; `lint` accepts `ttl` / `composes` / `requires`; bare `status` propagates `child X is stale` up to the parent row.
- [x] `go test ./...` clean.
- [x] `make lint` clean.
- [x] `bash .claude/scripts/e2e.sh`: 87 PASS.
- [ ] CI green.