### PR TITLE
docs: add overview table to 'What markgate does'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ operation with a pass/fail outcome. markgate addresses each with
 one of two primitives — `markgate run` (one-shot) or `markgate
 set` + `markgate verify` (the Gate pattern).
 
+| Pattern | Failure mode addressed | Mechanism |
+| --- | --- | --- |
+| 1 | Forgetting & duplicate execution | `markgate run` |
+| 2 | Hooks can't execute non-command tasks | `markgate set` + `markgate verify` |
+| 3 | Multi-task scope leak + N verify clutter | `.markgate.yml` with `composes` |
+
 ### Pattern 1: ensure non-duplicate runs (`markgate run`)
 
 You tell your coding agent to run `/check` (test, lint, build, doc


### PR DESCRIPTION
## Summary

Add a TL;DR overview table right after the "What markgate does" intro paragraph, so the mapping of `Pattern → Failure mode → Mechanism` is readable at a glance:

```markdown
| Pattern | Failure mode addressed | Mechanism |
| --- | --- | --- |
| 1 | Forgetting & duplicate execution | `markgate run` |
| 2 | Hooks can't execute non-command tasks | `markgate set` + `markgate verify` |
| 3 | Multi-task scope leak + N verify clutter | `.markgate.yml` with `composes` |
```

The intro paragraph already names the three failure modes and the two primitives in prose, but the per-pattern mapping is only visible after reading all three Pattern subsections. The table front-loads that mapping without changing the prose.

The Japanese blog post (`ja_zenn.md`) carries a parallel table — this brings the README to parity.

## Test plan

- [ ] Read the section opening (intro → table → Pattern 1). Confirm the table reads as a TL;DR, not a duplicate of the prose.
- [ ] Confirm the row text matches each Pattern subsection's framing (Pattern 1 = forgetting / duplicate execution, Pattern 2 = non-command tasks, Pattern 3 = scope leak + N verify clutter).