### PR TITLE
docs: relocate Shell completion from Install to CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,33 +85,6 @@ go install github.com/go-to-k/markgate/cmd/markgate@latest
 Linux / macOS / Windows archives (amd64 / arm64 / 386) — see
 [GitHub Releases](https://github.com/go-to-k/markgate/releases).
 
-### Shell completion
-
-`markgate completion <shell>` prints a completion script for `bash`,
-`zsh`, `fish`, or `powershell`. Pipe it into the location your shell
-loads.
-
-```sh
-# Bash (current session)
-source <(markgate completion bash)
-# Bash (persistent)
-markgate completion bash > /etc/bash_completion.d/markgate
-
-# Zsh — write into a directory on $fpath, e.g.
-markgate completion zsh > "${fpath[1]}/_markgate"
-
-# Fish
-markgate completion fish > ~/.config/fish/completions/markgate.fish
-
-# PowerShell
-markgate completion powershell | Out-String | Invoke-Expression
-```
-
-Once installed, the gate-key positions on `set` / `verify` / `status` /
-`clear` / `run` complete from the `gates:` map in `.markgate.yml` at
-the repo top-level. With no `.markgate.yml` present, completion stays
-silent — it never scans the marker directory or runs the gate.
-
 ## Basic setup
 
 The simplest shape: prefix the check command with `markgate run --`
@@ -865,6 +838,33 @@ MARKGATE_STATE_DIR       Marker storage directory. Same effect as
                          Precedence: --state-dir > this env >
                          state_dir: in .markgate.yml > default.
 ```
+
+### Shell completion
+
+`markgate completion <shell>` prints a completion script for `bash`,
+`zsh`, `fish`, or `powershell`. Pipe it into the location your shell
+loads.
+
+```sh
+# Bash (current session)
+source <(markgate completion bash)
+# Bash (persistent)
+markgate completion bash > /etc/bash_completion.d/markgate
+
+# Zsh — write into a directory on $fpath, e.g.
+markgate completion zsh > "${fpath[1]}/_markgate"
+
+# Fish
+markgate completion fish > ~/.config/fish/completions/markgate.fish
+
+# PowerShell
+markgate completion powershell | Out-String | Invoke-Expression
+```
+
+Once installed, the gate-key positions on `set` / `verify` / `status` /
+`clear` / `run` complete from the `gates:` map in `.markgate.yml` at
+the repo top-level. With no `.markgate.yml` present, completion stays
+silent — it never scans the marker directory or runs the gate.
 
 ## Sharing markers across machines (CI / teammates)
 


### PR DESCRIPTION
## Summary

`### Shell completion` was the last subsection under `## Install`, sitting alongside Homebrew / mise / `go install` / prebuilt binaries. The block is 27 lines (descriptions plus four shell-specific install commands) — almost as long as all four real install methods combined.

## Why move it

Shell completion is **post-install configuration**, not an install method. A first-time reader has just installed `markgate`, wants to try `set` / `verify`, and runs into a long bash/zsh/fish/powershell digression before reaching `## Basic setup`. The CLI works fine without completion; it's an enhancement.

## What changes

- `### Shell completion` removed from the end of `## Install`.
- Re-added at the end of `## CLI reference`, after `### Environment variables`.

That places it at the same depth as `Per-invocation overrides`, `Debugging a stale gate`, and `Environment variables` — all CLI affordances, not config-file features.

The heading text is unchanged, so the `#shell-completion` anchor slug is preserved. `grep -c '#shell'` shows no internal cross-references to it; external bookmarks keep working.

```
## Install
  Homebrew / Shell script / mise / go install / Prebuilt binaries
## Basic setup                         ← now reached sooner
...
## CLI reference
  ### markgate status (bare)
  ### Per-invocation overrides
  #### Debugging a stale gate
  ### Environment variables
  ### Shell completion                 ← new home
## Sharing markers ...
```

## Test plan

- [x] Diff is move-only (27+ / 27− on one file).
- [x] No cross-references to `#shell-completion` in the README (`grep` clean).
- [ ] CI green.
