### PR TITLE
docs: show requires parents with own include, name the composes/requires convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,11 +641,11 @@ gates:
     composes: [check, docs]
 
   # requires: same propagation plus `markgate set deploy` is refused
-  # if `migration` is stale. The parent declares its own `include:`,
-  # since deploy is an action gate with its own scope.
+  # if `migration` is stale. The deploy gate declares its own
+  # `include:`, since it's an action gate with its own scope.
   deploy:
     hash: files
-    include: ["k8s/**", "Dockerfile"]
+    include: ["deploy/**"]
     requires: [migration]
 
   check:
@@ -688,11 +688,10 @@ expects.
   doesn't change `set` semantics; you can promote to `requires`
   once you know you want `set` to refuse.
 
-`composes` parents are typically deps-only (no `include:`) — they
-exist purely to aggregate child verdicts. `requires` parents
-typically declare their own `include:` since they represent an
-action with its own scope (deploy manifests, image layers, release
-artifacts).
+Gates with `composes:` are typically deps-only (no `include:`) —
+they exist purely to aggregate the verdicts of their dependencies.
+Gates with `requires:` typically declare their own `include:`
+since they represent an action with its own scope.
 
 ## CLI reference
 

--- a/README.md
+++ b/README.md
@@ -641,8 +641,11 @@ gates:
     composes: [check, docs]
 
   # requires: same propagation plus `markgate set deploy` is refused
-  # if `migration` is stale.
+  # if `migration` is stale. The parent declares its own `include:`,
+  # since deploy is an action gate with its own scope.
   deploy:
+    hash: files
+    include: ["k8s/**", "Dockerfile"]
     requires: [migration]
 
   check:
@@ -684,6 +687,12 @@ expects.
 - If unsure, start with `composes`. It's the looser of the two and
   doesn't change `set` semantics; you can promote to `requires`
   once you know you want `set` to refuse.
+
+`composes` parents are typically deps-only (no `include:`) — they
+exist purely to aggregate child verdicts. `requires` parents
+typically declare their own `include:` since they represent an
+action with its own scope (deploy manifests, image layers, release
+artifacts).
 
 ## CLI reference
 

--- a/README.md
+++ b/README.md
@@ -640,13 +640,14 @@ gates:
   verify-pr:
     composes: [check, docs]
 
-  # requires: same propagation plus `markgate set deploy` is refused
-  # if `migration` is stale. The deploy gate declares its own
-  # `include:`, since it's an action gate with its own scope.
-  deploy:
+  # requires: same propagation plus `markgate set pr-ready` is
+  # refused unless every required child is fresh. The pr-ready
+  # gate declares its own `include:`, since its marker captures
+  # the state being declared "ready".
+  pr-ready:
     hash: files
-    include: ["deploy/**"]
-    requires: [migration]
+    include: ["src/**", "docs/**"]
+    requires: [check, docs]
 
   check:
     hash: files
@@ -654,9 +655,6 @@ gates:
   docs:
     hash: files
     include: ["docs/**", "README.md"]
-  migration:
-    hash: files
-    include: ["db/migrations/**"]
 ```
 
 #### Parent's own scope
@@ -680,10 +678,11 @@ expects.
   for `verify-pr` shaped gates that combine independent checks; you
   set each child gate as that check finishes, and the parent's
   verdict tracks them automatically.
-- Reach for **`requires`** when the parent represents an action
-  that *must not happen* unless the children are demonstrably
-  fresh. Deploy after a passed migration, image push after a passed
-  vuln scan, release tag after a passed e2e suite.
+- Reach for **`requires`** when the parent gate represents a
+  **declaration** that should be refused unless its dependencies
+  are demonstrably fresh — like marking a state as "PR-ready"
+  after `check` / `docs` have passed, or "merge-OK" after all CI
+  checks pass.
 - If unsure, start with `composes`. It's the looser of the two and
   doesn't change `set` semantics; you can promote to `requires`
   once you know you want `set` to refuse.
@@ -691,7 +690,8 @@ expects.
 Gates with `composes:` are typically deps-only (no `include:`) —
 they exist purely to aggregate the verdicts of their dependencies.
 Gates with `requires:` typically declare their own `include:`
-since they represent an action with its own scope.
+since their marker captures the state being declared (so the
+declaration can later be verified against the current state).
 
 ## CLI reference
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ markgate verify pre-commit || {
 
 `markgate set pre-commit` is unconditional — the parent records its marker even if a child is stale. That's the right default for *summary* gates that observe child state.
 
-**Strict variant (`requires`)** — same `verify` propagation, but `markgate set <parent>` is refused (exit 2) when any child is stale, and the error names the offending child. Reach for it when the parent represents an action that *must not happen* before its children pass — `deploy` requiring a fresh `migration` gate, `release` requiring a fresh `e2e` gate. See [Gate dependencies](#gate-dependencies-composes-vs-requires) for the full shape.
+**Strict variant (`requires`)** — same `verify` propagation, but `markgate set <parent>` is refused (exit 2) when any child is stale, and the error names the offending child. Reach for it when the parent gate represents a **declaration** that should be refused unless its dependencies are fresh — like `pr-ready` requiring `check` and `docs`, or `merge-ok` requiring all CI checks. See [Gate dependencies](#gate-dependencies-composes-vs-requires) for the full shape.
 
 ## How it works
 
@@ -680,9 +680,10 @@ expects.
   verdict tracks them automatically.
 - Reach for **`requires`** when the parent gate represents a
   **declaration** that should be refused unless its dependencies
-  are demonstrably fresh — like marking a state as "PR-ready"
-  after `check` / `docs` have passed, or "merge-OK" after all CI
-  checks pass.
+  are demonstrably fresh. The `set` itself is the declaration
+  moment (e.g., `markgate set pr-ready` after `check` / `docs`
+  have passed) — refusing to `set` prevents the declaration from
+  being recorded.
 - If unsure, start with `composes`. It's the looser of the two and
   doesn't change `set` semantics; you can promote to `requires`
   once you know you want `set` to refuse.
@@ -1144,10 +1145,10 @@ markers where commit-access already implies trust in the signal.
   when the parent is a *summary* gate ("all the pieces I care about
   are currently fresh") — `set` of the parent is allowed regardless
   of child state, but `verify` propagates. Use `requires` when the
-  parent represents an action that must not happen unless every
-  child is demonstrably fresh (deploy after migration, image push
-  after vuln scan): `set` is refused with exit 2 if a required
-  child is stale. See
+  parent gate represents a **declaration** that should be refused
+  unless every dependency is fresh (e.g., `pr-ready` requiring
+  `check` and `docs`): `set` is the declaration itself and is
+  refused with exit 2 if a required child is stale. See
   [Gate dependencies](#gate-dependencies-composes-vs-requires).
 
 ## License


### PR DESCRIPTION
## Summary

Make the practical asymmetry between `composes` and `requires` parents visible in the Gate dependencies section. The spec already allows either to have its own `include:` (see `#### Parent's own scope`), but the example paired both as deps-only, which can leave readers thinking "parent gates don't get include" in general.

- `deploy` gate in the example now carries `hash: files` + `include: ["k8s/**", "Dockerfile"]` with a one-line comment naming why ("deploy is an action gate with its own scope"). The yml visually shows: `composes` parent deps-only / `requires` parent with own include.
- New closing paragraph in `#### Which one should I use?` states the convention explicitly, so the asymmetry doesn't depend on the reader inferring it from the example:

  > `composes` parents are typically deps-only (no `include:`) — they exist purely to aggregate child verdicts. `requires` parents typically declare their own `include:` since they represent an action with its own scope (deploy manifests, image layers, release artifacts).

`#### Parent's own scope` stays unchanged — it already documents the spec allowance correctly; this PR is about practice/convention.

## Test plan

- [ ] Read the Gate dependencies section end-to-end. Confirm the example reads as "summary gate (deps-only) vs action gate (own include)" without inviting a spec-restriction misread.
- [ ] Confirm "Which one should I use?" now reads composes/requires as a use-case decision (summary vs action) backed by a convention sentence, not just a `set` semantic difference.
- [ ] Spot-check that anchors / table links pointing at `requires` / `composes` keep resolving.