### PR TITLE
docs: rewrite Pattern 2 re-edit narrative for user-desire + plain language

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,10 @@ which writes a small **marker** recording the pass. The hook calls
 itself, but it can **refuse to proceed unless the marker confirms it
 ran**.
 
-Code keeps moving after the first `/check-docs`. The agent runs
-the skill, the marker passes — but if the code is edited again
-and the agent forgets to re-run, the marker is already stale (it's
-keyed to the current repo state). The hook blocks until
-`/check-docs` runs against the new state.
+The agent implements, runs `/check-docs`, the marker passes. But
+after another code edit, you'd want `/check-docs` to run again —
+and if the agent forgets, the marker no longer matches the new
+code, so the hook blocks until `/check-docs` re-runs.
 
 ![set drops a marker; verify reads it](docs/images/markgate-set-verify.png)
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ ran**.
 The agent implements, runs `/check-docs`, the marker passes. But
 after another code edit, you'd want `/check-docs` to run again —
 and if the agent forgets, the marker no longer matches the new
-code, so the hook blocks until `/check-docs` re-runs.
+code, so the hook blocks until `/check-docs` runs again.
 
 ![set drops a marker; verify reads it](docs/images/markgate-set-verify.png)
 


### PR DESCRIPTION
## Summary

Refine the Pattern 2 re-edit narrative paragraph that PR #55 introduced. Two issues with that first version:

1. **System-only perspective.** It told the cycle as "agent forgets, hook enforces" but didn't voice the reader's "I implemented, I checked, I edited again, I'd want to re-check" desire — which is the half that makes the case feel relatable instead of abstract.
2. **Premature jargon.** "Keyed to the current repo state" / "against the new state" introduced state-hash terminology that the README hasn't defined yet at that point. The formal explanation lives in `## How it works`, which comes later.

Rewrite the paragraph to:

- Open with the cycle the reader lives in: the agent **implements**, runs `/check-docs`, the marker passes.
- Voice the human desire ("you'd want `/check-docs` to run again") before naming the failure mode ("the agent forgets").
- Drop the "keyed to ... state" jargon, replace with the plain match-or-mismatch framing the surrounding prose already uses.
- End the cycle with an unambiguous re-run, not the elliptical "until it does."

## Test plan

- [ ] Read Pattern 2 end-to-end against the blog title "Coding Agent のド忘れを機械的・強制的に捕捉する" -- confirm the re-edit cycle (implement → check → edit again → want to re-check) reads as a recognizable everyday loop.
- [ ] Confirm the paragraph no longer references "current repo state" / "new state" jargon (those concepts now appear first in `## How it works`, where they're properly defined).
- [ ] Spot-check that anchors / cross-refs that point into Pattern 2 still resolve.