### PR TITLE
docs: fix Pattern 2 overstatement that 'a hook can't execute' LLM skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ shape is identical — see [Drop into your hook manager](#drop-into-your-hook-ma
 Some tasks aren't commands. "Did `/check-docs` find docs out of
 sync with src?" "Did `/investigate-aws` find anything wrong?" An
 LLM-led skill can work through these — judging, investigating, or
-updating step by step — but a hook can't execute any of it. So when
+updating step by step. You want the **agent's own session** to do
+this work, where its built-up context, the files it has open, and
+its prior decisions are already in play. (A hook could technically
+shell out to `claude -p`, but that runs in a fresh context, costs
+extra tokens, and bypasses the skill's iteration loop.) So when
 the agent forgets or skips the task, the hook has no grip on
 whether it actually happened.
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ Some tasks aren't commands. "Did `/check-docs` find docs out of
 sync with src?" "Did `/investigate-aws` find anything wrong?" An
 LLM-led skill can work through these — judging, investigating, or
 updating step by step. You want the **agent's own session** to do
-this work, where its built-up context, the files it has open, and
-its prior decisions are already in play. (A hook could technically
-shell out to `claude -p`, but that runs in a fresh context, costs
-extra tokens, and bypasses the skill's iteration loop.) So when
-the agent forgets or skips the task, the hook has no grip on
+this work, where its built-up context (conversation history, open
+files, prior decisions) is already in play. (A hook could
+technically shell out to `claude -p`, but that runs in a fresh
+context, so the agent's prior state isn't there to build on.) So
+when the agent forgets or skips the task, the hook has no grip on
 whether it actually happened.
 
 `markgate set` + `markgate verify` give the hook a grip by splitting


### PR DESCRIPTION
## Summary

Pattern 2 currently says "a hook can't execute any of it," which is an overstatement — a hook *can* shell out to `claude -p "/check-docs"`, and that *is* a command a hook can run. A power-user reading the README would immediately push back.

The real blocker is the **value of the agent's own session**:

- The agent has built-up context (conversation, files open, decisions made) that a fresh `claude -p` invocation doesn't see.
- Each `claude -p` costs extra tokens.
- The skill's own iteration loop (multi-turn reasoning) is bypassed when a hook invokes it as a one-shot.

Rewrite the paragraph so the motivation comes through, and acknowledge `claude -p` directly in a parenthetical so readers who would have asked are answered up-front:

```diff
- Some tasks aren't commands. "Did `/check-docs` find docs out of
- sync with src?" "Did `/investigate-aws` find anything wrong?" An
- LLM-led skill can work through these — judging, investigating, or
- updating step by step — but a hook can't execute any of it. So when
- the agent forgets or skips the task, the hook has no grip on
- whether it actually happened.
+ Some tasks aren't commands. "Did `/check-docs` find docs out of
+ sync with src?" "Did `/investigate-aws` find anything wrong?" An
+ LLM-led skill can work through these — judging, investigating, or
+ updating step by step. You want the **agent's own session** to do
+ this work, where its built-up context, the files it has open, and
+ its prior decisions are already in play. (A hook could technically
+ shell out to `claude -p`, but that runs in a fresh context, costs
+ extra tokens, and bypasses the skill's iteration loop.) So when
+ the agent forgets or skips the task, the hook has no grip on
+ whether it actually happened.
```

The closing sentence ("So when the agent forgets or skips the task...") stays — that's the motivating gap for the `set` + `verify` split immediately below.

## Test plan

- [ ] Read Pattern 2 intro end-to-end. Confirm the new wording answers the "but I can run `claude -p` from a hook, right?" objection in passing, rather than provoking it.
- [ ] Confirm the closing transition into `set` + `verify` still reads cleanly.