### PR TITLE
docs: separate 'challenges' from 'markgate's patterns' in intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ enforce **non-command tasks** (e.g., LLM review), and aggregate
 
 ## What markgate does
 
-Coding agents forget — context loss, token pressure, hurry. Hooks
-help, but have three failure modes when you want an AI coding
-agent to reliably run a required task — a check (lint, test,
+Coding agents forget — context loss, token pressure, hurry.
+Wiring hooks to reliably run a required task (a check (lint, test,
 build), an LLM-judged review, a code-generation step, or any
-operation with a pass/fail outcome. markgate addresses each with
-one of two primitives — `markgate run` (one-shot) or `markgate
-set` + `markgate verify` (the Gate pattern).
+operation with a pass/fail outcome) runs into **three recurring
+challenges**. markgate addresses these with **three patterns**,
+each backed by one of **two primitives** — `markgate run`
+(one-shot) or `markgate set` + `markgate verify` (the Gate
+pattern).
 
 | Pattern | Goal | Mechanism |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

Follow-up to #59 / #60. After the overview table landed (`Pattern | Goal | Mechanism`), the intro paragraph still framed the structure as **"three failure modes"** and left it implicit that the **three patterns** are markgate's design (not generic patterns observed in hook adoption). That made the paragraph read at odds with the table — failure tone in prose vs. Goal framing in the rows, and "three patterns" was ambiguous (markgate's? or typical?).

Rewrite the paragraph so the problem and the solution use distinct nouns and the 1:1 mapping is explicit:

```diff
- Coding agents forget — context loss, token pressure, hurry. Hooks
- help, but have three failure modes when you want an AI coding
- agent to reliably run a required task — a check (lint, test,
- build), an LLM-judged review, a code-generation step, or any
- operation with a pass/fail outcome. markgate addresses each with
- one of two primitives — `markgate run` (one-shot) or `markgate
- set` + `markgate verify` (the Gate pattern).
+ Coding agents forget — context loss, token pressure, hurry.
+ Wiring hooks to reliably run a required task (a check (lint, test,
+ build), an LLM-judged review, a code-generation step, or any
+ operation with a pass/fail outcome) runs into **three recurring
+ challenges**. markgate addresses these with **three patterns**,
+ each backed by one of **two primitives** — `markgate run`
+ (one-shot) or `markgate set` + `markgate verify` (the Gate
+ pattern).
```

Now:
- **three recurring challenges** — the problem (generic to hook adoption around an AI coding agent).
- **three patterns** — markgate's design (each targets one challenge).
- The 1:1 mapping is stated explicitly ("addresses these with three patterns"), which is what the table visualizes.

The em-dash list of example tasks moves into parentheses so the main clause stays focused on "wiring hooks ... runs into three recurring challenges."

## Test plan

- [ ] Read intro paragraph → table. Confirm "challenges" (paragraph) maps cleanly to the rows' "Goal" (since each pattern has a goal that addresses one challenge), and "three patterns" reads as markgate's own design rather than typical patterns.