### PR TITLE
docs: define marker inline at first use in Gate pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,12 @@ form [`set` + `verify`](#gate-pattern-set--verify) instead.
 ## Gate pattern: `set` + `verify`
 
 `markgate run -- <cmd>` bakes the check into the hook. The split
-form inverts it: the check sets its own marker where it lives, and
-the hook just verifies the marker. Zero-config at minimum, scales
-with `.markgate.yml`.
+form inverts it: the check sets its own marker where it lives — a
+record that the check just passed against the current state — and
+the hook just verifies the marker. (Marker mechanics — how the hash
+is computed, where the file lives — are in [How it works](#how-it-works)
+below; for now the "pass receipt" picture is enough.) Zero-config at
+minimum, scales with `.markgate.yml`.
 
 The two halves:
 


### PR DESCRIPTION
## Summary

- `marker` was first used in the Gate pattern section but only defined later in How it works. Add an inline gloss at first use ("a record that the check just passed against the current state") and a parenthetical forward pointer to How it works for mechanism details.
- Mirrors the pattern used in the Japanese blog post draft (inline definition + explicit "details come later" forward pointer).

## Test plan

- [x] `make lint`
- [x] `#how-it-works` anchor exists and is the next section
