### PR TITLE
docs: align overview table rows with Pattern subsection headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ operation with a pass/fail outcome. markgate addresses each with
 one of two primitives — `markgate run` (one-shot) or `markgate
 set` + `markgate verify` (the Gate pattern).
 
-| Pattern | Failure mode addressed | Mechanism |
+| Pattern | Goal | Mechanism |
 | --- | --- | --- |
-| 1 | Forgetting & duplicate execution | `markgate run` |
-| 2 | Hooks can't execute non-command tasks | `markgate set` + `markgate verify` |
-| 3 | Multi-task scope leak + N verify clutter | `.markgate.yml` with `composes` |
+| 1 | Ensure non-duplicate runs | `markgate run` |
+| 2 | Enforce non-command tasks | `markgate set` + `markgate verify` |
+| 3 | Scope each task & aggregate the verdict | `.markgate.yml` with `composes` |
 
 ### Pattern 1: ensure non-duplicate runs (`markgate run`)
 


### PR DESCRIPTION
## Summary

Follow-up to #59. The overview table I added there used failure-mode phrasing in the rows, which didn't match the goal/action phrasing each Pattern subsection heading uses:

| | Pattern heading (existing) | Old table row (#59) |
|---|---|---|
| 1 | "ensure non-duplicate runs" | "Forgetting & duplicate execution" |
| 2 | "enforce non-command tasks" | "Hooks can't execute non-command tasks" |
| 3 | "scope each task to its files, aggregate the verdict" | "Multi-task scope leak + N verify clutter" |

A reader scrolling from the table into Pattern 1 hit a label mismatch and had to mentally map.

Rename the column header to **Goal** and rewrite each row to mirror its Pattern subsection heading:

```markdown
| Pattern | Goal | Mechanism |
| --- | --- | --- |
| 1 | Ensure non-duplicate runs | `markgate run` |
| 2 | Enforce non-command tasks | `markgate set` + `markgate verify` |
| 3 | Scope each task & aggregate the verdict | `.markgate.yml` with `composes` |
```

The Japanese blog (`ja_zenn.md`) already pairs its parallel table this way (section name == row text), so this brings the README to the same internal consistency.

## Test plan

- [ ] Read intro → table → Pattern 1 heading. Confirm "Ensure non-duplicate runs" in the table reads identically to the Pattern 1 subsection heading.
- [ ] Same for Pattern 2 / Pattern 3 rows.