### PR TITLE
fix(cli): config lint mirrors runtime validation

### DIFF
--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -314,6 +314,38 @@ EOF
 $MG config lint >/dev/null 2>&1
 assert_eq "lint malformed glob exit=2" "2" "$?"
 
+# Lint surfaces every rule that would make `markgate run` exit 2 (the
+# config.Validate-shared rules — undeclared refs, both-set, unknown
+# hash, ttl parse, cycle), so a clean lint means the config will load.
+cat > .markgate.yml <<'EOF'
+gates:
+  check:
+    hash: files
+    include: ["src/**"]
+  docs:
+    hash: files
+    include: ["src/**"]
+  verify-pr:
+    requires: [check, doaaaaaaacs]
+EOF
+mkdir -p src && echo x > src/a.go
+out=$($MG config lint 2>&1)
+code=$?
+assert_eq "lint undeclared ref exit=1" "1" "$code"
+assert_contains "lint flags undeclared ref" "doaaaaaaacs" "$out"
+
+cat > .markgate.yml <<'EOF'
+gates:
+  cache:
+    hash: files
+    include: ["src/**"]
+    ttl: 5xs
+EOF
+out=$($MG config lint 2>&1)
+code=$?
+assert_eq "lint ttl parse exit=1" "1" "$code"
+assert_contains "lint flags ttl parse error" "gates.cache.ttl" "$out"
+
 cyan "=== #34 TTL ==="
 new_repo
 

--- a/README.md
+++ b/README.md
@@ -690,8 +690,11 @@ markgate status     [key]              Show marker + match status (bare:
 markgate clear      [key]              Delete the marker (idempotent).
 markgate run        [key] -- <cmd>...  Sugar for verify + <cmd> + set.
 markgate init                          Write a starter .markgate.yml.
-markgate config lint                   Warn on dead include/exclude globs
-                                       and unknown fields in .markgate.yml.
+markgate config lint                   Warn on dead include/exclude globs,
+                                       unknown fields, and every rule that
+                                       would make `markgate run` exit 2
+                                       (unknown hash, ttl parse, undeclared
+                                       composes/requires refs, cycles).
                                        Exit 0 clean, 1 warnings, 2 error.
                                        --json emits an array of
                                        {path, severity, message}.

--- a/internal/cli/config_lint.go
+++ b/internal/cli/config_lint.go
@@ -69,10 +69,15 @@ func newConfigLintCmd() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "lint",
-		Short: "Report dead globs and unknown fields in .markgate.yml",
+		Short: "Report typos and config errors in .markgate.yml",
 		Long: "Walks .markgate.yml and warns on:\n" +
 			"  - include/exclude globs that match zero files in the working tree\n" +
-			"  - unknown top-level or per-gate keys (typos, leftovers).\n\n" +
+			"  - unknown top-level or per-gate keys (typos, leftovers)\n" +
+			"  - unknown hash type, malformed ttl, composes+requires both set\n" +
+			"  - composes/requires entries that name an undeclared gate\n" +
+			"  - self-references and cycles between gates.\n\n" +
+			"Every rule that would make `markgate run` exit 2 is surfaced here\n" +
+			"as a warning, so a clean lint means the config will load.\n\n" +
 			"Exit codes: 0 clean, 1 warnings, 2 parse / read error.",
 		Args: cobra.NoArgs,
 	}
@@ -129,10 +134,14 @@ func runConfigLint(out io.Writer, jsonOut bool) error {
 	return nil
 }
 
-// collectFindings walks the YAML tree for unknown keys and the typed
-// config for dead include/exclude globs, returning the merged warning
-// set. A non-nil error means a glob pattern was malformed (config
-// error, not finding) — caller surfaces it as exit 2.
+// collectFindings walks the YAML tree for unknown keys, the typed
+// config for dead include/exclude globs, and the shared validator for
+// every rule Load enforces at runtime (unknown hash, ttl parse,
+// composes+requires both set, undeclared / self-referencing /
+// cycling child gates). Sourcing those last from config.Validate
+// keeps lint from drifting away from runtime validation as new rules
+// land. A non-nil error means a glob pattern was malformed — caller
+// surfaces it as exit 2.
 func collectFindings(topLevel string, root *yaml.Node, cfg *config.Config) ([]lintFinding, error) {
 	findings := unknownFieldFindings(root)
 	dead, err := deadGlobFindings(topLevel, cfg)
@@ -140,6 +149,13 @@ func collectFindings(topLevel string, root *yaml.Node, cfg *config.Config) ([]li
 		return nil, err
 	}
 	findings = append(findings, dead...)
+	for _, f := range cfg.Validate() {
+		findings = append(findings, lintFinding{
+			Path:     f.Path,
+			Severity: "warning",
+			Message:  f.Message,
+		})
+	}
 	return findings, nil
 }
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -1663,6 +1663,146 @@ func TestConfigLint_KnowsAllGateFields(t *testing.T) {
 	}
 }
 
+// TestConfigLint_UndeclaredRequiresRef covers the original report:
+// a typo inside requires used to slide through lint and only fail at
+// runtime with exit 2. lint now mirrors config.Validate so the typo
+// surfaces as a warning before the user runs the gate.
+func TestConfigLint_UndeclaredRequiresRef(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n"+
+			"  check:\n    hash: files\n    include: [\"src/**\"]\n"+
+			"  docs:\n    hash: files\n    include: [\"src/**\"]\n"+
+			"  verify-pr:\n    requires: [check, doaaaaaaacs]\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("undeclared requires ref: code = %d, want 1; out:\n%s", code, out)
+	}
+	if !strings.Contains(out, `gates.verify-pr: references undeclared gate "doaaaaaaacs"`) {
+		t.Errorf("missing undeclared-ref warning, got:\n%s", out)
+	}
+}
+
+func TestConfigLint_UndeclaredComposesRef(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  parent:\n    composes: [ghost]\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("undeclared composes ref: code = %d, want 1; out:\n%s", code, out)
+	}
+	if !strings.Contains(out, `gates.parent: references undeclared gate "ghost"`) {
+		t.Errorf("missing undeclared-ref warning, got:\n%s", out)
+	}
+}
+
+func TestConfigLint_BothComposesAndRequires(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n"+
+			"  child:\n    hash: git-tree\n"+
+			"  parent:\n    composes: [child]\n    requires: [child]\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("composes+requires both set: code = %d, want 1; out:\n%s", code, out)
+	}
+	if !strings.Contains(out, "gates.parent: composes and requires cannot both be set") {
+		t.Errorf("missing both-set warning, got:\n%s", out)
+	}
+}
+
+func TestConfigLint_UnknownHash(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  x:\n    hash: bogus\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("unknown hash: code = %d, want 1; out:\n%s", code, out)
+	}
+	if !strings.Contains(out, `gates.x: unknown hash "bogus"`) {
+		t.Errorf("missing unknown-hash warning, got:\n%s", out)
+	}
+}
+
+func TestConfigLint_TTLParseError(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "foo.txt", "x")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  cache:\n    hash: files\n    include: [\"*.txt\"]\n    ttl: 5xs\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("ttl parse: code = %d, want 1; out:\n%s", code, out)
+	}
+	if !strings.Contains(out, "gates.cache.ttl:") {
+		t.Errorf("missing ttl warning, got:\n%s", out)
+	}
+}
+
+func TestConfigLint_SelfReference(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  a:\n    composes: [a]\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("self-ref: code = %d, want 1; out:\n%s", code, out)
+	}
+	if !strings.Contains(out, "gates.a: cycle detected (self-reference)") {
+		t.Errorf("missing self-reference warning, got:\n%s", out)
+	}
+	// findCycle's general path must not double-report the self-loop.
+	if strings.Count(out, "cycle detected") != 1 {
+		t.Errorf("self-reference reported more than once:\n%s", out)
+	}
+}
+
+func TestConfigLint_Cycle(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n"+
+			"  a:\n    composes: [b]\n"+
+			"  b:\n    requires: [c]\n"+
+			"  c:\n    composes: [a]\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("cycle: code = %d, want 1; out:\n%s", code, out)
+	}
+	if !strings.Contains(out, "gates: cycle detected") {
+		t.Errorf("missing cycle warning, got:\n%s", out)
+	}
+}
+
+// TestConfigLint_AggregatesMultipleFindings covers the design intent
+// of routing validate's rules through Validate(): a config with both
+// a lint-only finding (dead glob) and a runtime-error finding
+// (undeclared ref) reports both, instead of validate short-circuiting
+// before lint can finish its walk.
+func TestConfigLint_AggregatesMultipleFindings(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n"+
+			"  docs:\n    hash: files\n    include: [\"docss/**\"]\n"+
+			"  verify-pr:\n    requires: [ghost]\n")
+
+	code, out := runCmd(t, "config", "lint")
+	if code != 1 {
+		t.Errorf("aggregate: code = %d, want 1; out:\n%s", code, out)
+	}
+	if !strings.Contains(out, "gates.docs.include[0]: 'docss/**' matches 0 files") {
+		t.Errorf("missing dead-glob warning, got:\n%s", out)
+	}
+	if !strings.Contains(out, `gates.verify-pr: references undeclared gate "ghost"`) {
+		t.Errorf("missing undeclared-ref warning, got:\n%s", out)
+	}
+}
+
 // TestStatus_BareRecursesThroughRequires covers the cdkd report:
 // single-key status correctly recurses through requires/composes,
 // but bare `status` (list form) used to skip the recursion and showed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,6 +83,22 @@ func (g Gate) Children() []string {
 	return out
 }
 
+// Finding is one validation issue produced by Validate. Both Load and
+// `markgate config lint` consume the same finding stream — Load surfaces
+// the first as an error (preserving the historical exit-2 behavior),
+// while lint surfaces all of them as warnings so they compose with its
+// dead-glob and unknown-field checks. Sharing the producer keeps lint
+// from drifting away from runtime validation.
+type Finding struct {
+	// Path is the dotted location of the offender, e.g.
+	// "gates.x.requires[0]" or "gates.x.hash". Used by lint to populate
+	// its finding's Path; Load ignores it.
+	Path string
+	// Message is the user-facing explanation, already prefixed with Path
+	// (so Load can print it directly without re-formatting).
+	Message string
+}
+
 // Load reads topLevel/.markgate.yml. A missing file yields an empty
 // Config (never nil) so callers can always call c.Gate(...) safely.
 func Load(topLevel string) (*Config, error) {
@@ -98,49 +114,98 @@ func Load(topLevel string) (*Config, error) {
 	if err := yaml.Unmarshal(data, &c); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", Filename, err)
 	}
-	if err := c.validate(); err != nil {
-		return nil, err
+	if findings := c.Validate(); len(findings) > 0 {
+		return nil, errors.New(findings[0].Message)
 	}
 	return &c, nil
 }
 
-func (c *Config) validate() error {
-	for k, g := range c.Gates {
-		if err := key.Validate(k); err != nil {
-			return fmt.Errorf("gates.%s: %w", k, err)
-		}
-		switch g.Hash {
-		case "", HashGitTree:
-			// git-tree accepts optional include/exclude for narrowing the
-			// hash target while keeping HEAD-aware invalidation.
-		case HashFiles:
-			if len(g.Include) == 0 {
-				return fmt.Errorf("gates.%s: hash=files requires a non-empty include list", k)
-			}
-		default:
-			return fmt.Errorf("gates.%s: unknown hash %q (want %q or %q)", k, g.Hash, HashGitTree, HashFiles)
-		}
-		if g.TTL != "" {
-			if _, err := duration.Parse(g.TTL); err != nil {
-				return fmt.Errorf("gates.%s.ttl: %w", k, err)
-			}
-		}
-		if len(g.Composes) > 0 && len(g.Requires) > 0 {
-			return fmt.Errorf("gates.%s: composes and requires cannot both be set", k)
-		}
-		for _, child := range g.Children() {
-			if _, ok := c.Gates[child]; !ok {
-				return fmt.Errorf("gates.%s: references undeclared gate %q", k, child)
-			}
-			if child == k {
-				return fmt.Errorf("gates.%s: cycle detected (self-reference)", k)
-			}
-		}
+// Validate returns every validation issue in c. An empty slice means c
+// is valid. Order is deterministic (gates iterated in lexical order,
+// per-gate checks in a fixed sequence) so callers like lint can rely
+// on stable output.
+func (c *Config) Validate() []Finding {
+	var out []Finding
+	names := make([]string, 0, len(c.Gates))
+	for name := range c.Gates {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		out = append(out, validateGate(c, name, c.Gates[name])...)
 	}
 	if cycle := c.findCycle(); cycle != "" {
-		return fmt.Errorf("gates: cycle detected (%s)", cycle)
+		out = append(out, Finding{
+			Path:    "gates",
+			Message: fmt.Sprintf("gates: cycle detected (%s)", cycle),
+		})
 	}
-	return nil
+	return out
+}
+
+func validateGate(c *Config, name string, g Gate) []Finding {
+	var out []Finding
+	if err := key.Validate(name); err != nil {
+		out = append(out, Finding{
+			Path:    fmt.Sprintf("gates.%s", name),
+			Message: fmt.Sprintf("gates.%s: %s", name, err.Error()),
+		})
+	}
+	switch g.Hash {
+	case "", HashGitTree:
+		// git-tree accepts optional include/exclude for narrowing the
+		// hash target while keeping HEAD-aware invalidation.
+	case HashFiles:
+		if len(g.Include) == 0 {
+			out = append(out, Finding{
+				Path:    fmt.Sprintf("gates.%s", name),
+				Message: fmt.Sprintf("gates.%s: hash=files requires a non-empty include list", name),
+			})
+		}
+	default:
+		out = append(out, Finding{
+			Path:    fmt.Sprintf("gates.%s.hash", name),
+			Message: fmt.Sprintf("gates.%s: unknown hash %q (want %q or %q)", name, g.Hash, HashGitTree, HashFiles),
+		})
+	}
+	if g.TTL != "" {
+		if _, err := duration.Parse(g.TTL); err != nil {
+			out = append(out, Finding{
+				Path:    fmt.Sprintf("gates.%s.ttl", name),
+				Message: fmt.Sprintf("gates.%s.ttl: %s", name, err.Error()),
+			})
+		}
+	}
+	if len(g.Composes) > 0 && len(g.Requires) > 0 {
+		out = append(out, Finding{
+			Path:    fmt.Sprintf("gates.%s", name),
+			Message: fmt.Sprintf("gates.%s: composes and requires cannot both be set", name),
+		})
+	}
+	out = append(out, validateChildren(c, name, "composes", g.Composes)...)
+	out = append(out, validateChildren(c, name, "requires", g.Requires)...)
+	return out
+}
+
+func validateChildren(c *Config, parent, field string, children []string) []Finding {
+	var out []Finding
+	for i, child := range children {
+		path := fmt.Sprintf("gates.%s.%s[%d]", parent, field, i)
+		if child == parent {
+			out = append(out, Finding{
+				Path:    path,
+				Message: fmt.Sprintf("gates.%s: cycle detected (self-reference)", parent),
+			})
+			continue
+		}
+		if _, ok := c.Gates[child]; !ok {
+			out = append(out, Finding{
+				Path:    path,
+				Message: fmt.Sprintf("gates.%s: references undeclared gate %q", parent, child),
+			})
+		}
+	}
+	return out
 }
 
 // findCycle returns a human-readable cycle path (e.g. "a -> b -> a") if any
@@ -182,6 +247,12 @@ func (c *Config) findCycle() string {
 			}
 			child := top.kids[top.idx]
 			top.idx++
+			if child == top.node {
+				// Self-loop is reported per-edge by Validate (with the
+				// composes/requires index in Path); skip here so we don't
+				// emit a duplicate "cycle detected (a -> a)" finding.
+				continue
+			}
 			switch color[child] {
 			case white:
 				parent[child] = top.node


### PR DESCRIPTION
## Summary

- `markgate config lint` was silently passing configs that `markgate run` would reject at exit 2 — undeclared `composes` / `requires` refs (the reported case), `hash: files` without `include`, unknown hash, malformed `ttl`, `composes` and `requires` both set, gate cycles. lint and `config.Load`'s `validate` were two separate implementations of overlapping rules and had drifted.
- Refactored `validate` into `Config.Validate() []Finding`. `Load` surfaces the first finding as an error (preserving exit-2 semantics); `config lint` surfaces every finding as a warning so they compose with its existing dead-glob and unknown-field checks. New runtime rules now reach lint for free — no second allowlist to keep in sync.
- Per-edge self-reference reporting moved to a per-`composes[i]` / `requires[i]` finding, with `findCycle` skipping self-loops to avoid duplicate "cycle detected" output.

## Test plan

- [x] `go test ./...` passes (added 8 lint integration tests: undeclared requires/composes, both-set, unknown hash, ttl parse, self-ref, cycle, multi-finding aggregation)
- [x] `make lint` 0 issues
- [x] `.claude/scripts/e2e.sh` 91/91 (added undeclared-ref + ttl-parse assertions)
- [x] Smoke against the reported config in a fresh repo: `markgate config lint` exits 1 and reports `gates.verify-pr: references undeclared gate "doaaaaaaacs"`
