### PR TITLE
test: cover composes/requires with own include

### DIFF
--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -498,6 +498,57 @@ code=$?
 assert_eq "requires set refuses stale-child exit=2" "2" "$code"
 assert_contains "requires error names offending child" "migration" "$out"
 
+cyan "=== #28 composes + parent include ==="
+new_repo
+cat > .markgate.yml <<'EOF'
+gates:
+  child: { hash: files, include: ["src/**"] }
+  pr:
+    hash: files
+    include: ["docs/**"]
+    composes: [child]
+EOF
+$MG set child >/dev/null 2>&1
+$MG set pr >/dev/null 2>&1
+$MG verify pr >/dev/null 2>&1
+assert_eq "composes+include verify all-match exit=0" "0" "$?"
+
+# Parent's own scope changes → verify mismatch (child still fresh).
+echo z >> docs/README.md
+$MG verify pr >/dev/null 2>&1
+assert_eq "composes+include verify parent-scope-stale exit=1" "1" "$?"
+
+cyan "=== #28 requires + parent include ==="
+new_repo
+cat > .markgate.yml <<'EOF'
+gates:
+  migration: { hash: files, include: ["src/**"] }
+  deploy:
+    hash: files
+    include: ["docs/**"]
+    requires: [migration]
+EOF
+$MG set migration >/dev/null 2>&1
+$MG set deploy >/dev/null 2>&1
+$MG verify deploy >/dev/null 2>&1
+assert_eq "requires+include verify all-match exit=0" "0" "$?"
+
+# Parent's own scope changes → verify mismatch.
+echo z >> docs/README.md
+$MG verify deploy >/dev/null 2>&1
+assert_eq "requires+include verify parent-scope-stale exit=1" "1" "$?"
+
+# set parent ignores parent's own digest — succeeds with fresh child.
+$MG set deploy >/dev/null 2>&1
+assert_eq "requires+include set parent succeeds with fresh child" "0" "$?"
+
+# Stale child → set parent refused (regardless of parent's own include).
+echo w >> src/a.go
+out=$($MG set deploy 2>&1)
+code=$?
+assert_eq "requires+include set refuses with stale child exit=2" "2" "$code"
+assert_contains "requires+include set error names child" "migration" "$out"
+
 cyan "=== #28 config-load errors ==="
 
 cat > .markgate.yml <<'EOF'


### PR DESCRIPTION
## Summary

The existing `#28 composes (loose)` and `#28 requires (strict)` e2e sections only exercised deps-only parents (no `include:` on the parent). The "Parent's own scope" feature — where the parent declares its own `include:` so its digest is computed and ANDed with the children — is documented in `#### Parent's own scope` but had no regression coverage.

Add two new sections after `#28 requires (strict)`:

- **`#28 composes + parent include`** (2 assertions)
  - verify passes when child is fresh and the parent's own scope is unchanged
  - verify fails when the parent's own scope changes (child still fresh) — the parent's own digest mismatches even though the composed dependency is OK

- **`#28 requires + parent include`** (5 assertions)
  - verify passes when all fresh
  - verify fails when the parent's own scope changes
  - `set parent` succeeds with a fresh child even if the parent's own scope has changed since the last marker (set ignores the parent's own digest — it just records the current state)
  - `set parent` is refused (exit 2) when the child is stale, regardless of the parent's own include state
  - the refusal error still names the offending child

Total assertions: 91 → 98.

## Test plan

- [x] `bash .claude/scripts/e2e.sh` — all 98 assertions pass (was 91 before, +7)
- [ ] Re-read the new sections to confirm they fail loudly if the spec drifts (e.g., if `set` ever started caring about the parent's own digest, the "set parent succeeds with fresh child" assertion would catch it)