### PR TITLE
docs: thread "forgetting" framing through README front half

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ which writes a small **marker** recording the pass. The hook calls
 itself, but it can **refuse to proceed unless the marker confirms it
 ran**.
 
-The marker is keyed to the current repo state, so a code edit
-after `set` invalidates it — the skill has to run again before
-the hook lets through.
+Code keeps moving after the first `/check-docs`. The agent runs
+the skill, the marker passes — but if the code is edited again
+and the agent forgets to re-run, the marker is already stale (it's
+keyed to the current repo state). The hook blocks until
+`/check-docs` runs against the new state.
 
 ![set drops a marker; verify reads it](docs/images/markgate-set-verify.png)
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ enforce **non-command tasks** (e.g., LLM review), and aggregate
 
 ## What markgate does
 
-Hooks have three failure modes when you want an AI coding agent to
-reliably run a required task — a check (lint, test, build), an
-LLM-judged review, a code-generation step, or any operation with a
-pass/fail outcome. markgate addresses each with one of two primitives
-— `markgate run` (one-shot) or `markgate set` + `markgate verify`
-(the Gate pattern).
+Coding agents forget — context loss, token pressure, hurry. Hooks
+help, but have three failure modes when you want an AI coding
+agent to reliably run a required task — a check (lint, test,
+build), an LLM-judged review, a code-generation step, or any
+operation with a pass/fail outcome. markgate addresses each with
+one of two primitives — `markgate run` (one-shot) or `markgate
+set` + `markgate verify` (the Gate pattern).
 
 ### Pattern 1: ensure non-duplicate runs (`markgate run`)
 
@@ -75,8 +76,8 @@ shape is identical — see [Drop into your hook manager](#drop-into-your-hook-ma
 Some tasks aren't commands. "Did `/check-docs` find docs out of
 sync with src?" "Did `/investigate-aws` find anything wrong?" An
 LLM-led skill can work through these — judging, investigating, or
-updating step by step — but a hook can't execute any of it. So even
-when the agent is supposed to do the task, the hook has no grip on
+updating step by step — but a hook can't execute any of it. So when
+the agent forgets or skips the task, the hook has no grip on
 whether it actually happened.
 
 `markgate set` + `markgate verify` give the hook a grip by splitting
@@ -86,6 +87,10 @@ which writes a small **marker** recording the pass. The hook calls
 `markgate verify` to read it. The hook still can't run the skill
 itself, but it can **refuse to proceed unless the marker confirms it
 ran**.
+
+The marker is keyed to the current repo state, so a code edit
+after `set` invalidates it — the skill has to run again before
+the hook lets through.
 
 ![set drops a marker; verify reads it](docs/images/markgate-set-verify.png)
 


### PR DESCRIPTION
## Summary

Thread the blog's "ド忘れを機械的・強制的に捕捉する" framing through the README front half, so a click-through reader from the Zenn post lands on language that echoes the same beat.

- `## What markgate does` intro: prepend "Coding agents forget — context loss, token pressure, hurry. Hooks help, but ..." so the three failure modes have a stated cause (the agent forgetting) before the analytical breakdown. Pattern 1 already says "sometimes it forgets" — the intro now sets it up.
- Pattern 2 gap framing: "even when the agent is supposed to do the task" → "when the agent forgets or skips the task". Extends the forgetting frame from Pattern 1's command path into Pattern 2's skill path.
- Pattern 2 state-binding: new narrative paragraph covering the re-edit case — the agent implements, runs `/check-docs`, marker passes, then edits the code again and forgets to re-run. The marker is keyed to the current repo state, so the edit invalidates it and the hook forces a re-run. Without this, a reader could leave Pattern 2 thinking one successful `set` satisfies the hook forever.

Tagline left alone: "mechanical enforcement layer" stays as the structural framing (broader than forgetting — covers duplicate runs, non-command tasks, and multi-task aggregation).

## Test plan

- [ ] Read the front half end-to-end: tagline → intro → Pattern 1 → Pattern 2 → Pattern 3. Confirm the "forget" thread reads naturally, not as a tacked-on keyword.
- [ ] Confirm Pattern 2's re-edit narrative matches what the existing `markgate-set-verify.png` second row already depicts visually (implementation → /check-docs → verify → commit cycle).
- [ ] Spot-check that no existing anchors (`#pattern-2-...`, `#markgateyml-reference`, etc.) referenced from elsewhere in the doc were broken.