### PR TITLE
feat(hasher): add hash: diff so base-branch churn stops invalidating markers

### DIFF
--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -579,6 +579,115 @@ EOF
 $MG verify a >/dev/null 2>&1
 assert_eq "composes+requires rejected exit=2" "2" "$?"
 
+cyan "=== #68 hash: diff (base-branch churn) ==="
+new_repo
+
+printf 'l1\nl2\nl3\nl4\nl5\n' > src/a.go
+printf 'b1\nb2\nb3\nb4\nb5\n' > src/b.go
+cat > .markgate.yml <<'EOF'
+gates:
+  integ:
+    hash: diff
+    base: main
+    include:
+      - "src/**"
+EOF
+git add -A && git commit -qm "diff fixture" >/dev/null
+git checkout -q -b feat
+printf 'MINE\nl2\nl3\nl4\nl5\n' > src/a.go
+git commit -qam "my work" >/dev/null
+
+$MG set integ >/dev/null 2>&1
+assert_eq "diff: set on a branch ahead of base exit=0" "0" "$?"
+
+$MG verify integ >/dev/null 2>&1
+assert_eq "diff: verify after set exit=0" "0" "$?"
+
+out=$($MG status integ 2>&1)
+assert_contains "diff: status records the base ref" "base:       main" "$out"
+assert_contains "diff: status records the merge base" "merge base:" "$out"
+
+# An unrelated in-scope file changes on the base branch and is merged in.
+git checkout -q main
+printf 'b1\nb2\nb3\nb4\nBASE\n' > src/b.go
+git commit -qam "unrelated base work" >/dev/null
+git checkout -q feat
+git merge -q --no-edit main >/dev/null
+$MG verify integ >/dev/null 2>&1
+assert_eq "diff: unrelated base-branch change stays fresh exit=0" "0" "$?"
+
+# The base branch touches a file this branch also changed.
+git checkout -q main
+printf 'l1\nl2\nl3\nl4\nBASE\n' > src/a.go
+git commit -qam "base touches my file" >/dev/null
+git checkout -q feat
+git merge -q --no-edit main >/dev/null
+$MG verify integ >/dev/null 2>&1
+assert_eq "diff: same-file base-branch change goes stale exit=1" "1" "$?"
+
+$MG set integ >/dev/null 2>&1
+printf 'l1\nl2\nEDITED\nl4\nl5\n' > src/a.go
+$MG verify integ >/dev/null 2>&1
+assert_eq "diff: uncommitted in-scope edit exit=1" "1" "$?"
+
+$MG set integ >/dev/null 2>&1
+echo "out of scope" > docs/README.md
+$MG verify integ >/dev/null 2>&1
+assert_eq "diff: out-of-scope edit stays fresh exit=0" "0" "$?"
+
+echo "new file" > src/untracked.go
+$MG verify integ >/dev/null 2>&1
+assert_eq "diff: untracked in-scope file exit=1" "1" "$?"
+rm src/untracked.go
+git checkout -q -- docs/README.md src/a.go
+
+# Clean base-branch checkout: empty delta, constant digest -> refuse.
+git checkout -q main
+out=$($MG verify integ 2>&1)
+code=$?
+assert_eq "diff: clean base branch errors exit=2" "2" "$code"
+assert_contains "diff: base-branch error names hash=diff" "hash=diff" "$out"
+out=$($MG set integ 2>&1)
+assert_eq "diff: set on the base branch errors exit=2" "2" "$?"
+
+# Bare status keeps listing instead of aborting on the unusable gate.
+out=$($MG status 2>&1)
+assert_contains "diff: bare status still renders the row" "integ" "$out"
+
+git checkout -q feat
+out=$($MG verify integ --base origin/never-fetched 2>&1)
+assert_eq "diff: unresolvable base errors exit=2" "2" "$?"
+assert_contains "diff: unresolvable base names the ref" "never-fetched" "$out"
+
+$MG set flagged --hash diff --base main >/dev/null 2>&1
+assert_eq "diff: --hash diff --base flags exit=0" "0" "$?"
+$MG set flagless --hash diff >/dev/null 2>&1
+assert_eq "diff: --hash diff without --base exit=2" "2" "$?"
+$MG set nondiff --base main >/dev/null 2>&1
+assert_eq "diff: --base without hash=diff exit=2" "2" "$?"
+
+cat > .markgate.yml <<'EOF'
+gates:
+  integ:
+    hash: diff
+    include:
+      - "src/**"
+EOF
+$MG verify integ >/dev/null 2>&1
+assert_eq "diff: config without base rejected exit=2" "2" "$?"
+
+cat > .markgate.yml <<'EOF'
+gates:
+  scan:
+    hash: files
+    base: main
+    include:
+      - "src/**"
+EOF
+out=$($MG config lint 2>&1)
+assert_eq "diff: base on a files gate lints dirty exit=1" "1" "$?"
+assert_contains "diff: lint explains base misuse" "base is only valid with hash=diff" "$out"
+
 # ─────────────────────────────────────────────────────────────────
 echo
 cyan "=== summary ==="

--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -3,9 +3,15 @@
 #
 # Covers (a) the original primitives — set / verify / clear / run /
 # init / version, default key, --hash files + --include, --state-dir
-# override, env-var override — and (b) the six features added in the
+# override, env-var override — (b) the six features added in the
 # 2026-05-09 batch: shell completion, config lint, TTL, --explain,
-# bare status, and gate dependencies (composes / requires).
+# bare status, and gate dependencies (composes / requires) — and
+# (c) the hash: diff strategy (#68): base-branch churn staying fresh,
+# same-file churn going stale, the empty-delta and unresolvable-base
+# refusals, flag and config validation.
+#
+# The assertion COUNT is printed by the summary and deliberately not
+# repeated in prose anywhere: it drifted by 14 the last time it was.
 #
 # This script is invoked manually via the `verify-e2e` skill and
 # automatically by the e2e-pre-merge hook (which wraps it in
@@ -650,9 +656,12 @@ assert_contains "diff: base-branch error names hash=diff" "hash=diff" "$out"
 out=$($MG set integ 2>&1)
 assert_eq "diff: set on the base branch errors exit=2" "2" "$?"
 
-# Bare status keeps listing instead of aborting on the unusable gate.
+# Bare status keeps listing instead of aborting on the unusable gate:
+# the healthy gate must still appear alongside the refusing one.
+$MG set healthy --hash files --include "src/**" >/dev/null 2>&1
 out=$($MG status 2>&1)
-assert_contains "diff: bare status still renders the row" "integ" "$out"
+assert_contains "diff: bare status still renders the diff row" "integ" "$out"
+assert_contains "diff: bare status keeps rendering other gates" "healthy" "$out"
 
 git checkout -q feat
 out=$($MG verify integ --base origin/never-fetched 2>&1)
@@ -661,8 +670,11 @@ assert_contains "diff: unresolvable base names the ref" "never-fetched" "$out"
 
 $MG set flagged --hash diff --base main >/dev/null 2>&1
 assert_eq "diff: --hash diff --base flags exit=0" "0" "$?"
-$MG set flagless --hash diff >/dev/null 2>&1
+out=$($MG set flagless --hash diff 2>&1)
 assert_eq "diff: --hash diff without --base exit=2" "2" "$?"
+# Names the flag, so the assertion still fails if the eager validation
+# is removed and the error arrives later from merge-base resolution.
+assert_contains "diff: missing --base names the flag" "requires --base" "$out"
 $MG set nondiff --base main >/dev/null 2>&1
 assert_eq "diff: --base without hash=diff exit=2" "2" "$?"
 

--- a/.claude/skills/verify-e2e/SKILL.md
+++ b/.claude/skills/verify-e2e/SKILL.md
@@ -28,9 +28,9 @@ the manual entry point and a good rehearsal step before pushing.
 
 ## What it covers
 
-119 assertions across three layers:
+Three layers of assertions (the script prints the count on every run; it is deliberately not restated here, because a number copied into prose drifts):
 
-**Core primitives (37 assertions)**
+**Core primitives**
 
 - `set` / `verify` / `clear` cycle including `clear` idempotency
 - Default key (no positional arg) → `default`
@@ -43,7 +43,7 @@ the manual entry point and a good rehearsal step before pushing.
 - `init` writes `.markgate.yml` and is non-clobbering
 - `version` prints something
 
-**2026-05-09 batch features (61 assertions)**
+**2026-05-09 batch features**
 
 - `completion`: bash script emit, unknown-shell exit=2, dynamic
   gate-key completion via `__complete`
@@ -61,7 +61,7 @@ the manual entry point and a good rehearsal step before pushing.
 - Config-load errors: cycle / missing child / both fields set
   all reject at exit=2
 
-**`hash: diff` (21 assertions)**
+**`hash: diff`**
 
 - set / verify on a branch ahead of the base; `status` records the
   base ref and the resolved merge base
@@ -84,7 +84,7 @@ The hook wraps the script in `go run ./cmd/markgate run
 hook-e2e-pre-merge -- bash .claude/scripts/e2e.sh`, so:
 
 - **First run after a source change**: full ~10–15s execution
-  (build + 119 assertions, the script does its own `go build` to
+  (build + every assertion, the script does its own `go build` to
   the temp dir).
 - **Repeat run with no source change**: ~0.1s skip, marker hit.
 
@@ -95,7 +95,7 @@ any source change invalidates it.
 ## Running it
 
 ```sh
-bash .claude/scripts/e2e.sh             # full run, 119 PASS lines + summary
+bash .claude/scripts/e2e.sh             # full run, one PASS line per assertion + summary
 QUIET=1 bash .claude/scripts/e2e.sh     # only print section headers + failures
 ```
 

--- a/.claude/skills/verify-e2e/SKILL.md
+++ b/.claude/skills/verify-e2e/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-e2e
-description: Run the markgate end-to-end CLI verification script (`.claude/scripts/e2e.sh`). It exercises the full CLI surface — original primitives (set / verify / clear / run / init / version, default key, --hash files + --include, --state-dir, env-var, precedence) plus every feature added in the 2026-05-09 batch (completion, config lint, TTL, --explain, bare status, composes / requires). Wraps the script in `markgate run` so unchanged repos skip the run. Use whenever you want to confirm "all features still work" before declaring done, opening a PR, or merging — or when your changes touch the CLI surface and you want a quick smoke before pushing.
+description: Run the markgate end-to-end CLI verification script (`.claude/scripts/e2e.sh`). It exercises the full CLI surface — original primitives (set / verify / clear / run / init / version, default key, --hash files + --include, --state-dir, env-var, precedence) plus every feature added in the 2026-05-09 batch (completion, config lint, TTL, --explain, bare status, composes / requires) and the hash: diff strategy. Wraps the script in `markgate run` so unchanged repos skip the run. Use whenever you want to confirm "all features still work" before declaring done, opening a PR, or merging — or when your changes touch the CLI surface and you want a quick smoke before pushing.
 ---
 
 # verify-e2e
@@ -28,9 +28,9 @@ the manual entry point and a good rehearsal step before pushing.
 
 ## What it covers
 
-84 assertions across two layers:
+119 assertions across three layers:
 
-**Pre-existing primitives (33 assertions)**
+**Core primitives (37 assertions)**
 
 - `set` / `verify` / `clear` cycle including `clear` idempotency
 - Default key (no positional arg) → `default`
@@ -43,7 +43,7 @@ the manual entry point and a good rehearsal step before pushing.
 - `init` writes `.markgate.yml` and is non-clobbering
 - `version` prints something
 
-**2026-05-09 batch features (51 assertions)**
+**2026-05-09 batch features (61 assertions)**
 
 - `completion`: bash script emit, unknown-shell exit=2, dynamic
   gate-key completion via `__complete`
@@ -61,13 +61,30 @@ the manual entry point and a good rehearsal step before pushing.
 - Config-load errors: cycle / missing child / both fields set
   all reject at exit=2
 
+**`hash: diff` (21 assertions)**
+
+- set / verify on a branch ahead of the base; `status` records the
+  base ref and the resolved merge base
+- unrelated base-branch change merged in -> still fresh; a change to
+  a file the branch also touched -> stale
+- uncommitted in-scope edit / untracked in-scope file -> stale;
+  out-of-scope edit -> fresh
+- clean base-branch checkout -> `verify` and `set` both exit=2
+  naming `hash=diff`; bare `status` degrades the row instead of
+  aborting the listing
+- unresolvable base -> exit=2 naming the ref
+- `--hash diff --base` flags; `--hash diff` without `--base` and
+  `--base` without `hash=diff` both exit=2
+- config without `base` rejected; `base` on a `files` gate lints
+  dirty with an explanatory message
+
 ## How it caches
 
 The hook wraps the script in `go run ./cmd/markgate run
 hook-e2e-pre-merge -- bash .claude/scripts/e2e.sh`, so:
 
 - **First run after a source change**: full ~10–15s execution
-  (build + 84 assertions, the script does its own `go build` to
+  (build + 119 assertions, the script does its own `go build` to
   the temp dir).
 - **Repeat run with no source change**: ~0.1s skip, marker hit.
 
@@ -78,7 +95,7 @@ any source change invalidates it.
 ## Running it
 
 ```sh
-bash .claude/scripts/e2e.sh             # full run, 84 PASS lines + summary
+bash .claude/scripts/e2e.sh             # full run, 119 PASS lines + summary
 QUIET=1 bash .claude/scripts/e2e.sh     # only print section headers + failures
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,11 @@ it is the spec — see "README as a spec" below.
   `Config.Gate(key)`).
 - `internal/state/` — marker read / write. Atomic save via temp-file +
   fsync + rename. Callers never touch files directly.
-- `internal/hasher/` — `GitTree` and `Files` strategies implement
-  `Hasher`.
+- `internal/hasher/` — `GitTree`, `Files` and `Diff` strategies
+  implement `Hasher`.
 - `internal/gitutil/` — `git rev-parse` wrappers (top-level, git-dir,
-  HEAD SHA).
+  HEAD SHA), merge-base resolution, and the raw working-tree delta a
+  `hash: diff` gate digests.
 - `internal/key/` — key syntax validation (`[a-z0-9][a-z0-9-]*`).
 
 ## Design principles
@@ -165,7 +166,7 @@ message to a temp file first sidesteps all shell escaping.
   (expensive to unwind). Exits 2 with a message pointing at the fix
   (`git checkout -b <feature-branch>`).
 - `hooks/e2e-pre-merge.sh` is a PreToolUse hook on Bash: before any
-  `gh pr merge ...` it runs `.claude/scripts/e2e.sh` (the full 84-
+  `gh pr merge ...` it runs `.claude/scripts/e2e.sh` (the full 119-
   assertion CLI smoke), wrapped in `markgate run` so unchanged
   repos skip in ~0.1s. Failure exits 2 and blocks the merge. The
   same script is invokable manually via the `verify-e2e` skill.
@@ -174,8 +175,9 @@ message to a temp file first sidesteps all shell escaping.
   (set / verify / clear / run / init / version, default key,
   `--hash files`, `--state-dir`, env-var, precedence) and every
   feature added in the 2026-05-09 batch (completion, config lint,
-  TTL, `--explain`, bare status, composes / requires). 84 PASS on
-  green; exit code = number of failures.
+  TTL, `--explain`, bare status, composes / requires) plus
+  `hash: diff` (#68). 119 PASS on green; exit code = number of
+  failures.
 
 ### How the dogfood works (no install needed)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,8 +166,8 @@ message to a temp file first sidesteps all shell escaping.
   (expensive to unwind). Exits 2 with a message pointing at the fix
   (`git checkout -b <feature-branch>`).
 - `hooks/e2e-pre-merge.sh` is a PreToolUse hook on Bash: before any
-  `gh pr merge ...` it runs `.claude/scripts/e2e.sh` (the full 119-
-  assertion CLI smoke), wrapped in `markgate run` so unchanged
+  `gh pr merge ...` it runs `.claude/scripts/e2e.sh` (the full
+  black-box CLI smoke), wrapped in `markgate run` so unchanged
   repos skip in ~0.1s. Failure exits 2 and blocks the merge. The
   same script is invokable manually via the `verify-e2e` skill.
 - `scripts/e2e.sh` is the black-box CLI smoke (built binary +
@@ -176,8 +176,9 @@ message to a temp file first sidesteps all shell escaping.
   `--hash files`, `--state-dir`, env-var, precedence) and every
   feature added in the 2026-05-09 batch (completion, config lint,
   TTL, `--explain`, bare status, composes / requires) plus
-  `hash: diff` (#68). 119 PASS on green; exit code = number of
-  failures.
+  `hash: diff` (#68). The script's summary prints the assertion count;
+  exit code = number of failures. Do not restate the count here — it
+  has no way to stay in sync and has already drifted once.
 
 ### How the dogfood works (no install needed)
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Per-gate fields:
 | field | purpose |
 | --- | --- |
 | `hash` | `git-tree` (default), `files`, or `diff` |
-| `include` | glob list; required for `hash: files` |
+| `include` | glob list; required for `hash: files`, optional for `hash: diff` (omitted = the branch's whole delta) |
 | `exclude` | glob list |
 | `base` | ref a `hash: diff` gate measures its delta from (e.g. `origin/main`); required there, rejected everywhere else — see [Hashing strategies](#hashing-strategies-git-tree-vs-files-vs-diff) |
 | `state_dir` | optional override of marker storage location — see [Sharing markers](#sharing-markers-across-machines-ci--teammates) |
@@ -569,6 +569,7 @@ The `hash` field above picks one of three strategies:
 | Changes pulled from the base branch invalidate? | Yes | Yes, if in scope | Only for files you also changed |
 | `.gitignore` respected? | Yes (automatic) | No — scope is explicit | Yes (untracked-not-ignored) |
 | Needs config? | No | Yes (`include` required) | Yes (`base` required) |
+| Strictness | Strictest | Narrowed to your globs | **Least strict** — a base-branch change your branch does not touch is trusted unverified; see the limitation below |
 
 When to use which:
 
@@ -582,7 +583,10 @@ When to use which:
 - **`diff`** = "re-verify only when *my branch's* changes move".
   Expensive gates on long-lived branches, where most invalidations
   come from merging an updated base branch rather than from your own
-  work.
+  work. It is the **least strict** of the three and the only one that
+  can call a state fresh that was never verified in that exact
+  combination — adopt it deliberately, after reading
+  [what it does not catch](#hash-diff--ignore-changes-that-arrive-from-the-base-branch).
 
 Rule of thumb: start with `git-tree` (add `exclude` if needed).
 Reach for `files` only when you specifically want the "ignore
@@ -657,8 +661,11 @@ disk — never from the text `git diff` prints, which moves with
 other per-user settings. Two machines holding the same content
 therefore agree on the digest, which is what makes a `diff` gate safe
 to share (see [Sharing markers](#sharing-markers-across-machines-ci--teammates)).
-Binary files are compared as bytes, and a mode-only change (`chmod`)
-adds the path to the delta and invalidates.
+Binary files are compared as bytes. A mode-only change (`chmod`) on a
+path that was not already in the delta adds it and invalidates; on a
+path the branch had already modified it does not, because markgate
+hashes content and never permission bits (`hash: files` and
+`git-tree` ignore mode entirely).
 
 `ttl`, `composes`, and `requires` are **optional** — the basic
 gate pattern works without them. Skip the rest of this section
@@ -1033,11 +1040,11 @@ marker is **committed** to the repo.
 | aspect | **A. Not committed** (CI cache / artifact) | **B. Committed** |
 | --- | --- | --- |
 | Marker in the repo? | No (typically gitignored, or outside the repo) | Yes, tracked in git |
-| Works with hash type | any | **`files` or `diff`** — committing with `git-tree` breaks: the commit changes HEAD → digest is instantly stale |
+| Works with hash type | any | **`files`, or `diff` with the state dir out of scope** — committing with `git-tree` breaks: the commit changes HEAD → digest is instantly stale |
 | Local → CI sharing | Needs CI cache / artifact / shared volume | Just `git push` |
 | Tamper surface | Whoever can write to the cache | Whoever has commit access |
 | Extra infra | CI cache provider (e.g. `actions/cache`, `actions/upload-artifact`) | None — git is enough |
-| Best for | CI-internal reuse across runs; teams already on remote cache infra | Zero-infra local→CI sharing for `files`-hash gates (coverage, scans) |
+| Best for | CI-internal reuse across runs; teams already on remote cache infra | Zero-infra local→CI sharing for scoped gates (coverage, scans) |
 
 ### A. Not committed (CI cache / artifact)
 
@@ -1045,13 +1052,15 @@ Store the marker somewhere CI can pick it up, but keep it out of git.
 `.markgate-cache/` at the repo root is a conventional choice; any
 path outside `.git/` works. (If you'd rather commit the marker into
 git so CI sees it without any cache layer, skip to
-[Pattern B](#b-committed-files-hash) — that's a different shape, not
+[Pattern B](#b-committed-scoped-hash) — that's a different shape, not
 a variant of this one.)
 
 #### Step 1. Add the state dir to `.gitignore`
 
-**This is a required setup step on `hash: git-tree`, not optional
-hygiene.** Do this *before* your first `markgate run`:
+**This is a required setup step on `hash: git-tree` — and on any
+`hash: diff` gate whose `include`/`exclude` does not keep the state dir
+out of the delta — not optional hygiene.** Do this *before* your first
+`markgate run`:
 
 ```gitignore
 # .gitignore — add the state dir you chose
@@ -1062,8 +1071,9 @@ You can skip this only if:
 
 - the state dir is **outside the repo** (e.g. `$RUNNER_TEMP/mg`,
   `/tmp/mg`, `$HOME/.cache/markgate`), **or**
-- you're on `hash: files` (gitignore then becomes hygiene, not
-  required — see why below).
+- you're on `hash: files`, or on a `hash: diff` gate whose
+  `include`/`exclude` keeps the state dir out of the delta (gitignore
+  then becomes hygiene, not required — see why below).
 
 <details>
 <summary>Why it's required on <code>hash: git-tree</code> (click to expand)</summary>
@@ -1085,6 +1095,12 @@ Gitignoring the state dir keeps the marker out of the digest.
 `hash: files` sidesteps this: the marker is only in the digest if an
 `include` glob matches it, which it normally won't. That's why
 gitignore is optional on `files`.
+
+`hash: diff` sidesteps it the same way **when the gate is scoped** —
+the marker is an untracked file, so it lands in the branch's delta
+unless `include`/`exclude` filters it out. An unscoped diff gate (no
+`include`) behaves exactly like `git-tree` here, so gitignore the
+state dir or scope the gate.
 
 </details>
 
@@ -1141,11 +1157,19 @@ jobs:
       - run: markgate verify expensive --state-dir .markgate-cache || make expensive-check
 ```
 
-### B. Committed (files hash)
+### B. Committed (scoped hash)
 
 Keep the state directory **tracked in git** and commit the marker with
-the code. Works only with `hash: files`: `git-tree` would change HEAD
-on the commit and invalidate the marker it just wrote.
+the code. Requires a hash type that ignores the commit itself:
+
+- **`hash: files`** — always safe: the marker is only in the digest if
+  an `include` glob matches it.
+- **`hash: diff`** — safe as long as `include`/`exclude` keeps the
+  state dir out of the branch's delta. An *unscoped* diff gate (no
+  `include`) folds the marker into its own delta and self-invalidates
+  the moment it is written, exactly as `git-tree` does.
+- **`hash: git-tree`** — breaks: the commit changes HEAD and
+  invalidates the marker it just wrote.
 
 Typical fit: coverage reports, image vulnerability scans — expensive,
 deterministic, and already re-running them on every push is waste

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ strict variant (`requires`) that refuses `set` on a stale child.
 ## Use cases
 
 Each section follows the same shape: **Scope** (what triggers
-re-verify — a [`hash`](#hashing-strategies-git-tree-vs-files)
+re-verify — a [`hash`](#hashing-strategies-git-tree-vs-files-vs-diff)
 strategy) → **Commands** (what goes in your shell / hook). All
 examples below use scoped `files`-hash gates defined in
 [`.markgate.yml`](#markgateyml-reference) at the repo root, and the
@@ -513,16 +513,17 @@ markgate init --force  # overwrite an existing one
 ```
 
 The generated file enables the `default` gate with `git-tree` hash,
-plus commented-out examples (an `exclude` list on `git-tree` and a
-`files`-type gate) — uncomment what you need.
+plus commented-out examples (an `exclude` list on `git-tree`, a
+`files`-type gate, and a `diff`-type gate) — uncomment what you need.
 
 Per-gate fields:
 
 | field | purpose |
 | --- | --- |
-| `hash` | `git-tree` (default) or `files` |
+| `hash` | `git-tree` (default), `files`, or `diff` |
 | `include` | glob list; required for `hash: files` |
 | `exclude` | glob list |
+| `base` | ref a `hash: diff` gate measures its delta from (e.g. `origin/main`); required there, rejected everywhere else — see [Hashing strategies](#hashing-strategies-git-tree-vs-files-vs-diff) |
 | `state_dir` | optional override of marker storage location — see [Sharing markers](#sharing-markers-across-machines-ci--teammates) |
 | `ttl` | optional wall-clock expiry for the marker — see [Wall-clock expiry (`ttl`)](#wall-clock-expiry-ttl) |
 | `composes` | child gate keys whose freshness is ANDed into this one — see [Gate dependencies](#gate-dependencies-composes-vs-requires) |
@@ -556,17 +557,18 @@ markgate set               # same as `markgate set default`
 markgate set pre-pr        # a second, independent gate
 ```
 
-### Hashing strategies: `git-tree` vs `files`
+### Hashing strategies: `git-tree` vs `files` vs `diff`
 
-The `hash` field above picks one of two strategies:
+The `hash` field above picks one of three strategies:
 
-| aspect | `git-tree` (default) | `files` |
-| --- | --- | --- |
-| What it hashes | `HEAD` + diff-vs-HEAD ∪ untracked-not-ignored | whatever matches your `include` globs |
-| `HEAD` in the hash? | **Yes** | **No** |
-| Commits invalidate the marker? | Yes | Only if they touch in-scope files |
-| `.gitignore` respected? | Yes (automatic) | No — scope is explicit |
-| Needs config? | No | Yes (`include` required) |
+| aspect | `git-tree` (default) | `files` | `diff` |
+| --- | --- | --- | --- |
+| What it hashes | `HEAD` + diff-vs-HEAD ∪ untracked-not-ignored | whatever matches your `include` globs | the delta against `merge-base(base, HEAD)`, narrowed by `include` |
+| `HEAD` in the hash? | **Yes** | **No** | **No** |
+| Commits invalidate the marker? | Yes | Only if they touch in-scope files | Only if they change your delta |
+| Changes pulled from the base branch invalidate? | Yes | Yes, if in scope | Only for files you also changed |
+| `.gitignore` respected? | Yes (automatic) | No — scope is explicit | Yes (untracked-not-ignored) |
+| Needs config? | No | Yes (`include` required) | Yes (`base` required) |
 
 When to use which:
 
@@ -577,10 +579,86 @@ When to use which:
 - **`files`** = "re-verify *only* when these paths change, ignore
   other commits". Narrow gates (docs consistency, vuln scan rooted
   on a lockfile, coverage for one sub-tree).
+- **`diff`** = "re-verify only when *my branch's* changes move".
+  Expensive gates on long-lived branches, where most invalidations
+  come from merging an updated base branch rather than from your own
+  work.
 
 Rule of thumb: start with `git-tree` (add `exclude` if needed).
 Reach for `files` only when you specifically want the "ignore
-commits that don't touch these paths" semantics.
+commits that don't touch these paths" semantics, and for `diff` only
+when base-branch churn is what keeps re-triggering an expensive gate.
+
+#### `hash: diff` — ignore changes that arrive from the base branch
+
+`git-tree` and `files` both digest **content**, so neither can tell
+the work you did from the work that arrived when you pulled or
+rebased onto an updated base branch. On a busy repo that becomes the
+dominant source of invalidation, and it carries no information about
+your branch: every change that reached the base branch passed the
+same gates in its own PR.
+
+`diff` digests the **delta against `merge-base(base, HEAD)`**
+instead:
+
+```yaml
+gates:
+  integ:
+    hash: diff
+    base: origin/main
+    ttl: 14d
+    include:
+      - "src/providers/**"
+```
+
+| event | `files` | `diff` |
+| --- | --- | --- |
+| the base branch changes an **unrelated** in-scope file | stale | **fresh** |
+| the base branch changes a file **this branch also changed** | stale | stale |
+| you edit an in-scope file (committed or not) | stale | stale |
+| you edit an out-of-scope file | fresh | fresh |
+
+The correlation check is file-granular and needs no configuration: an
+incoming change to a file your branch also touched is part of your own
+delta, so it still invalidates.
+
+**Requirements, all failing closed with exit 2:**
+
+- `base:` is **required** and has no default. It must resolve locally,
+  so fetch it first (`git fetch origin`). markgate deliberately does
+  not guess `origin/HEAD`: a base ref that resolved differently on a
+  developer machine and in CI would make the same gate mean two
+  different things.
+- The delta must be non-empty. A clean checkout of the base branch —
+  or a branch with no changes yet, or one whose changes were all
+  reverted — has nothing to hash, so the digest would be a constant
+  the marker could never fall out of. markgate errors rather than
+  report a freshness that can never expire. A fresh branch with
+  **uncommitted** work is fine: that delta is not empty, which is what
+  pre-commit gates need.
+- Uncommitted edits and untracked files count, exactly as they do
+  under the other two strategies.
+
+**What it deliberately does not catch.** Cross-file interaction: if
+caller `C` uses `A` and `B`, you change `A`, and the base branch
+changes `B`, the two deltas never overlap and the marker stays fresh
+even though that combination was never verified. `files` catches it
+incidentally, so `diff` is a real reduction in strictness, traded
+against not re-running on unrelated churn. Two things bound the
+residual risk: pair `diff` with [`ttl`](#wall-clock-expiry-ttl) as a
+time-based backstop, and note that the whole model assumes the base
+branch is itself gated — if the same gate does not run on the base
+branch's own PRs, `diff` is trusting changes nothing ever verified.
+
+**Determinism.** The digest is built from git object identity (the
+blob each path holds at the merge base) plus the current bytes on
+disk — never from the text `git diff` prints, which moves with
+`diff.algorithm`, `diff.context`, `diff.noprefix`, `color.diff` and
+other per-user settings. Two machines holding the same content
+therefore agree on the digest, which is what makes a `diff` gate safe
+to share (see [Sharing markers](#sharing-markers-across-machines-ci--teammates)).
+Binary files are compared as bytes, and a mode-only change (`chmod`)
+adds the path to the delta and invalidates.
 
 `ttl`, `composes`, and `requires` are **optional** — the basic
 gate pattern works without them. Skip the rest of this section
@@ -809,9 +887,12 @@ the same `state` / `note` vocabulary as the table; `markgate status
 so one-off scopes don't need a `.markgate.yml`:
 
 ```text
---hash git-tree|files    Override hash type for this call.
+--hash git-tree|files|diff
+                         Override hash type for this call.
 --include <glob>         Repeatable. Override the gate's include list.
 --exclude <glob>         Repeatable. Override the gate's exclude list.
+--base <ref>             Base ref for --hash diff (e.g. origin/main).
+                         Required there, rejected on other hash types.
 --state-dir <path>       Directory to store marker files. Takes
                          precedence over MARKGATE_STATE_DIR env and
                          state_dir: in .markgate.yml. Default:
@@ -830,7 +911,7 @@ so one-off scopes don't need a `.markgate.yml`:
 ```
 
 Flag syntax is identical across hash types. With `--hash files`,
-`--include` is required. Example — exclude `vendor/` without any
+`--include` is required; with `--hash diff`, `--base` is. Example — exclude `vendor/` without any
 config file:
 
 ```sh
@@ -840,8 +921,9 @@ markgate run --exclude 'vendor/**' -- pnpm build
 #### Debugging a stale gate
 
 `--explain` lists the files **currently in scope** for the active
-hasher (`git-tree` or `files`) after `--include` / `--exclude`
-filtering. It is **not** a diff against the marker — markgate stores
+hasher (`git-tree`, `files`, or `diff` — for `diff` that is the delta
+against the merge base, not the whole include set) after `--include` /
+`--exclude` filtering. It is **not** a diff against the marker — markgate stores
 only a single SHA-256, so "files that changed since `set`" cannot be
 reconstructed post-hoc. What you see is the candidate set the hasher
 would fold into the digest right now; if the wrong files appear (or
@@ -951,7 +1033,7 @@ marker is **committed** to the repo.
 | aspect | **A. Not committed** (CI cache / artifact) | **B. Committed** |
 | --- | --- | --- |
 | Marker in the repo? | No (typically gitignored, or outside the repo) | Yes, tracked in git |
-| Works with hash type | `git-tree` or `files` | **`files` only** — committing with `git-tree` breaks: the commit changes HEAD → digest is instantly stale |
+| Works with hash type | any | **`files` or `diff`** — committing with `git-tree` breaks: the commit changes HEAD → digest is instantly stale |
 | Local → CI sharing | Needs CI cache / artifact / shared volume | Just `git push` |
 | Tamper surface | Whoever can write to the cache | Whoever has commit access |
 | Extra infra | CI cache provider (e.g. `actions/cache`, `actions/upload-artifact`) | None — git is enough |
@@ -1122,11 +1204,21 @@ markers where commit-access already implies trust in the signal.
   markers are under `.git/`. If you use `--state-dir` pointing inside
   the repo, gitignore that directory.
 - **What if I don't want HEAD in the hash?** Use
-  [`hash: files`](#hashing-strategies-git-tree-vs-files) for that
+  [`hash: files`](#hashing-strategies-git-tree-vs-files-vs-diff) for that
   gate.
+- **My gate keeps re-running because teammates keep merging into the
+  base branch.** That is what
+  [`hash: diff`](#hash-diff--ignore-changes-that-arrive-from-the-base-branch)
+  is for: it hashes your branch's delta, so an incoming change only
+  counts when it touches a file you also changed.
+- **Why does my `diff` gate error on the base branch?** Because there
+  is nothing between the base and your working tree, so the digest
+  would be a constant that never goes stale. Run the gate from a
+  branch that is ahead of the base — or make (not necessarily commit)
+  a change first.
 - **Does `files` respect `.gitignore`?** No. `files` is explicit
   scope by design. Use `git-tree` when you want `.gitignore`-aware
-  behavior. (See [Hashing strategies](#hashing-strategies-git-tree-vs-files).)
+  behavior. (See [Hashing strategies](#hashing-strategies-git-tree-vs-files-vs-diff).)
 - **Can markers be shared across machines / CI?** Yes, via
   `--state-dir`, `MARKGATE_STATE_DIR`, or `state_dir:` in
   `.markgate.yml`. See

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -225,12 +227,16 @@ type evalResult struct {
 // child's expired TTL propagates up — the parent's evaluate will
 // receive matched=false from the child and bubble it.
 func (c *gateCtx) evaluate() (evalResult, error) {
-	if err := c.preflight(); err != nil {
-		return evalResult{}, err
-	}
 	m, err := state.Load(c.markerPath)
 	if err != nil {
 		if errors.Is(err, state.ErrNotFound) {
+			// Nothing to compare against, so no digest gets computed on
+			// this path and the hasher's preconditions would go
+			// unchecked — leaving `run` to execute its child first and
+			// refuse to record the result afterwards.
+			if pErr := c.preflight(); pErr != nil {
+				return evalResult{}, pErr
+			}
 			return evalResult{reason: "no marker"}, nil
 		}
 		return evalResult{}, err
@@ -244,6 +250,11 @@ func (c *gateCtx) evaluate() (evalResult, error) {
 		// Gate flipped between own-scope and deps-only since last set;
 		// the marker is from a different freshness model. Treat it as
 		// stale so the next set rewrites it under the current model.
+		// Same reasoning as the no-marker path: this returns without
+		// hashing, so preconditions need their own check.
+		if pErr := c.preflight(); pErr != nil {
+			return evalResult{}, pErr
+		}
 		res.hashTypeChanged = true
 		res.reason = "marker kind changed"
 		return res, nil
@@ -300,12 +311,47 @@ func (c *gateCtx) evaluate() (evalResult, error) {
 // base would report a plain mismatch, `run` would execute its (by
 // assumption expensive) child, and only the closing `set` would refuse —
 // after the cost was already paid.
+//
+// Callers invoke it ONLY on paths that return without hashing: when a
+// digest is computed, Hash reports the same errors, and running both
+// would double every diff gate's git work on the hot path.
 func (c *gateCtx) preflight() error {
+	if !c.gate.HasOwnScope() {
+		// Freshness is purely the AND of children; the hasher is never
+		// consulted, so its preconditions are not this gate's business.
+		return nil
+	}
 	d, ok := c.hasher.(hasher.Diff)
 	if !ok {
 		return nil
 	}
 	return d.Preflight(c.repo)
+}
+
+// warnEmptyDiffScope reports a diff gate recording a marker whose
+// in-scope delta is empty. That digest is a constant: legitimate when
+// the branch genuinely changes nothing the gate covers (the case this
+// hash type exists to keep fresh), and the signature of a typo'd
+// include otherwise. Refusing would make the gate unusable on branches
+// it should trivially pass, so the compromise is that it is never
+// silent — the same class of mistake that made a cwd-scoped delta look
+// like a permanently fresh marker.
+func warnEmptyDiffScope(c *gateCtx, errOut io.Writer) {
+	d, ok := c.hasher.(hasher.Diff)
+	if !ok {
+		return
+	}
+	scope, err := d.Scope(c.repo)
+	if err != nil || len(scope) > 0 {
+		return
+	}
+	patterns := "(everything)"
+	if len(c.gate.Include) > 0 {
+		patterns = strings.Join(c.gate.Include, ", ")
+	}
+	fmt.Fprintf(errOut,
+		"markgate: %s: hash=diff recorded an empty in-scope delta (include: %s); this branch changes nothing the gate covers, so the marker stays fresh until it does\n",
+		c.key, patterns)
 }
 
 // staleRequiredChild returns the key of the first direct requires child

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -45,19 +45,23 @@ type gateFlagValues struct {
 	hash     string
 	include  []string
 	exclude  []string
+	base     string
 	stateDir string
 }
 
-// addGateFlags registers --hash / --include / --exclude / --state-dir on
-// cmd and returns a pointer whose fields are populated when RunE fires.
+// addGateFlags registers --hash / --include / --exclude / --base /
+// --state-dir on cmd and returns a pointer whose fields are populated
+// when RunE fires.
 func addGateFlags(cmd *cobra.Command) *gateFlagValues {
 	v := &gateFlagValues{}
 	cmd.Flags().StringVar(&v.hash, "hash", "",
-		"override hash type for this invocation: git-tree or files")
+		"override hash type for this invocation: git-tree, files or diff")
 	cmd.Flags().StringArrayVar(&v.include, "include", nil,
 		"glob to include (repeatable); overrides config include list")
 	cmd.Flags().StringArrayVar(&v.exclude, "exclude", nil,
 		"glob to exclude (repeatable); overrides config exclude list")
+	cmd.Flags().StringVar(&v.base, "base", "",
+		"base ref a hash=diff gate measures its delta from (e.g. origin/main)")
 	cmd.Flags().StringVar(&v.stateDir, "state-dir", "",
 		"directory to store marker files; overrides "+EnvStateDir+" env and state_dir: in .markgate.yml (default: <git-dir>/markgate)")
 	return v
@@ -76,6 +80,9 @@ func (v *gateFlagValues) override(g config.Gate) config.Gate {
 	}
 	if v.exclude != nil {
 		g.Exclude = v.exclude
+	}
+	if v.base != "" {
+		g.Base = v.base
 	}
 	return g
 }
@@ -218,6 +225,9 @@ type evalResult struct {
 // child's expired TTL propagates up — the parent's evaluate will
 // receive matched=false from the child and bubble it.
 func (c *gateCtx) evaluate() (evalResult, error) {
+	if err := c.preflight(); err != nil {
+		return evalResult{}, err
+	}
 	m, err := state.Load(c.markerPath)
 	if err != nil {
 		if errors.Is(err, state.ErrNotFound) {
@@ -285,6 +295,19 @@ func (c *gateCtx) evaluate() (evalResult, error) {
 	return res, nil
 }
 
+// preflight surfaces hasher preconditions that must fail loudly even
+// when no marker exists yet. Without it a diff gate with an unusable
+// base would report a plain mismatch, `run` would execute its (by
+// assumption expensive) child, and only the closing `set` would refuse —
+// after the cost was already paid.
+func (c *gateCtx) preflight() error {
+	d, ok := c.hasher.(hasher.Diff)
+	if !ok {
+		return nil
+	}
+	return d.Preflight(c.repo)
+}
+
 // staleRequiredChild returns the key of the first direct requires child
 // whose recursive evaluate is mismatch — for set-time enforcement.
 // Returns "" when every required child is fresh.
@@ -342,6 +365,9 @@ func resolveMarkerPath(overrides *gateFlagValues, gate config.Gate, topLevel, gi
 // validateGate enforces the invariants that config.validate also enforces,
 // so CLI overrides cannot construct an illegal gate.
 func validateGate(g config.Gate) error {
+	if g.Base != "" && g.Hash != config.HashDiff {
+		return fmt.Errorf("base is only valid with hash=diff (got hash=%q)", g.Hash)
+	}
 	switch g.Hash {
 	case "", config.HashGitTree:
 		return nil
@@ -350,8 +376,13 @@ func validateGate(g config.Gate) error {
 			return fmt.Errorf("hash=files requires --include or an include list in config")
 		}
 		return nil
+	case config.HashDiff:
+		if g.Base == "" {
+			return fmt.Errorf("hash=diff requires --base or a base: in config")
+		}
+		return nil
 	default:
-		return fmt.Errorf("unknown hash type %q (want %q or %q)", g.Hash, config.HashGitTree, config.HashFiles)
+		return fmt.Errorf("unknown hash type %q (want %q, %q or %q)", g.Hash, config.HashGitTree, config.HashFiles, config.HashDiff)
 	}
 }
 
@@ -424,7 +455,8 @@ func formatAge(d time.Duration) string {
 }
 
 // newMarker computes the current digest and returns a marker ready to save.
-// HEAD is recorded only for git-tree, to aid status output. CreatedAt is
+// HEAD is recorded only for git-tree, and base / merge base only for
+// diff, to aid status output. CreatedAt is
 // stamped here (via the package's now indirection) rather than left for
 // state.Save to fill in, so tests that pin the clock for TTL coverage
 // observe the pinned value. Deps-only gates (no own scope) get a marker
@@ -447,6 +479,15 @@ func newMarker(c *gateCtx) (*state.Marker, error) {
 	if _, ok := c.hasher.(hasher.GitTree); ok {
 		if head, err := c.repo.HeadSHA(); err == nil {
 			m.Head = head
+		}
+	}
+	if d, ok := c.hasher.(hasher.Diff); ok {
+		// Recorded for diagnostics only. Neither field is compared at
+		// verify time — a moved merge base is exactly what this hash
+		// type is built to tolerate.
+		m.Base = d.Base
+		if mergeBase, err := d.MergeBase(c.repo); err == nil {
+			m.MergeBase = mergeBase
 		}
 	}
 	return m, nil

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -36,12 +36,15 @@ gates:
     #   Pattern A: not committed (e.g. restored from CI cache).
     #     state_dir: .markgate-cache
     #     -> gitignore .markgate-cache/ (required if you stay on
-    #        hash: git-tree, optional hygiene for hash: files).
+    #        hash: git-tree or on an unscoped hash: diff gate,
+    #        optional hygiene for hash: files).
     #
     #   Pattern B: committed to git for zero-infra local->CI sharing.
     #     state_dir: .markgate-state
-    #     -> requires hash: files (git-tree would break: the commit
-    #        changes HEAD and stales the marker it just wrote).
+    #     -> requires a scoped hash: files or hash: diff gate whose
+    #        include/exclude keeps the state dir out of scope
+    #        (git-tree would break: the commit changes HEAD and stales
+    #        the marker it just wrote).
     #
     # See README "Sharing markers" for the full picture.
 
@@ -55,8 +58,14 @@ gates:
   # Example: ignore base-branch changes to files this branch has not
   # touched (hash: diff). The digest covers only the delta against
   # merge-base(base, HEAD), so pulling an unrelated change from the base
-  # branch keeps the marker fresh. Requires base:, and errors when run
-  # from the base branch itself. See README "Hashing strategies".
+  # branch keeps the marker fresh. Requires base:, and errors when the
+  # delta is empty (e.g. on the base branch itself).
+  #
+  # This is the LEAST STRICT hash type: a base-branch change your branch
+  # never touched is trusted without re-verification, so a combination
+  # that was never verified together can read as fresh. Pair it with
+  # ttl:, and only use it where the base branch runs the same gate.
+  # See README "Hashing strategies" before adopting it.
   # integ:
   #   hash: diff
   #   base: origin/main

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -17,6 +17,7 @@ const initSkeleton = `# markgate configuration - https://github.com/go-to-k/mark
 # Define a gate here only when you want:
 #   - exclude patterns on the default git-tree hash, or
 #   - a narrow-scope (hash: files) gate for docs / Docker / coverage, or
+#   - a branch-delta (hash: diff) gate that ignores base-branch churn, or
 #   - a non-default marker storage directory (state_dir) for sharing
 #     markers across machines / CI.
 
@@ -50,6 +51,18 @@ gates:
   #   include:
   #     - "docs/**"
   #     - "README.md"
+
+  # Example: ignore base-branch changes to files this branch has not
+  # touched (hash: diff). The digest covers only the delta against
+  # merge-base(base, HEAD), so pulling an unrelated change from the base
+  # branch keeps the marker fresh. Requires base:, and errors when run
+  # from the base branch itself. See README "Hashing strategies".
+  # integ:
+  #   hash: diff
+  #   base: origin/main
+  #   ttl: 14d
+  #   include:
+  #     - "src/**"
 
   # Example: wall-clock expiry for gates that verify external state
   # (cloud APIs, vuln DB, ...). Units: s/m/h/d/w (m is minutes, not

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -54,6 +54,30 @@ func runCmdStderr(t *testing.T, args ...string) (int, string, string) {
 	return 2, stdout.String(), stderr.String()
 }
 
+// runCmdMsg is runCmd plus the error text: Execute prints it to stderr in
+// a real process, so the harness surfaces it here instead. Used by tests
+// that assert an error explains itself, not merely that it happened.
+func runCmdMsg(t *testing.T, args ...string) (int, string) {
+	t.Helper()
+	root := newRootCmd("test")
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs(args)
+
+	err := root.Execute()
+	if err == nil {
+		return 0, ""
+	}
+	var ee *ExitError
+	if errors.As(err, &ee) {
+		if ee.Err == nil {
+			return ee.Code, ""
+		}
+		return ee.Code, ee.Err.Error()
+	}
+	return 2, err.Error()
+}
+
 // initRepo creates a fresh repo in a temp dir, chdirs into it (auto-
 // restored by t.Chdir), and returns the path.
 func initRepo(t *testing.T) string {
@@ -1863,5 +1887,315 @@ func TestStatus_BareRecursesThroughRequires(t *testing.T) {
 	}
 	if !strings.Contains(parentLine, "child child is stale") {
 		t.Errorf("parent row note should mention stale child, got: %q", parentLine)
+	}
+}
+
+// gitIn runs a git command inside dir, failing the test on error. Diff-gate
+// tests need real branches, which initRepo alone does not provide.
+func gitIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+const diffGateConfig = "gates:\n  integ:\n    hash: diff\n    base: main\n    include:\n      - \"src/**\"\n"
+
+// initDiffRepo seeds a repo with an in-scope src/ tree on main, then
+// checks out a feature branch carrying one committed change.
+func initDiffRepo(t *testing.T) string {
+	t.Helper()
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a1\na2\na3\na4\na5\n")
+	writeRepoFile(t, dir, "src/b.go", "b1\nb2\nb3\nb4\nb5\n")
+	writeRepoFile(t, dir, "docs/x.md", "x\n")
+	writeRepoFile(t, dir, ".markgate.yml", diffGateConfig)
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	gitIn(t, dir, "checkout", "-q", "-b", "feat")
+	writeRepoFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	gitIn(t, dir, "commit", "-qam", "my work")
+	return dir
+}
+
+func TestDiffHash_UnrelatedBaseBranchChangeStaysFresh(t *testing.T) {
+	dir := initDiffRepo(t)
+	if code, _ := runCmd(t, "set", "integ"); code != 0 {
+		t.Fatalf("set: code = %d, want 0", code)
+	}
+
+	gitIn(t, dir, "checkout", "-q", "main")
+	writeRepoFile(t, dir, "src/b.go", "b1\nb2\nb3\nb4\nBASE\n")
+	gitIn(t, dir, "commit", "-qam", "unrelated base work")
+	gitIn(t, dir, "checkout", "-q", "feat")
+	gitIn(t, dir, "merge", "-q", "--no-edit", "main")
+
+	if code, _ := runCmd(t, "verify", "integ"); code != 0 {
+		t.Errorf("verify after unrelated base merge: code = %d, want 0 (still fresh)", code)
+	}
+}
+
+func TestDiffHash_SameFileBaseBranchChangeGoesStale(t *testing.T) {
+	dir := initDiffRepo(t)
+	if code, _ := runCmd(t, "set", "integ"); code != 0 {
+		t.Fatalf("set: code = %d, want 0", code)
+	}
+
+	gitIn(t, dir, "checkout", "-q", "main")
+	writeRepoFile(t, dir, "src/a.go", "a1\na2\na3\na4\nBASE\n")
+	gitIn(t, dir, "commit", "-qam", "base touches the same file")
+	gitIn(t, dir, "checkout", "-q", "feat")
+	gitIn(t, dir, "merge", "-q", "--no-edit", "main")
+
+	if code, _ := runCmd(t, "verify", "integ"); code != 1 {
+		t.Errorf("verify after same-file base merge: code = %d, want 1 (stale)", code)
+	}
+}
+
+func TestDiffHash_UncommittedInScopeEditGoesStale(t *testing.T) {
+	dir := initDiffRepo(t)
+	if code, _ := runCmd(t, "set", "integ"); code != 0 {
+		t.Fatalf("set: code = %d, want 0", code)
+	}
+	writeRepoFile(t, dir, "src/a.go", "a1\nMINE AGAIN\na3\na4\na5\n")
+	if code, _ := runCmd(t, "verify", "integ"); code != 1 {
+		t.Errorf("verify after uncommitted in-scope edit: code = %d, want 1", code)
+	}
+}
+
+func TestDiffHash_OutOfScopeEditStaysFresh(t *testing.T) {
+	dir := initDiffRepo(t)
+	if code, _ := runCmd(t, "set", "integ"); code != 0 {
+		t.Fatalf("set: code = %d, want 0", code)
+	}
+	writeRepoFile(t, dir, "docs/x.md", "edited outside the include set\n")
+	gitIn(t, dir, "commit", "-qam", "docs")
+	if code, _ := runCmd(t, "verify", "integ"); code != 0 {
+		t.Errorf("verify after out-of-scope edit: code = %d, want 0", code)
+	}
+}
+
+// TestDiffHash_BaseBranchErrors covers the degenerate case the whole hash
+// type turns on: with an empty delta the digest is a constant, so verify
+// and set both refuse rather than reporting a freshness that can never
+// expire. Exit 2 (error), not 0 (silent pass) and not a files-mode
+// fallback.
+func TestDiffHash_BaseBranchErrors(t *testing.T) {
+	dir := initDiffRepo(t)
+	gitIn(t, dir, "checkout", "-q", "main")
+
+	code, msg := runCmdMsg(t, "verify", "integ")
+	if code != 2 {
+		t.Errorf("verify on base branch: code = %d, want 2", code)
+	}
+	if !strings.Contains(msg, "hash=diff") {
+		t.Errorf("verify on base branch: error = %q, want it to name hash=diff", msg)
+	}
+	if setCode, _ := runCmd(t, "set", "integ"); setCode != 2 {
+		t.Errorf("set on base branch: code = %d, want 2", setCode)
+	}
+	markerPath := filepath.Join(dir, ".git", "markgate", "integ.json")
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("set on base branch wrote a marker at %s (err = %v)", markerPath, err)
+	}
+}
+
+// TestDiffHash_FreshBranchWithUncommittedWorkIsUsable is the flip side of
+// the check above: markgate's core flow runs gates BEFORE the first
+// commit, where HEAD still equals the merge base but the delta is not
+// empty. That must work, otherwise a diff gate could never guard a
+// pre-commit hook.
+func TestDiffHash_FreshBranchWithUncommittedWorkIsUsable(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a\n")
+	writeRepoFile(t, dir, ".markgate.yml", diffGateConfig)
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	gitIn(t, dir, "checkout", "-q", "-b", "feat")
+	writeRepoFile(t, dir, "src/a.go", "uncommitted work\n")
+
+	if code, _ := runCmd(t, "set", "integ"); code != 0 {
+		t.Fatalf("set on fresh branch with uncommitted work: code = %d, want 0", code)
+	}
+	if code, _ := runCmd(t, "verify", "integ"); code != 0 {
+		t.Errorf("verify: code = %d, want 0", code)
+	}
+	writeRepoFile(t, dir, "src/a.go", "more work\n")
+	if code, _ := runCmd(t, "verify", "integ"); code != 1 {
+		t.Errorf("verify after further edit: code = %d, want 1", code)
+	}
+}
+
+func TestDiffHash_UnresolvableBaseErrors(t *testing.T) {
+	dir := initDiffRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  integ:\n    hash: diff\n    base: origin/never-fetched\n    include:\n      - \"src/**\"\n")
+
+	code, msg := runCmdMsg(t, "verify", "integ")
+	if code != 2 {
+		t.Errorf("verify with unresolvable base: code = %d, want 2", code)
+	}
+	if !strings.Contains(msg, "never-fetched") {
+		t.Errorf("error = %q, want it to name the unresolvable ref", msg)
+	}
+	if setCode, _ := runCmd(t, "set", "integ"); setCode != 2 {
+		t.Errorf("set with unresolvable base: code = %d, want 2", setCode)
+	}
+}
+
+func TestDiffHash_ConfigRequiresBase(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  integ:\n    hash: diff\n    include:\n      - \"src/**\"\n")
+	if code, _ := runCmd(t, "verify", "integ"); code != 2 {
+		t.Errorf("hash=diff without base: code = %d, want 2", code)
+	}
+	if code, out := runCmd(t, "config", "lint"); code != 1 || !strings.Contains(out, "hash=diff requires a base ref") {
+		t.Errorf("lint: code = %d, out = %q", code, out)
+	}
+}
+
+func TestDiffHash_BaseOnNonDiffGateIsAConfigError(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  check:\n    hash: files\n    base: main\n    include:\n      - \"src/**\"\n")
+	if code, _ := runCmd(t, "verify", "check"); code != 2 {
+		t.Errorf("base on hash=files: code = %d, want 2", code)
+	}
+	if code, out := runCmd(t, "config", "lint"); code != 1 || !strings.Contains(out, "base is only valid with hash=diff") {
+		t.Errorf("lint: code = %d, out = %q", code, out)
+	}
+}
+
+func TestDiffHash_Flags(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	gitIn(t, dir, "checkout", "-q", "-b", "feat")
+	writeRepoFile(t, dir, "src/a.go", "mine\n")
+	gitIn(t, dir, "commit", "-qam", "my work")
+
+	if code, _ := runCmd(t, "set", "check", "--hash", "diff"); code != 2 {
+		t.Error("--hash diff without --base: want code 2")
+	}
+	if code, _ := runCmd(t, "set", "check", "--hash", "diff", "--base", "main"); code != 0 {
+		t.Error("--hash diff --base main: want code 0")
+	}
+	if code, _ := runCmd(t, "verify", "check", "--hash", "diff", "--base", "main"); code != 0 {
+		t.Error("verify with the same flags: want code 0")
+	}
+	if code, _ := runCmd(t, "set", "check", "--base", "main"); code != 2 {
+		t.Error("--base without hash=diff: want code 2")
+	}
+}
+
+// TestDiffHash_MarkerRecordsBase pins the diagnostics `status` needs to
+// explain a diff gate: which ref it measures from, and where the merge
+// base sat when the marker was written.
+func TestDiffHash_MarkerRecordsBase(t *testing.T) {
+	dir := initDiffRepo(t)
+	if code, _ := runCmd(t, "set", "integ"); code != 0 {
+		t.Fatalf("set: code = %d", code)
+	}
+
+	code, out := runCmd(t, "status", "integ")
+	if code != 0 {
+		t.Fatalf("status: code = %d, out = %q", code, out)
+	}
+	if !strings.Contains(out, "hash type:  diff") || !strings.Contains(out, "base:       main") {
+		t.Errorf("status text missing base info: %q", out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".git", "markgate", "integ.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m struct {
+		Base      string `json:"base"`
+		MergeBase string `json:"merge_base"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m.Base != "main" || len(m.MergeBase) != 40 {
+		t.Errorf("marker base = %q, merge_base = %q", m.Base, m.MergeBase)
+	}
+}
+
+// TestDiffHash_BareStatusDegradesInsteadOfAborting keeps the "show me
+// every gate" view usable from the base branch: the offending row reports
+// the reason, the other rows still render.
+func TestDiffHash_BareStatusDegradesInsteadOfAborting(t *testing.T) {
+	dir := initDiffRepo(t)
+	writeRepoFile(t, dir, ".markgate.yml", diffGateConfig+"  other:\n    hash: files\n    include:\n      - \"src/**\"\n")
+	gitIn(t, dir, "commit", "-qam", "add a second gate")
+	if code, _ := runCmd(t, "set", "other"); code != 0 {
+		t.Fatalf("set other: code = %d", code)
+	}
+	// A clean base-branch checkout: the delta is empty, so the diff gate
+	// cannot produce a meaningful digest.
+	gitIn(t, dir, "checkout", "-q", "main")
+
+	code, out := runCmd(t, "status")
+	if code != 1 {
+		t.Errorf("bare status on base branch: code = %d, want 1", code)
+	}
+	if !strings.Contains(out, "other") {
+		t.Errorf("bare status dropped the healthy row: %q", out)
+	}
+	if !strings.Contains(out, "hash=diff") {
+		t.Errorf("bare status did not explain the diff row: %q", out)
+	}
+}
+
+// TestDiffHash_RunSkipsThenRunsAfterInScopeEdit exercises the sugar path
+// end to end: a hit skips the child, an in-scope edit re-runs it.
+func TestDiffHash_RunSkipsThenRunsAfterInScopeEdit(t *testing.T) {
+	dir := initDiffRepo(t)
+	stamp := filepath.Join(dir, "ran.txt")
+
+	if code, _ := runCmd(t, "run", "integ", "--", "touch", stamp); code != 0 {
+		t.Fatalf("first run: code = %d", code)
+	}
+	if _, err := os.Stat(stamp); err != nil {
+		t.Fatalf("child did not run: %v", err)
+	}
+	if err := os.Remove(stamp); err != nil {
+		t.Fatal(err)
+	}
+	if code, _ := runCmd(t, "run", "integ", "--", "touch", stamp); code != 0 {
+		t.Fatalf("second run: code = %d", code)
+	}
+	if _, err := os.Stat(stamp); !errors.Is(err, os.ErrNotExist) {
+		t.Error("child ran again despite a fresh marker")
+	}
+
+	writeRepoFile(t, dir, "src/a.go", "a1\nCHANGED\na3\na4\na5\n")
+	if code, _ := runCmd(t, "run", "integ", "--", "touch", stamp); code != 0 {
+		t.Fatalf("third run: code = %d", code)
+	}
+	if _, err := os.Stat(stamp); err != nil {
+		t.Errorf("child did not re-run after an in-scope edit: %v", err)
+	}
+}
+
+// TestDiffHash_ExplainListsDelta checks the --explain scope listing is the
+// delta, not the whole include set: docs/x.md is in neither, and src/b.go
+// is in the include set but untouched by this branch.
+func TestDiffHash_ExplainListsDelta(t *testing.T) {
+	initDiffRepo(t)
+	code, _, stderr := runCmdStderr(t, "status", "integ", "--explain")
+	if code != 1 {
+		t.Fatalf("status --explain before set: code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "src/a.go") {
+		t.Errorf("scope missing the changed file: %q", stderr)
+	}
+	if strings.Contains(stderr, "src/b.go") {
+		t.Errorf("scope included an untouched in-include file: %q", stderr)
 	}
 }

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2043,6 +2045,10 @@ func TestDiffHash_UnresolvableBaseErrors(t *testing.T) {
 	if setCode, _ := runCmd(t, "set", "integ"); setCode != 2 {
 		t.Errorf("set with unresolvable base: code = %d, want 2", setCode)
 	}
+	markerPath := filepath.Join(dir, ".git", "markgate", "integ.json")
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("set with unresolvable base wrote a marker at %s (err = %v)", markerPath, err)
+	}
 }
 
 func TestDiffHash_ConfigRequiresBase(t *testing.T) {
@@ -2079,8 +2085,11 @@ func TestDiffHash_Flags(t *testing.T) {
 	writeRepoFile(t, dir, "src/a.go", "mine\n")
 	gitIn(t, dir, "commit", "-qam", "my work")
 
-	if code, _ := runCmd(t, "set", "check", "--hash", "diff"); code != 2 {
-		t.Error("--hash diff without --base: want code 2")
+	// The message matters as much as the code here: without the eager
+	// validation both of these still exit 2, just later and with an
+	// error that names neither the flag nor the mistake.
+	if code, msg := runCmdMsg(t, "set", "check", "--hash", "diff"); code != 2 || !strings.Contains(msg, "requires --base") {
+		t.Errorf("--hash diff without --base: code = %d, msg = %q", code, msg)
 	}
 	if code, _ := runCmd(t, "set", "check", "--hash", "diff", "--base", "main"); code != 0 {
 		t.Error("--hash diff --base main: want code 0")
@@ -2088,8 +2097,8 @@ func TestDiffHash_Flags(t *testing.T) {
 	if code, _ := runCmd(t, "verify", "check", "--hash", "diff", "--base", "main"); code != 0 {
 		t.Error("verify with the same flags: want code 0")
 	}
-	if code, _ := runCmd(t, "set", "check", "--base", "main"); code != 2 {
-		t.Error("--base without hash=diff: want code 2")
+	if code, msg := runCmdMsg(t, "set", "check", "--base", "main"); code != 2 || !strings.Contains(msg, "base is only valid with hash=diff") {
+		t.Errorf("--base without hash=diff: code = %d, msg = %q", code, msg)
 	}
 }
 
@@ -2197,5 +2206,279 @@ func TestDiffHash_ExplainListsDelta(t *testing.T) {
 	}
 	if strings.Contains(stderr, "src/b.go") {
 		t.Errorf("scope included an untouched in-include file: %q", stderr)
+	}
+}
+
+// setGitConfigEnv injects git configuration for the duration of t via
+// GIT_CONFIG_COUNT, which outranks the repo's own config file and is
+// how a hostile-but-legal user setting is simulated.
+func setGitConfigEnv(t *testing.T, kv ...string) {
+	t.Helper()
+	if len(kv)%2 != 0 {
+		t.Fatalf("setGitConfigEnv: odd number of arguments: %v", kv)
+	}
+	t.Setenv("GIT_CONFIG_COUNT", strconv.Itoa(len(kv)/2))
+	for i := 0; i < len(kv); i += 2 {
+		t.Setenv(fmt.Sprintf("GIT_CONFIG_KEY_%d", i/2), kv[i])
+		t.Setenv(fmt.Sprintf("GIT_CONFIG_VALUE_%d", i/2), kv[i+1])
+	}
+}
+
+func markerDigest(t *testing.T, dir, key string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, ".git", "markgate", key+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m struct {
+		Digest string `json:"digest"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	return m.Digest
+}
+
+// TestDiffHash_SubdirectoryInvocationKeepsRepoScope pins the invariant
+// that a gate covers the same files wherever it is invoked from. git
+// scopes its path output to the cwd subtree and, under diff.relative,
+// prints paths relative to it — which filtered down to an empty delta,
+// recorded the digest of the empty set, and left the gate returning
+// "fresh" for every subsequent change.
+func TestDiffHash_SubdirectoryInvocationKeepsRepoScope(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "docs/x.md", "x1\n")
+	writeRepoFile(t, dir, "src/a.go", "a1\n")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  d:\n    hash: diff\n    base: main\n    include:\n      - \"docs/**\"\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	gitIn(t, dir, "checkout", "-q", "-b", "feat")
+	writeRepoFile(t, dir, "docs/x.md", "x2 mine\n")
+	gitIn(t, dir, "commit", "-qam", "my work")
+
+	setGitConfigEnv(t, "diff.relative", "true")
+
+	if code, _ := runCmd(t, "set", "d"); code != 0 {
+		t.Fatalf("set from repo root: code = %d", code)
+	}
+	fromRoot := markerDigest(t, dir, "d")
+
+	t.Chdir(filepath.Join(dir, "docs"))
+	if code, _ := runCmd(t, "set", "d"); code != 0 {
+		t.Fatalf("set from subdirectory: code = %d", code)
+	}
+	if fromSubdir := markerDigest(t, dir, "d"); fromSubdir != fromRoot {
+		t.Errorf("digest depends on cwd: root %s, docs/ %s", fromRoot, fromSubdir)
+	}
+
+	_, _, stderr := runCmdStderr(t, "verify", "d", "--explain")
+	if !strings.Contains(stderr, "docs/x.md") {
+		t.Errorf("scope from a subdirectory = %q, want the repo-relative path docs/x.md", stderr)
+	}
+
+	writeRepoFile(t, dir, "docs/x.md", "x3 more\n")
+	if code, _ := runCmd(t, "verify", "d"); code != 1 {
+		t.Errorf("in-scope change seen from a subdirectory: code = %d, want 1 (0 means the marker can never go stale)", code)
+	}
+}
+
+// TestGitTreeHash_SubdirectoryInvocationSeesWholeRepo covers the same
+// cwd dependence on the default hash type, where `ls-files --others`
+// silently stopped at the cwd subtree with no git config involved.
+func TestGitTreeHash_SubdirectoryInvocationSeesWholeRepo(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "docs/x.md", "x\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+
+	t.Chdir(filepath.Join(dir, "docs"))
+	if code, _ := runCmd(t, "set", "check"); code != 0 {
+		t.Fatalf("set: code = %d", code)
+	}
+
+	writeRepoFile(t, dir, "src/NEW.txt", "untracked, outside cwd\n")
+	if code, _ := runCmd(t, "verify", "check"); code != 1 {
+		t.Errorf("untracked file outside cwd: code = %d, want 1", code)
+	}
+}
+
+// TestDiffHash_RunRefusesBeforeExecutingChild pins the reason Preflight
+// exists. `run` guards work that is expensive by assumption, so a gate
+// that cannot record its result must refuse first, not after.
+func TestDiffHash_RunRefusesBeforeExecutingChild(t *testing.T) {
+	dir := initDiffRepo(t)
+	stamp := filepath.Join(dir, "child-ran.txt")
+
+	gitIn(t, dir, "checkout", "-q", "main")
+	if code, _ := runCmd(t, "run", "integ", "--", "touch", stamp); code != 2 {
+		t.Errorf("run on the base branch: code = %d, want 2", code)
+	}
+	if _, err := os.Stat(stamp); !errors.Is(err, os.ErrNotExist) {
+		t.Error("run executed its child on the base branch")
+	}
+
+	gitIn(t, dir, "checkout", "-q", "feat")
+	code, _ := runCmd(t, "run", "integ", "--base", "origin/never-fetched", "--", "touch", stamp)
+	if code != 2 {
+		t.Errorf("run with an unresolvable base: code = %d, want 2", code)
+	}
+	if _, err := os.Stat(stamp); !errors.Is(err, os.ErrNotExist) {
+		t.Error("run executed its child with an unresolvable base")
+	}
+}
+
+// TestDiffHash_EmptyInScopeDeltaWarnsButStaysUsable is the deliberate
+// non-refusal: a branch that changes nothing the gate covers is exactly
+// the case this hash type exists to keep fresh, so it must not error —
+// but the constant digest is also what a typo'd include produces, so it
+// is announced rather than recorded silently.
+func TestDiffHash_EmptyInScopeDeltaWarnsButStaysUsable(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a\n")
+	writeRepoFile(t, dir, "docs/x.md", "x\n")
+	writeRepoFile(t, dir, ".markgate.yml", diffGateConfig)
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	gitIn(t, dir, "checkout", "-q", "-b", "docs-only")
+	writeRepoFile(t, dir, "docs/x.md", "docs only change\n")
+	gitIn(t, dir, "commit", "-qam", "docs")
+
+	code, _, stderr := runCmdStderr(t, "set", "integ")
+	if code != 0 {
+		t.Fatalf("set on a branch with no in-scope changes: code = %d, want 0", code)
+	}
+	if !strings.Contains(stderr, "empty in-scope delta") {
+		t.Errorf("set stderr = %q, want an empty-delta warning", stderr)
+	}
+	if verifyCode, _ := runCmd(t, "verify", "integ"); verifyCode != 0 {
+		t.Errorf("verify: code = %d, want 0 (a branch touching nothing in scope stays fresh)", verifyCode)
+	}
+
+	writeRepoFile(t, dir, "src/a.go", "now in scope\n")
+	if verifyCode, _ := runCmd(t, "verify", "integ"); verifyCode != 1 {
+		t.Errorf("verify after an in-scope change: code = %d, want 1", verifyCode)
+	}
+}
+
+// TestDiffHash_RebaseOntoMovedBase covers the other way a branch takes
+// on base-branch work. Rebasing rewrites every commit and moves the
+// merge base, so a content-blind implementation would invalidate here.
+func TestDiffHash_RebaseOntoMovedBase(t *testing.T) {
+	dir := initDiffRepo(t)
+	if code, _ := runCmd(t, "set", "integ"); code != 0 {
+		t.Fatalf("set: code = %d", code)
+	}
+
+	gitIn(t, dir, "checkout", "-q", "main")
+	writeRepoFile(t, dir, "src/b.go", "b1\nb2\nb3\nb4\nBASE\n")
+	gitIn(t, dir, "commit", "-qam", "unrelated base work")
+	gitIn(t, dir, "checkout", "-q", "feat")
+	gitIn(t, dir, "rebase", "main")
+
+	if code, _ := runCmd(t, "verify", "integ"); code != 0 {
+		t.Errorf("verify after rebasing onto an unrelated base change: code = %d, want 0", code)
+	}
+
+	gitIn(t, dir, "checkout", "-q", "main")
+	writeRepoFile(t, dir, "src/a.go", "a1\na2\na3\na4\nBASE\n")
+	gitIn(t, dir, "commit", "-qam", "base touches my file")
+	gitIn(t, dir, "checkout", "-q", "feat")
+	gitIn(t, dir, "rebase", "main")
+
+	if code, _ := runCmd(t, "verify", "integ"); code != 1 {
+		t.Errorf("verify after rebasing onto a change to my own file: code = %d, want 1", code)
+	}
+}
+
+func TestDiffHash_WithTTL(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a\n")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  integ:\n    hash: diff\n    base: main\n    ttl: 7d\n    include:\n      - \"src/**\"\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	gitIn(t, dir, "checkout", "-q", "-b", "feat")
+	writeRepoFile(t, dir, "src/a.go", "mine\n")
+	gitIn(t, dir, "commit", "-qam", "my work")
+
+	t0 := time.Now().UTC()
+	withClock(t, t0)
+	if code, _ := runCmd(t, "set", "integ"); code != 0 {
+		t.Fatalf("set: code = %d", code)
+	}
+	withClock(t, t0.Add(3*24*time.Hour))
+	if code, _ := runCmd(t, "verify", "integ"); code != 0 {
+		t.Errorf("verify within ttl: code = %d, want 0", code)
+	}
+	withClock(t, t0.Add(8*24*time.Hour))
+	if code, _ := runCmd(t, "verify", "integ"); code != 1 {
+		t.Errorf("verify past ttl: code = %d, want 1 (ttl is the backstop for what diff deliberately ignores)", code)
+	}
+}
+
+func TestDiffHash_AsRequiresChild(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a\n")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  pre-merge:\n    requires:\n      - integ\n  integ:\n    hash: diff\n    base: main\n    include:\n      - \"src/**\"\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	gitIn(t, dir, "checkout", "-q", "-b", "feat")
+	writeRepoFile(t, dir, "src/a.go", "mine\n")
+	gitIn(t, dir, "commit", "-qam", "my work")
+
+	if code, msg := runCmdMsg(t, "set", "pre-merge"); code != 2 || !strings.Contains(msg, "integ") {
+		t.Errorf("set parent with a stale diff child: code = %d, msg = %q", code, msg)
+	}
+	if code, _ := runCmd(t, "set", "integ"); code != 0 {
+		t.Fatalf("set child: code = %d", code)
+	}
+	if code, _ := runCmd(t, "set", "pre-merge"); code != 0 {
+		t.Fatalf("set parent after the child is fresh: code = %d", code)
+	}
+	if code, _ := runCmd(t, "verify", "pre-merge"); code != 0 {
+		t.Errorf("verify parent: code = %d, want 0", code)
+	}
+
+	writeRepoFile(t, dir, "src/a.go", "changed again\n")
+	if code, _ := runCmd(t, "verify", "pre-merge"); code != 1 {
+		t.Errorf("verify parent after the child's delta moved: code = %d, want 1", code)
+	}
+
+	// A child whose base is unusable is an error, not a quiet mismatch,
+	// and it propagates through the parent.
+	gitIn(t, dir, "checkout", "-q", "--", "src/a.go")
+	gitIn(t, dir, "checkout", "-q", "main")
+	if code, msg := runCmdMsg(t, "verify", "pre-merge"); code != 2 || !strings.Contains(msg, "hash=diff") {
+		t.Errorf("verify parent from the base branch: code = %d, msg = %q, want 2 naming hash=diff", code, msg)
+	}
+}
+
+func TestDiffHash_WithStateDir(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a\n")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  integ:\n    hash: diff\n    base: main\n    state_dir: .markgate-state\n    include:\n      - \"src/**\"\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	gitIn(t, dir, "checkout", "-q", "-b", "feat")
+	writeRepoFile(t, dir, "src/a.go", "mine\n")
+	gitIn(t, dir, "commit", "-qam", "my work")
+
+	if code, _ := runCmd(t, "set", "integ"); code != 0 {
+		t.Fatalf("set: code = %d", code)
+	}
+	marker := filepath.Join(dir, ".markgate-state", "integ.json")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("marker not written to state_dir: %v", err)
+	}
+	// The marker now lives inside the worktree. It is out of the gate's
+	// include set, so committing it must not disturb the digest — this
+	// is what makes `diff` shareable the way `files` is.
+	gitIn(t, dir, "add", ".markgate-state")
+	gitIn(t, dir, "commit", "-qm", "commit the marker")
+	if code, _ := runCmd(t, "verify", "integ"); code != 0 {
+		t.Errorf("verify after committing the marker: code = %d, want 0", code)
 	}
 }

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -2212,15 +2212,12 @@ func TestDiffHash_ExplainListsDelta(t *testing.T) {
 // setGitConfigEnv injects git configuration for the duration of t via
 // GIT_CONFIG_COUNT, which outranks the repo's own config file and is
 // how a hostile-but-legal user setting is simulated.
-func setGitConfigEnv(t *testing.T, kv ...string) {
+func setGitConfigEnv(t *testing.T, settings ...[2]string) {
 	t.Helper()
-	if len(kv)%2 != 0 {
-		t.Fatalf("setGitConfigEnv: odd number of arguments: %v", kv)
-	}
-	t.Setenv("GIT_CONFIG_COUNT", strconv.Itoa(len(kv)/2))
-	for i := 0; i < len(kv); i += 2 {
-		t.Setenv(fmt.Sprintf("GIT_CONFIG_KEY_%d", i/2), kv[i])
-		t.Setenv(fmt.Sprintf("GIT_CONFIG_VALUE_%d", i/2), kv[i+1])
+	t.Setenv("GIT_CONFIG_COUNT", strconv.Itoa(len(settings)))
+	for i, kv := range settings {
+		t.Setenv(fmt.Sprintf("GIT_CONFIG_KEY_%d", i), kv[0])
+		t.Setenv(fmt.Sprintf("GIT_CONFIG_VALUE_%d", i), kv[1])
 	}
 }
 
@@ -2257,7 +2254,7 @@ func TestDiffHash_SubdirectoryInvocationKeepsRepoScope(t *testing.T) {
 	writeRepoFile(t, dir, "docs/x.md", "x2 mine\n")
 	gitIn(t, dir, "commit", "-qam", "my work")
 
-	setGitConfigEnv(t, "diff.relative", "true")
+	setGitConfigEnv(t, [2]string{"diff.relative", "true"})
 
 	if code, _ := runCmd(t, "set", "d"); code != 0 {
 		t.Fatalf("set from repo root: code = %d", code)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -92,6 +92,7 @@ func runE(cmd *cobra.Command, args []string, overrides *gateFlagValues, explain 
 	if err := state.Save(c.markerPath, newM); err != nil {
 		return &ExitError{Code: 2, Err: err}
 	}
+	warnEmptyDiffScope(c, cmd.ErrOrStderr())
 	return nil
 }
 

--- a/internal/cli/set.go
+++ b/internal/cli/set.go
@@ -33,6 +33,7 @@ func newSetCmd() *cobra.Command {
 		if err := state.Save(c.markerPath, m); err != nil {
 			return &ExitError{Code: 2, Err: err}
 		}
+		warnEmptyDiffScope(c, cmd.ErrOrStderr())
 		fmt.Fprintf(cmd.OutOrStdout(), "marker saved: %s\n", c.key)
 		return nil
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -60,6 +60,8 @@ type statusMarkerJSON struct {
 	Kind      string `json:"kind,omitempty"`
 	HashType  string `json:"hash_type,omitempty"`
 	Head      string `json:"head,omitempty"`
+	Base      string `json:"base,omitempty"`
+	MergeBase string `json:"merge_base,omitempty"`
 }
 
 type statusRowJSON struct {
@@ -95,6 +97,8 @@ func (r statusRow) toJSON() statusRowJSON {
 			Kind:      r.marker.Kind,
 			HashType:  r.marker.HashType,
 			Head:      r.marker.Head,
+			Base:      r.marker.Base,
+			MergeBase: r.marker.MergeBase,
 		}
 	}
 	return row
@@ -205,6 +209,12 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 	fmt.Fprintf(out, "created:    %s\n", m.CreatedAt.Format(time.RFC3339))
 	if m.Head != "" {
 		fmt.Fprintf(out, "head:       %s\n", m.Head)
+	}
+	if m.Base != "" {
+		fmt.Fprintf(out, "base:       %s\n", m.Base)
+	}
+	if m.MergeBase != "" {
+		fmt.Fprintf(out, "merge base: %s\n", m.MergeBase)
 	}
 	if c.gate.TTL != "" {
 		fmt.Fprintf(out, "ttl:        %s\n", c.gate.TTL)
@@ -363,6 +373,18 @@ func buildRow(c *gateCtx, configured bool, clock time.Time) (statusRow, error) {
 	}
 	res, err := c.evaluate()
 	if err != nil {
+		// A diff gate whose base is unusable (unfetched ref, or HEAD
+		// sitting at the merge base) is an error everywhere else, but
+		// the bare listing is the "show me every gate" view: report the
+		// offending row and keep rendering the others.
+		if errors.Is(err, hasher.ErrDiffBase) {
+			row.state = stateMismatch
+			// Only the "what", not the "how to fix": the remedy clause
+			// after the semicolon would blow the table's width open, and
+			// `markgate status <key>` prints the whole message anyway.
+			row.note = strings.SplitN(err.Error(), ";", 2)[0]
+			return row, nil
+		}
 		return row, err
 	}
 	if res.marker == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ const Filename = ".markgate.yml"
 const (
 	HashGitTree = "git-tree"
 	HashFiles   = "files"
+	HashDiff    = "diff"
 )
 
 // Config mirrors the YAML document.
@@ -38,6 +39,10 @@ type Gate struct {
 	Hash    string   `yaml:"hash"`
 	Include []string `yaml:"include,omitempty"`
 	Exclude []string `yaml:"exclude,omitempty"`
+	// Base is the ref a hash=diff gate measures its delta from
+	// (e.g. origin/main). Required on hash=diff and rejected on every
+	// other hash type, where it would be a silent no-op.
+	Base string `yaml:"base,omitempty"`
 	// StateDir overrides the marker storage directory for this gate.
 	// Relative paths resolve against the repo top-level (same semantics as
 	// the --state-dir flag). Committing an absolute path is an anti-pattern
@@ -162,10 +167,23 @@ func validateGate(c *Config, name string, g Gate) []Finding {
 				Message: fmt.Sprintf("gates.%s: hash=files requires a non-empty include list", name),
 			})
 		}
+	case HashDiff:
+		if g.Base == "" {
+			out = append(out, Finding{
+				Path:    fmt.Sprintf("gates.%s", name),
+				Message: fmt.Sprintf("gates.%s: hash=diff requires a base ref (e.g. base: origin/main)", name),
+			})
+		}
 	default:
 		out = append(out, Finding{
 			Path:    fmt.Sprintf("gates.%s.hash", name),
-			Message: fmt.Sprintf("gates.%s: unknown hash %q (want %q or %q)", name, g.Hash, HashGitTree, HashFiles),
+			Message: fmt.Sprintf("gates.%s: unknown hash %q (want %q, %q or %q)", name, g.Hash, HashGitTree, HashFiles, HashDiff),
+		})
+	}
+	if g.Base != "" && g.Hash != HashDiff {
+		out = append(out, Finding{
+			Path:    fmt.Sprintf("gates.%s.base", name),
+			Message: fmt.Sprintf("gates.%s: base is only valid with hash=diff", name),
 		})
 	}
 	if g.TTL != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,6 +46,43 @@ func TestLoad_FilesRequiresInclude(t *testing.T) {
 	}
 }
 
+func TestLoad_DiffRequiresBase(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "gates:\n  integ:\n    hash: diff\n")
+	if _, err := Load(dir); err == nil {
+		t.Error("want error when base missing for diff")
+	}
+}
+
+func TestLoad_DiffOK(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "gates:\n  integ:\n    hash: diff\n    base: origin/main\n")
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := c.Gate("integ")
+	if g.Hash != HashDiff || g.Base != "origin/main" {
+		t.Errorf("Gate = %+v, want hash=%q base=origin/main", g, HashDiff)
+	}
+}
+
+// base on any other hash type is a silent no-op, which is exactly how a
+// gate ends up trusted for behavior it does not have.
+func TestLoad_BaseRejectedOnNonDiffGate(t *testing.T) {
+	for _, body := range []string{
+		"gates:\n  x:\n    hash: files\n    include:\n      - \"src/**\"\n    base: main\n",
+		"gates:\n  x:\n    hash: git-tree\n    base: main\n",
+		"gates:\n  x:\n    base: main\n",
+	} {
+		dir := t.TempDir()
+		writeConfig(t, dir, body)
+		if _, err := Load(dir); err == nil {
+			t.Errorf("want error for base on a non-diff gate: %q", body)
+		}
+	}
+}
+
 func TestLoad_UnknownHash(t *testing.T) {
 	dir := t.TempDir()
 	writeConfig(t, dir, "gates:\n  x:\n    hash: bogus\n")

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -16,6 +16,9 @@ import (
 // An empty Dir means the current process working directory.
 type Repo struct {
 	Dir string
+	// root memoizes TopLevel so the path-producing commands can be
+	// re-rooted without paying an extra rev-parse per call.
+	root string
 }
 
 // New returns a Repo bound to dir. Pass "" to use the process cwd.
@@ -37,8 +40,29 @@ var ErrRefNotFound = errors.New("ref does not resolve to a commit")
 var ErrNoMergeBase = errors.New("no merge base")
 
 func (r *Repo) run(args ...string) ([]byte, error) {
+	return r.runIn(r.Dir, args...)
+}
+
+// runAtRoot runs git from the worktree root instead of the caller's cwd.
+// Every command whose OUTPUT is a set of paths must go through this:
+// git scopes `ls-files --others` to the cwd subtree, and under
+// `diff.relative` it also prints paths relative to the cwd. Either one
+// silently changes which files a gate covers depending on the directory
+// a hook happened to run from — and a delta whose paths no longer match
+// the repo-relative globs filters down to nothing, which is a marker
+// that can never go stale. Re-rooting fixes both without depending on
+// a git version for --no-relative.
+func (r *Repo) runAtRoot(args ...string) ([]byte, error) {
+	root, err := r.TopLevel()
+	if err != nil {
+		return nil, err
+	}
+	return r.runIn(root, args...)
+}
+
+func (r *Repo) runIn(dir string, args ...string) ([]byte, error) {
 	cmd := exec.Command("git", args...)
-	cmd.Dir = r.Dir
+	cmd.Dir = dir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -55,13 +79,19 @@ func (r *Repo) run(args ...string) ([]byte, error) {
 	return stdout.Bytes(), nil
 }
 
-// TopLevel returns the absolute path to the working tree root.
+// TopLevel returns the absolute path to the working tree root. The
+// result is memoized: it is resolved once per Repo and then reused by
+// every path-producing command.
 func (r *Repo) TopLevel() (string, error) {
+	if r.root != "" {
+		return r.root, nil
+	}
 	out, err := r.run("rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(out)), nil
+	r.root = strings.TrimSpace(string(out))
+	return r.root, nil
 }
 
 // GitDir returns the absolute path to the .git directory (or worktree
@@ -84,9 +114,9 @@ func (r *Repo) HeadSHA() (string, error) {
 }
 
 // DiffHeadNames returns paths (repo-relative) that differ from HEAD in the
-// working tree or index.
+// working tree or index, for the whole repository regardless of cwd.
 func (r *Repo) DiffHeadNames() ([]string, error) {
-	out, err := r.run("diff", "HEAD", "--name-only", "-z")
+	out, err := r.runAtRoot("diff", "HEAD", "--name-only", "-z")
 	if err != nil {
 		return nil, err
 	}
@@ -143,10 +173,11 @@ const zeroBlob = "0000000000000000000000000000000000000000"
 
 // DiffFrom returns the working-tree differences against commit rev
 // (index state is irrelevant, matching the git-tree hasher's staging
-// invariant). Rename detection is off and SHAs are unabbreviated so the
-// result never depends on the caller's git config.
+// invariant). Rename detection is off, SHAs are unabbreviated, and the
+// command runs from the worktree root, so the result depends on neither
+// the caller's git config nor the directory it was invoked from.
 func (r *Repo) DiffFrom(rev string) ([]DiffEntry, error) {
-	out, err := r.run("diff", "--raw", "--no-abbrev", "--no-renames", "-z", rev)
+	out, err := r.runAtRoot("diff", "--raw", "--no-abbrev", "--no-renames", "-z", rev)
 	if err != nil {
 		return nil, err
 	}
@@ -168,9 +199,9 @@ func (r *Repo) DiffFrom(rev string) ([]DiffEntry, error) {
 }
 
 // UntrackedNames returns paths (repo-relative) that are untracked but not
-// ignored.
+// ignored, for the whole repository regardless of cwd.
 func (r *Repo) UntrackedNames() ([]string, error) {
-	out, err := r.run("ls-files", "--others", "--exclude-standard", "-z")
+	out, err := r.runAtRoot("ls-files", "--others", "--exclude-standard", "-z")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -27,6 +27,15 @@ func New(dir string) *Repo {
 // inside a repository. Callers translate this to exit code 2.
 var ErrNotARepo = errors.New("not a git repository")
 
+// ErrRefNotFound is returned by ResolveCommit / MergeBase when the ref
+// does not resolve to a commit (typo, or never fetched).
+var ErrRefNotFound = errors.New("ref does not resolve to a commit")
+
+// ErrNoMergeBase is returned by MergeBase when the two commits share no
+// ancestor (unrelated histories, or a shallow clone that does not reach
+// far enough back).
+var ErrNoMergeBase = errors.New("no merge base")
+
 func (r *Repo) run(args ...string) ([]byte, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = r.Dir
@@ -82,6 +91,80 @@ func (r *Repo) DiffHeadNames() ([]string, error) {
 		return nil, err
 	}
 	return splitNUL(out), nil
+}
+
+// ResolveCommit returns the full SHA that ref points at, or
+// ErrRefNotFound when it does not name a commit.
+func (r *Repo) ResolveCommit(ref string) (string, error) {
+	out, err := r.run("rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("%q: %w", ref, ErrRefNotFound)
+	}
+	sha := strings.TrimSpace(string(out))
+	if sha == "" {
+		return "", fmt.Errorf("%q: %w", ref, ErrRefNotFound)
+	}
+	return sha, nil
+}
+
+// MergeBase returns the best common ancestor of ref and HEAD. The ref is
+// resolved first so an unfetched / mistyped ref reports ErrRefNotFound
+// rather than the generic "no merge base".
+func (r *Repo) MergeBase(ref string) (string, error) {
+	if _, err := r.ResolveCommit(ref); err != nil {
+		return "", err
+	}
+	// git merge-base exits 1 with empty output when no ancestor exists,
+	// which run() surfaces as a bare "exit status 1"; both shapes mean
+	// the same thing to callers.
+	out, err := r.run("merge-base", ref, "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("%q and HEAD: %w", ref, ErrNoMergeBase)
+	}
+	sha := strings.TrimSpace(string(out))
+	if sha == "" {
+		return "", fmt.Errorf("%q and HEAD: %w", ref, ErrNoMergeBase)
+	}
+	return sha, nil
+}
+
+// DiffEntry is one path whose working-tree content differs from a base
+// commit. BaseBlob is the blob SHA the base side holds, or "" when the
+// path does not exist there (added on this side).
+type DiffEntry struct {
+	Path     string
+	BaseBlob string
+}
+
+// zeroBlob is git's "unknown / absent" blob SHA in raw diff output. It
+// appears on the destination side of every working-tree comparison, and
+// on the source side of an addition.
+const zeroBlob = "0000000000000000000000000000000000000000"
+
+// DiffFrom returns the working-tree differences against commit rev
+// (index state is irrelevant, matching the git-tree hasher's staging
+// invariant). Rename detection is off and SHAs are unabbreviated so the
+// result never depends on the caller's git config.
+func (r *Repo) DiffFrom(rev string) ([]DiffEntry, error) {
+	out, err := r.run("diff", "--raw", "--no-abbrev", "--no-renames", "-z", rev)
+	if err != nil {
+		return nil, err
+	}
+	fields := splitNUL(out)
+	entries := make([]DiffEntry, 0, len(fields)/2)
+	for i := 0; i+1 < len(fields); i += 2 {
+		// meta is ":<srcmode> <dstmode> <srcsha> <dstsha> <status>".
+		meta := strings.Fields(fields[i])
+		if len(meta) < 5 {
+			return nil, fmt.Errorf("git diff --raw: unexpected record %q", fields[i])
+		}
+		base := meta[2]
+		if base == zeroBlob {
+			base = ""
+		}
+		entries = append(entries, DiffEntry{Path: fields[i+1], BaseBlob: base})
+	}
+	return entries, nil
 }
 
 // UntrackedNames returns paths (repo-relative) that are untracked but not

--- a/internal/hasher/diff.go
+++ b/internal/hasher/diff.go
@@ -1,0 +1,162 @@
+package hasher
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/go-to-k/markgate/internal/config"
+	"github.com/go-to-k/markgate/internal/gitutil"
+)
+
+// ErrDiffBase marks the fail-closed preconditions of the diff hasher: a
+// base ref that cannot be resolved, and a working tree that is identical
+// to the merge base (where the delta is empty, so the digest is a
+// constant the marker could never fall out of). Callers that render many
+// gates at once (bare `status`) match on it to degrade one row instead
+// of aborting the whole listing; every other command surfaces it as an
+// error.
+var ErrDiffBase = errors.New("hash=diff")
+
+// Diff hashes the working-tree delta against merge-base(Base, HEAD):
+// for every changed path it folds in the blob the base side holds plus
+// the current worktree content. Untracked-and-not-ignored files count as
+// changes too, so a brand-new in-scope file is never invisible.
+//
+// Neither HEAD nor the merge-base SHA is part of the digest. That is the
+// whole point: when the base branch moves under an unrelated in-scope
+// file, that file stops differing from the new merge base and drops out
+// of the digest, leaving the marker fresh. A base-branch change to a
+// file this branch also touched stays in the delta and still invalidates.
+//
+// An empty delta (a clean base-branch checkout, a branch with no changes
+// yet, a fully reverted branch) is refused: see ErrDiffBase.
+type Diff struct {
+	Include []string
+	Exclude []string
+	Base    string
+}
+
+// Type implements Hasher.
+func (Diff) Type() string { return config.HashDiff }
+
+// Hash implements Hasher.
+func (d Diff) Hash(repo *gitutil.Repo) (string, error) {
+	top, err := repo.TopLevel()
+	if err != nil {
+		return "", err
+	}
+	entries, err := d.entries(repo)
+	if err != nil {
+		return "", err
+	}
+
+	h := sha256.New()
+	for _, e := range entries {
+		// The base-side blob is framed in so that resolving a merge by
+		// keeping this branch's version — same worktree content, new
+		// starting point — still counts as a change.
+		fmt.Fprintf(h, "base\x00%s\x00%s\x00", e.Path, e.BaseBlob)
+		if err := hashEntry(h, filepath.Join(top, e.Path), e.Path); err != nil {
+			return "", err
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// Scope implements Hasher.
+func (d Diff) Scope(repo *gitutil.Repo) ([]string, error) {
+	entries, err := d.entries(repo)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Path)
+	}
+	return out, nil
+}
+
+// MergeBase resolves merge-base(Base, HEAD), reporting an unusable base
+// ref as ErrDiffBase. Exported so `set` can record the resolved SHA on
+// the marker for diagnostics.
+func (d Diff) MergeBase(repo *gitutil.Repo) (string, error) {
+	if d.Base == "" {
+		return "", fmt.Errorf("%w: no base ref configured", ErrDiffBase)
+	}
+	mergeBase, err := repo.MergeBase(d.Base)
+	switch {
+	case errors.Is(err, gitutil.ErrRefNotFound):
+		return "", fmt.Errorf("%w: base ref %q does not resolve; fetch it first (git fetch origin)", ErrDiffBase, d.Base)
+	case errors.Is(err, gitutil.ErrNoMergeBase):
+		return "", fmt.Errorf("%w: %q and HEAD share no history; a shallow clone needs git fetch --unshallow", ErrDiffBase, d.Base)
+	case err != nil:
+		return "", err
+	}
+	return mergeBase, nil
+}
+
+// Preflight reports the same errors Hash would, without computing a
+// digest. Callers use it to refuse a misconfigured gate before doing
+// expensive work — `markgate run` would otherwise execute its child and
+// only then discover it cannot record the result.
+func (d Diff) Preflight(repo *gitutil.Repo) error {
+	_, err := d.entries(repo)
+	return err
+}
+
+// entries returns the sorted, include/exclude-filtered delta. Patterns
+// are matched with the same doublestar matcher the other hashers use —
+// never handed to git as pathspecs, whose default magic gives the same
+// pattern a different meaning (`src/*.go` matches across directory
+// boundaries there, `src/**/*.go` does not match `src/a.go`).
+func (d Diff) entries(repo *gitutil.Repo) ([]gitutil.DiffEntry, error) {
+	mergeBase, err := d.MergeBase(repo)
+	if err != nil {
+		return nil, err
+	}
+	changed, err := repo.DiffFrom(mergeBase)
+	if err != nil {
+		return nil, err
+	}
+	untracked, err := repo.UntrackedNames()
+	if err != nil {
+		return nil, err
+	}
+
+	// An empty delta is the one state this hash type cannot represent:
+	// the digest degenerates to a constant, so a marker set here would
+	// never go stale again. Refuse it rather than hand back a digest
+	// that cannot expire. Checked before include/exclude filtering — a
+	// branch whose changes all land outside the gate's scope is exactly
+	// the case this hash type exists to keep fresh.
+	if len(changed) == 0 && len(untracked) == 0 {
+		return nil, fmt.Errorf("%w: no delta against merge-base(%s, HEAD); the digest would be a constant that never goes stale, so run this gate from a branch ahead of the base rather than the base branch itself", ErrDiffBase, d.Base)
+	}
+
+	baseBlob := make(map[string]string, len(changed)+len(untracked))
+	paths := make([]string, 0, len(changed)+len(untracked))
+	for _, e := range changed {
+		baseBlob[e.Path] = e.BaseBlob
+		paths = append(paths, e.Path)
+	}
+	for _, p := range untracked {
+		if _, ok := baseBlob[p]; ok {
+			continue
+		}
+		baseBlob[p] = ""
+		paths = append(paths, p)
+	}
+
+	kept, err := filterGlobs(dedupSort(paths), d.Include, d.Exclude)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]gitutil.DiffEntry, 0, len(kept))
+	for _, p := range kept {
+		out = append(out, gitutil.DiffEntry{Path: p, BaseBlob: baseBlob[p]})
+	}
+	return out, nil
+}

--- a/internal/hasher/diff_test.go
+++ b/internal/hasher/diff_test.go
@@ -1,6 +1,7 @@
 package hasher
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -242,6 +243,48 @@ func TestDiff_BinaryContentGoesStale(t *testing.T) {
 	}
 }
 
+// TestDiff_ResolvingAMergeByKeepingOursStillCounts is the case the
+// base-blob half of the digest exists for. Content-only hashing cannot
+// see it: the worktree bytes are unchanged, but the branch now carries
+// its version of the file over a DIFFERENT base version, and that
+// combination was never verified.
+func TestDiff_ResolvingAMergeByKeepingOursStillCounts(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/a.go", "MINE\na2\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+
+	h := srcDiff()
+	before := mustHash(t, h, repo)
+	beforeBytes, err := os.ReadFile(filepath.Join(dir, "src/a.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The base branch rewrites the same line, so merging conflicts.
+	runGit(t, dir, "checkout", "-q", "main")
+	writeFile(t, dir, "src/a.go", "BASE\na2\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "base rewrites the same line")
+	runGit(t, dir, "checkout", "-q", "feat")
+	if out, mergeErr := runGitAllowFail(dir, "merge", "--no-edit", "main"); mergeErr == nil {
+		t.Fatalf("fixture broken: the merge was expected to conflict\n%s", out)
+	}
+	runGit(t, dir, "checkout", "--ours", "--", "src/a.go")
+	runGit(t, dir, "add", "src/a.go")
+	runGit(t, dir, "commit", "-qm", "resolve by keeping ours")
+
+	afterBytes, err := os.ReadFile(filepath.Join(dir, "src/a.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(beforeBytes, afterBytes) {
+		t.Fatalf("fixture broken: worktree content changed, so the test would pass on content alone\nbefore=%q after=%q", beforeBytes, afterBytes)
+	}
+
+	if after := mustHash(t, h, repo); before == after {
+		t.Error("keeping ours over a moved base did not invalidate the digest")
+	}
+}
+
 func TestDiff_OnBaseBranchErrors(t *testing.T) {
 	repo, dir := newDiffRepo(t)
 	runGit(t, dir, "checkout", "-q", "main")
@@ -308,6 +351,13 @@ func TestDiff_MissingBaseErrors(t *testing.T) {
 // is filtered with doublestar rather than handed to git as a pathspec:
 // git's default pathspec magic reads `src/*.go` as matching across
 // directory boundaries and `src/**/*.go` as NOT matching `src/a.go`.
+//
+// The guarantee is about PATTERN SEMANTICS, and holds for a non-empty
+// include list over paths that exist in the worktree. The two modes
+// select from different universes — `files` globs the filesystem,
+// `diff` filters the branch's delta — so they legitimately differ
+// where those universes do; the two cases that produces are pinned by
+// the tests immediately below rather than papered over here.
 func TestDiff_ScopeMatchesFilesHasher(t *testing.T) {
 	repo, dir := newDiffRepo(t)
 	writeFile(t, dir, "src/deep/nested/c.go", "c\n")
@@ -350,6 +400,63 @@ func TestDiff_ScopeMatchesFilesHasher(t *testing.T) {
 		}
 		if !equalStrings(want, got) {
 			t.Errorf("include=%v exclude=%v: files scope %v, diff scope %v", tc.include, tc.exclude, want, got)
+		}
+	}
+}
+
+// TestDiff_EmptyIncludeCoversTheWholeDelta pins one of the two
+// deliberate divergences: an omitted include is a legal diff config
+// meaning "everything I changed", whereas `hash: files` rejects it at
+// validation (it would have nothing to glob).
+func TestDiff_EmptyIncludeCoversTheWholeDelta(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/a.go", "mine\n")
+	writeFile(t, dir, "docs/x.md", "mine too\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+
+	scope, err := (Diff{Base: "main"}).Scope(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(scope, []string{"docs/x.md", "src/a.go"}) {
+		t.Errorf("unscoped diff scope = %v, want the whole delta", scope)
+	}
+
+	// Excluding without including is equally legal and subtracts from
+	// that whole-delta default.
+	scope, err = (Diff{Exclude: []string{"docs/**"}, Base: "main"}).Scope(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(scope, []string{"src/a.go"}) {
+		t.Errorf("exclude-only diff scope = %v, want the delta minus docs", scope)
+	}
+}
+
+// TestDiff_DeletedPathStaysInScope pins the other divergence: `files`
+// globs the filesystem, so a deleted path simply vanishes from its
+// scope, while `diff` must keep it — a branch that deletes an in-scope
+// file has certainly changed what the gate verified.
+func TestDiff_DeletedPathStaysInScope(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	runGit(t, dir, "rm", "-q", "src/b.go")
+	runGit(t, dir, "commit", "-qm", "delete an in-scope file")
+
+	diffScope, err := (Diff{Include: []string{"src/**"}, Base: "main"}).Scope(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalStrings(diffScope, []string{"src/b.go"}) {
+		t.Errorf("diff scope = %v, want the deleted path", diffScope)
+	}
+
+	filesScope, err := (Files{Include: []string{"src/**"}}).Scope(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range filesScope {
+		if p == "src/b.go" {
+			t.Error("files scope unexpectedly contains the deleted path")
 		}
 	}
 }

--- a/internal/hasher/diff_test.go
+++ b/internal/hasher/diff_test.go
@@ -1,0 +1,367 @@
+package hasher
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/go-to-k/markgate/internal/gitutil"
+)
+
+// newDiffRepo returns a repo whose main branch holds src/a.go, src/b.go
+// and docs/x.md, with a feature branch checked out.
+func newDiffRepo(t *testing.T) (*gitutil.Repo, string) {
+	t.Helper()
+	repo, dir := newTestRepo(t)
+	writeFile(t, dir, "src/a.go", "a1\na2\na3\na4\na5\n")
+	writeFile(t, dir, "src/b.go", "b1\nb2\nb3\nb4\nb5\n")
+	writeFile(t, dir, "docs/x.md", "x\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-qm", "seed")
+	runGit(t, dir, "checkout", "-q", "-b", "feat")
+	return repo, dir
+}
+
+func srcDiff() Diff {
+	return Diff{Include: []string{"src/**"}, Base: "main"}
+}
+
+func mustHash(t *testing.T, h Hasher, repo *gitutil.Repo) string {
+	t.Helper()
+	d, err := h.Hash(repo)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	return d
+}
+
+func TestDiff_UnrelatedBaseBranchChangeStaysFresh(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+
+	h := srcDiff()
+	before := mustHash(t, h, repo)
+
+	// An in-scope file this branch never touched changes on the base
+	// branch, and the branch merges it in.
+	runGit(t, dir, "checkout", "-q", "main")
+	writeFile(t, dir, "src/b.go", "b1\nb2\nb3\nb4\nBASE\n")
+	runGit(t, dir, "commit", "-qam", "unrelated base work")
+	runGit(t, dir, "checkout", "-q", "feat")
+	runGit(t, dir, "merge", "-q", "--no-edit", "main")
+
+	after := mustHash(t, h, repo)
+	if before != after {
+		t.Errorf("unrelated base-branch change invalidated the digest: %s -> %s", before, after)
+	}
+}
+
+func TestDiff_SameFileBaseBranchChangeGoesStale(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/a.go", "MINE\na2\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+
+	h := srcDiff()
+	before := mustHash(t, h, repo)
+
+	// The base branch touches the same file, far enough away to merge
+	// cleanly: the combination is unverified, so the marker must go stale.
+	runGit(t, dir, "checkout", "-q", "main")
+	writeFile(t, dir, "src/a.go", "a1\na2\na3\na4\nBASE\n")
+	runGit(t, dir, "commit", "-qam", "base touches the same file")
+	runGit(t, dir, "checkout", "-q", "feat")
+	runGit(t, dir, "merge", "-q", "--no-edit", "main")
+
+	after := mustHash(t, h, repo)
+	if before == after {
+		t.Error("base-branch change to a file this branch also changed did not invalidate the digest")
+	}
+}
+
+func TestDiff_UncommittedInScopeEditGoesStale(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	h := srcDiff()
+	writeFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+	before := mustHash(t, h, repo)
+
+	writeFile(t, dir, "src/a.go", "a1\nMINE AGAIN\na3\na4\na5\n")
+	if after := mustHash(t, h, repo); before == after {
+		t.Error("uncommitted in-scope edit did not invalidate the digest")
+	}
+}
+
+func TestDiff_OutOfScopeEditStaysFresh(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	h := srcDiff()
+	writeFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+	before := mustHash(t, h, repo)
+
+	writeFile(t, dir, "docs/x.md", "edited outside the include set\n")
+	runGit(t, dir, "commit", "-qam", "docs")
+	if after := mustHash(t, h, repo); before != after {
+		t.Errorf("out-of-scope edit invalidated the digest: %s -> %s", before, after)
+	}
+}
+
+func TestDiff_UntrackedInScopeFileGoesStale(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	h := srcDiff()
+	writeFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+	before := mustHash(t, h, repo)
+
+	// Untracked files are absent from `git diff`; the hasher folds them
+	// in explicitly so a brand-new source file is never invisible.
+	writeFile(t, dir, "src/new.go", "brand new\n")
+	if after := mustHash(t, h, repo); before == after {
+		t.Error("untracked in-scope file did not invalidate the digest")
+	}
+}
+
+func TestDiff_DeletionGoesStale(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	h := srcDiff()
+	writeFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+	before := mustHash(t, h, repo)
+
+	runGit(t, dir, "rm", "-q", "src/b.go")
+	if after := mustHash(t, h, repo); before == after {
+		t.Error("in-scope deletion did not invalidate the digest")
+	}
+}
+
+func TestDiff_StagingInvariant(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	h := srcDiff()
+	writeFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	before := mustHash(t, h, repo)
+
+	runGit(t, dir, "add", "src/a.go")
+	if after := mustHash(t, h, repo); before != after {
+		t.Errorf("digest changed across git add: %s -> %s", before, after)
+	}
+}
+
+func TestDiff_CommittingOwnWorkIsNotAChange(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	h := srcDiff()
+	writeFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	before := mustHash(t, h, repo)
+
+	// Unlike git-tree, committing the very content that was verified
+	// leaves the digest alone: the delta against the merge base is the
+	// same either way.
+	runGit(t, dir, "commit", "-qam", "commit the verified content")
+	if after := mustHash(t, h, repo); before != after {
+		t.Errorf("committing already-hashed content changed the digest: %s -> %s", before, after)
+	}
+}
+
+// TestDiff_DigestIsInvariantUnderGitConfig is the reason the digest is
+// built from blob identity plus worktree bytes rather than from the text
+// `git diff` prints: patch rendering is configurable per user, so a
+// text-derived digest would differ between two machines holding the same
+// content — turning every shared marker into a permanent miss.
+func TestDiff_DigestIsInvariantUnderGitConfig(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+	writeFile(t, dir, "src/new.go", "brand new\n")
+
+	h := srcDiff()
+	want := mustHash(t, h, repo)
+
+	cfg := [][2]string{
+		{"diff.algorithm", "patience"},
+		{"diff.mnemonicPrefix", "true"},
+		{"diff.context", "7"},
+		{"diff.noprefix", "true"},
+		{"diff.renames", "copies"},
+		{"diff.external", "/bin/false"},
+		{"color.diff", "always"},
+		{"core.abbrev", "12"},
+		{"core.autocrlf", "input"},
+	}
+	t.Setenv("GIT_CONFIG_COUNT", strconv.Itoa(len(cfg)))
+	for i, kv := range cfg {
+		t.Setenv(fmt.Sprintf("GIT_CONFIG_KEY_%d", i), kv[0])
+		t.Setenv(fmt.Sprintf("GIT_CONFIG_VALUE_%d", i), kv[1])
+	}
+	// GIT_EXTERNAL_DIFF would replace patch generation wholesale; the
+	// raw comparison never renders one, so it cannot be reached.
+	t.Setenv("GIT_EXTERNAL_DIFF", "/bin/false")
+
+	if got := mustHash(t, h, repo); got != want {
+		t.Errorf("digest moved under non-default git config: %s -> %s", want, got)
+	}
+}
+
+// TestDiff_ModeChangeGoesStale documents how a mode-only change is
+// represented: content is identical on both sides, but the path joins the
+// delta, so the digest moves. Stricter than hash: files, which never sees
+// permission bits at all.
+func TestDiff_ModeChangeGoesStale(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+
+	h := srcDiff()
+	before := mustHash(t, h, repo)
+
+	if err := os.Chmod(filepath.Join(dir, "src/b.go"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if after := mustHash(t, h, repo); before == after {
+		t.Error("mode-only change did not invalidate the digest")
+	}
+}
+
+// TestDiff_BinaryContentGoesStale pins that binary payloads are compared
+// as bytes: no "Binary files differ" placeholder can hide a change.
+func TestDiff_BinaryContentGoesStale(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/blob.bin", "\x00\x01\x02binary\x00")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-qm", "binary")
+	writeFile(t, dir, "src/a.go", "a1\nMINE\na3\na4\na5\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+
+	h := srcDiff()
+	before := mustHash(t, h, repo)
+
+	writeFile(t, dir, "src/blob.bin", "\x00\x01\x02BINARY\x00")
+	if after := mustHash(t, h, repo); before == after {
+		t.Error("binary content change did not invalidate the digest")
+	}
+}
+
+func TestDiff_OnBaseBranchErrors(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	runGit(t, dir, "checkout", "-q", "main")
+
+	_, err := srcDiff().Hash(repo)
+	if err == nil {
+		t.Fatal("want an error when HEAD is at the merge base, got nil")
+	}
+	if !errors.Is(err, ErrDiffBase) {
+		t.Errorf("error = %v, want one matching ErrDiffBase", err)
+	}
+}
+
+func TestDiff_BehindBaseBranchErrors(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	// feat has no commits of its own, main moves ahead: HEAD is still the
+	// merge base, so the delta is empty and the digest would be constant.
+	runGit(t, dir, "checkout", "-q", "main")
+	writeFile(t, dir, "src/b.go", "moved on\n")
+	runGit(t, dir, "commit", "-qam", "base moves ahead")
+	runGit(t, dir, "checkout", "-q", "feat")
+
+	if _, err := srcDiff().Hash(repo); !errors.Is(err, ErrDiffBase) {
+		t.Errorf("error = %v, want one matching ErrDiffBase", err)
+	}
+}
+
+func TestDiff_UnresolvableBaseErrors(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/a.go", "mine\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+
+	h := Diff{Include: []string{"src/**"}, Base: "origin/never-fetched"}
+	_, err := h.Hash(repo)
+	if !errors.Is(err, ErrDiffBase) {
+		t.Fatalf("error = %v, want one matching ErrDiffBase", err)
+	}
+	if _, scopeErr := h.Scope(repo); !errors.Is(scopeErr, ErrDiffBase) {
+		t.Errorf("Scope error = %v, want one matching ErrDiffBase", scopeErr)
+	}
+}
+
+func TestDiff_NoMergeBaseErrors(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	runGit(t, dir, "checkout", "-q", "--orphan", "unrelated")
+	writeFile(t, dir, "src/a.go", "unrelated history\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-qm", "orphan")
+
+	if _, err := srcDiff().Hash(repo); !errors.Is(err, ErrDiffBase) {
+		t.Errorf("error = %v, want one matching ErrDiffBase", err)
+	}
+}
+
+func TestDiff_MissingBaseErrors(t *testing.T) {
+	repo, _ := newDiffRepo(t)
+	if _, err := (Diff{Include: []string{"src/**"}}).Hash(repo); !errors.Is(err, ErrDiffBase) {
+		t.Errorf("error = %v, want one matching ErrDiffBase", err)
+	}
+}
+
+// TestDiff_ScopeMatchesFilesHasher pins the guarantee that include /
+// exclude mean the same thing in both modes. It is the reason the delta
+// is filtered with doublestar rather than handed to git as a pathspec:
+// git's default pathspec magic reads `src/*.go` as matching across
+// directory boundaries and `src/**/*.go` as NOT matching `src/a.go`.
+func TestDiff_ScopeMatchesFilesHasher(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/deep/nested/c.go", "c\n")
+	writeFile(t, dir, "src/notes.md", "n\n")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-qm", "more files")
+
+	// Every tracked file differs from the merge base, so the two hashers
+	// see the same candidate set and any divergence is glob semantics.
+	for _, rel := range []string{"src/a.go", "src/b.go", "src/deep/nested/c.go", "src/notes.md", "docs/x.md"} {
+		writeFile(t, dir, rel, "touched by this branch\n")
+	}
+	runGit(t, dir, "commit", "-qam", "touch everything")
+
+	cases := []struct {
+		include []string
+		exclude []string
+	}{
+		{include: []string{"src/**"}},
+		{include: []string{"src/**/*.go"}},
+		{include: []string{"src/*.go"}},
+		{include: []string{"**/*.md"}},
+		{include: []string{"src/**"}, exclude: []string{"**/*.md"}},
+		{include: []string{"src/**", "docs/**"}, exclude: []string{"src/deep/**"}},
+		{include: []string{"docs/x.md"}},
+	}
+	for _, tc := range cases {
+		files := Files{Include: tc.include, Exclude: tc.exclude}
+		want, err := files.Scope(repo)
+		if err != nil {
+			t.Fatalf("files scope %v: %v", tc.include, err)
+		}
+		diff := Diff{Include: tc.include, Exclude: tc.exclude, Base: "main"}
+		got, err := diff.Scope(repo)
+		if err != nil {
+			t.Fatalf("diff scope %v: %v", tc.include, err)
+		}
+		if len(want) == 0 {
+			t.Fatalf("include %v matched nothing under hash=files; the case proves nothing", tc.include)
+		}
+		if !equalStrings(want, got) {
+			t.Errorf("include=%v exclude=%v: files scope %v, diff scope %v", tc.include, tc.exclude, want, got)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/hasher/diff_test.go
+++ b/internal/hasher/diff_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -398,7 +399,7 @@ func TestDiff_ScopeMatchesFilesHasher(t *testing.T) {
 		if len(want) == 0 {
 			t.Fatalf("include %v matched nothing under hash=files; the case proves nothing", tc.include)
 		}
-		if !equalStrings(want, got) {
+		if !slices.Equal(want, got) {
 			t.Errorf("include=%v exclude=%v: files scope %v, diff scope %v", tc.include, tc.exclude, want, got)
 		}
 	}
@@ -418,7 +419,7 @@ func TestDiff_EmptyIncludeCoversTheWholeDelta(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !equalStrings(scope, []string{"docs/x.md", "src/a.go"}) {
+	if !slices.Equal(scope, []string{"docs/x.md", "src/a.go"}) {
 		t.Errorf("unscoped diff scope = %v, want the whole delta", scope)
 	}
 
@@ -428,7 +429,7 @@ func TestDiff_EmptyIncludeCoversTheWholeDelta(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !equalStrings(scope, []string{"src/a.go"}) {
+	if !slices.Equal(scope, []string{"src/a.go"}) {
 		t.Errorf("exclude-only diff scope = %v, want the delta minus docs", scope)
 	}
 }
@@ -446,7 +447,7 @@ func TestDiff_DeletedPathStaysInScope(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !equalStrings(diffScope, []string{"src/b.go"}) {
+	if !slices.Equal(diffScope, []string{"src/b.go"}) {
 		t.Errorf("diff scope = %v, want the deleted path", diffScope)
 	}
 
@@ -459,16 +460,4 @@ func TestDiff_DeletedPathStaysInScope(t *testing.T) {
 			t.Error("files scope unexpectedly contains the deleted path")
 		}
 	}
-}
-
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/hasher/hasher.go
+++ b/internal/hasher/hasher.go
@@ -1,12 +1,15 @@
 // Package hasher computes the state digest that markgate stores in a
 // marker and compares at verify time.
 //
-// Two strategies are provided:
+// Three strategies are provided:
 //
 //   - GitTree: hashes HEAD + (diff ∪ untracked), including deletions.
 //     Safe default; invalidates automatically when HEAD moves.
 //   - Files:   hashes files matching include globs minus exclude globs.
 //     Useful when you want narrower invalidation (e.g. docs only).
+//   - Diff:    hashes the working-tree delta against merge-base(base,
+//     HEAD). Changes arriving from the base branch under files this
+//     branch has not touched leave the digest alone.
 //
 // The digest format (framing, sort order, etc.) is an implementation
 // detail; markers written by one version are not guaranteed to validate
@@ -45,6 +48,8 @@ func For(g config.Gate) (Hasher, error) {
 		return GitTree{Include: g.Include, Exclude: g.Exclude}, nil
 	case config.HashFiles:
 		return Files{Include: g.Include, Exclude: g.Exclude}, nil
+	case config.HashDiff:
+		return Diff{Include: g.Include, Exclude: g.Exclude, Base: g.Base}, nil
 	default:
 		return nil, fmt.Errorf("unknown hash type %q", g.Hash)
 	}

--- a/internal/hasher/testhelpers_test.go
+++ b/internal/hasher/testhelpers_test.go
@@ -26,6 +26,16 @@ func newTestRepo(t *testing.T) (*gitutil.Repo, string) {
 	return gitutil.New(dir), dir
 }
 
+// runGitAllowFail is runGit for commands whose failure is the point
+// (a conflicting merge), returning the combined output and the error
+// instead of failing the test.
+func runGitAllowFail(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -48,12 +48,20 @@ const (
 )
 
 // Marker is the serialized form of a recorded state hash.
+//
+// Head, Base and MergeBase are diagnostics for `markgate status`, never
+// inputs to the freshness comparison: Head is written by the git-tree
+// hasher (whose digest already covers it), Base / MergeBase by the diff
+// hasher (whose digest deliberately excludes them, so a base branch that
+// moves under untouched files leaves the marker fresh).
 type Marker struct {
 	Version   int       `json:"version"`
 	Kind      string    `json:"kind,omitempty"`
 	HashType  string    `json:"hash_type,omitempty"`
 	Digest    string    `json:"digest,omitempty"`
 	Head      string    `json:"head,omitempty"`
+	Base      string    `json:"base,omitempty"`
+	MergeBase string    `json:"merge_base,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 }
 


### PR DESCRIPTION
Closes #68

## What

Adds a third hashing strategy, `hash: diff`, whose digest is the working-tree delta against `merge-base(base, HEAD)` rather than the content of the include set. A change that arrives from the base branch under a file this branch never touched drops out of the delta and leaves the marker fresh; a change to a file this branch also touched stays in the delta and still invalidates. Opt-in per gate; `git-tree` and `files` are untouched.

```yaml
gates:
  integ:
    hash: diff
    base: origin/main
    ttl: 14d
    include:
      - "src/providers/**"
```

## Design decisions that differ from the issue

Three points where the issue's sketch did not survive contact with the code. Each is implemented as described below and covered by a test.

**1. The digest is not `git diff` text.** The issue proposes hashing `git diff <merge-base>`. That output is a function of the invoking user's git configuration - `diff.algorithm`, `diff.context`, `diff.noprefix`, `diff.mnemonicPrefix`, `diff.renames`, `color.diff`, `core.abbrev`, external diff drivers - so two developers, or a developer and CI, would compute different digests for identical content. That does not make a marker stale, it makes it permanently worthless, which is worse than the problem being solved and would silently break the "Sharing markers" feature.

This implementation digests, per in-scope path, the blob SHA the merge base holds plus the current bytes on disk. Same freshness semantics, but the inputs are git object identity and file content rather than rendering options. `TestDiff_DigestIsInvariantUnderGitConfig` pins it by recomputing under nine non-default settings injected via `GIT_CONFIG_COUNT` (plus `GIT_EXTERNAL_DIFF`) and asserting the digest does not move.

Worktree bytes are read directly rather than via `git hash-object`, for two reasons: it is what `hash: files` and `git-tree` already hash, so a gate cannot mean different things in different modes; and a `clean` filter that normalises content away would make two genuinely different worktrees hash identically, which is a fail-open. The cost is that `core.autocrlf` affects the digest exactly as it already does for the other two strategies - no new divergence, and Unix/CI agree.

Binary files are compared as bytes (no "Binary files differ" placeholder to hide behind). A mode-only `chmod` adds the path to the delta and therefore invalidates - stricter than `hash: files`, which never sees permission bits.

**2. Untracked files are part of the delta.** `git diff` does not list them, so a digest taken from the diff alone would be blind to a brand-new in-scope source file: the marker would stay fresh while unverified code sat in the tree. The hasher folds in `ls-files --others --exclude-standard`, matching what `git-tree` and `files` already do.

**3. The empty-delta guard is on the delta, not on `HEAD == merge-base`.** The issue asks to error when HEAD sits at the merge base. That proxy is wrong in both directions:

- It **blocks a legitimate case.** On a fresh branch with uncommitted work, HEAD still equals the merge base. That is exactly the state markgate's core pre-commit flow runs in, so a diff gate could never guard a pre-commit hook.
- It **misses a real one.** A branch whose commits were fully reverted has `HEAD != merge-base` and an empty delta - the constant digest the rule exists to prevent, waved through.

The hazard is the empty delta itself, so that is what is checked, before include/exclude filtering. A branch whose changes all fall outside the gate's scope legitimately keeps a stable digest - that is the feature - while a clean base-branch checkout, a changeless branch and a reverted branch all error.

## Other decisions

- **`base` is required, no default.** Resolving `origin/HEAD` is tempting but it is frequently unset in CI clones, so the same gate would silently mean different things on a laptop and in CI. Mirrors the existing "`hash: files` requires `include`" precedent.
- **`base` on a non-diff gate is an error**, at config load and behind the `--base` flag. Accepting it silently is how a gate ends up trusted for behaviour it does not have; `config lint` surfaces it with the rest.
- **include/exclude are filtered with doublestar, never passed to git as pathspecs.** Verified rather than assumed: with git's default pathspec magic, `src/*.go` matches `src/deep/b.go` (crosses `/`) and `src/**/*.go` matches only `src/deep/b.go`, missing `src/a.go`. `TestDiff_ScopeMatchesFilesHasher` asserts the two modes resolve identical file sets across seven include/exclude combinations.
- **Preconditions are checked eagerly**, before the marker is loaded. Otherwise `markgate run` on a misconfigured gate would report a plain mismatch, execute its (by assumption expensive) child, and only then refuse to record the result.
- **The marker gains `base` and `merge_base`**, both diagnostics only and never compared - a moved merge base is precisely what this hash type exists to tolerate. `status` prints them. No schema bump: the fields are additive and older markers simply lack them.
- **Bare `markgate status` degrades instead of aborting.** An unusable diff gate is exit 2 everywhere else, but the "show me every gate" listing renders the offending row with the reason and keeps the other rows. Matched via `errors.Is(err, hasher.ErrDiffBase)`, so genuine I/O errors still abort.

## Accepted limitation

Cross-file interaction is invisible: if caller `C` uses `A` and `B`, this branch changes `A` and the base branch changes `B`, the deltas never overlap and the marker stays fresh. `hash: files` catches that incidentally, so this is a real reduction in strictness. It is stated in the README next to two bounding measures: pair `diff` with `ttl`, and note that the model assumes the base branch is itself gated - if the gate does not run on the base branch's own PRs, `diff` trusts changes nothing ever verified.

## Tests

- `internal/hasher/diff_test.go` (15 tests): unrelated base-branch change stays fresh; same-file base-branch change goes stale; uncommitted edit, untracked file, deletion, mode change and binary content all go stale; out-of-scope edit stays fresh; staging invariant; committing already-hashed content is not a change; base branch / behind base / unresolvable base / unrelated histories / missing base all error; digest invariant under git config; scope parity with `hash: files`.
- `internal/cli/integration_test.go` (13 tests): the same behaviours through the CLI, plus set-time refusal writing no marker, the fresh-branch-with-uncommitted-work case, flag validation both ways, marker contents, degraded bare status, `run` skip/re-run, and `--explain` listing the delta rather than the include set.
- `internal/config/config_test.go`: `base` required on diff, rejected elsewhere.
- `.claude/scripts/e2e.sh`: 21 new black-box assertions (119 total, up from 98 - the previous count recorded in CLAUDE.md and the verify-e2e skill said 84 and was stale; both are corrected).

## Verification

```text
go build ./...                 ok
go vet ./...                   ok
go test ./... -race            ok (all 7 packages)
golangci-lint run (v2.6.2)     0 issues
bash .claude/scripts/e2e.sh    PASS: 119  FAIL: 0
```

Also smoked against a built binary in a throwaway repo: `set` / `status` / `verify --explain` / merge of an unrelated base change (fresh) / clean base-branch checkout (exit 2 with the explanatory message) / bare `status` still listing.

## Docs

README: three-way strategy table, a `hash: diff` subsection (behaviour matrix, requirements, the limitation, determinism), `base` in the field table, `--base` in the CLI reference, the sharing-patterns row, two FAQ entries, and the renamed heading anchor fixed at all three reference sites. `markgate init` template gains a commented diff gate. CLAUDE.md layout notes and the verify-e2e skill are updated.


---

## Review round 1 — all three blockers fixed (a39dc9f)

### B1 — cwd-scoped delta made the gate pass forever

Reproduced exactly as reported: `set` from a subdirectory with `diff.relative=true` recorded `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` (the empty set) and every later verify returned 0.

Fixed structurally rather than with `--no-relative`: `TopLevel` is now memoized on `Repo`, and every command whose **output** is a set of paths (`DiffFrom`, `DiffHeadNames`, `UntrackedNames`) runs from the worktree root via a new `runAtRoot`. Version-independent, and it covers every caller instead of one rebinding per call site - `status`'s own `gitutil.New("")` and any future caller are in scope automatically.

**This also closes should-fix 2.** Confirmed against the built binary: with no git config at all, `set check --hash git-tree` from `docs/` followed by a new untracked file in `src/` now returns exit 1 where it previously returned 0. The pre-existing `hash: git-tree` bug is fixed by the same change, so there is nothing left to file separately.

Two regression tests, both verified to fail with the fix reverted:

```text
--- FAIL: TestDiffHash_SubdirectoryInvocationKeepsRepoScope
    digest depends on cwd: root 91312c85..., docs/ e3b0c442...
    scope from a subdirectory = "scope:\nstate: match\n", want the repo-relative path docs/x.md
    in-scope change seen from a subdirectory: code = 0, want 1 (0 means the marker can never go stale)
--- FAIL: TestGitTreeHash_SubdirectoryInvocationSeesWholeRepo
    untracked file outside cwd: code = 0, want 1
```

### B2 — README contradicted itself about committed markers

Section B is now "Committed (scoped hash)" with a three-way list (`files` always safe; `diff` safe when `include`/`exclude` keeps the state dir out of the delta; `git-tree` breaks), the anchor consumer at :1048 follows the rename, the table row carries the qualifier, the "best for" cell no longer says files-only, and the gitignore callout plus its rationale block both name the unscoped-diff case. `markgate init`'s Pattern A/B comments say the same thing.

The reviewer's finding that an unscoped diff gate self-invalidates when the state dir sits in the worktree is documented rather than validated away: `include` is legitimately optional on a diff gate, and the empty-include behaviour is now pinned by a test.

### B3 — base-blob framing had no coverage

`TestDiff_ResolvingAMergeByKeepingOursStillCounts` merges a conflicting base-branch change and resolves it with `--ours`, asserting first that the worktree bytes are byte-identical (so the test cannot pass on content alone) and then that the digest moved. With `e.BaseBlob` dropped from the framing:

```text
--- FAIL: TestDiff_ResolvingAMergeByKeepingOursStillCounts
    diff_test.go:284: keeping ours over a moved base did not invalidate the digest
```

## Should-fixes

**1 - empty check after include/exclude filtering: declined as an error, implemented as a warning.** Refusing on an empty *filtered* delta would make a diff gate unusable on any branch that changes nothing it covers - which is the case the hash type exists to keep fresh, and which `hash: files` handles without complaint. `markgate run integ -- <expensive>` on a docs-only branch would exit 2 and block the hook rather than skip the run. What the finding is really about is silence, so `set` / `run` now print:

```text
markgate: integ: hash=diff recorded an empty in-scope delta (include: src/**); this branch changes nothing the gate covers, so the marker stays fresh until it does
```

`TestDiffHash_EmptyInScopeDeltaWarnsButStaysUsable` pins both halves (warning present, exit code still 0, and an in-scope change still invalidates), and fails without the warning. Note `config lint`'s dead-glob check already covers the typo'd-include variant for diff gates, the same as for files gates.

**2 - closed by the B1 fix**, see above.

**3 - glob parity precondition.** The parity test's doc comment now states the precondition explicitly (pattern semantics, non-empty include, paths present in the worktree), and the two legitimate divergences are pinned by their own tests instead of being left implicit: `TestDiff_EmptyIncludeCoversTheWholeDelta` (an omitted include is legal for diff and means the whole delta; exclude-only subtracts from it) and `TestDiff_DeletedPathStaysInScope` (a deleted path stays in the diff scope and vanishes from the files scope, because one filters a git-derived list and the other globs the filesystem).

**4 - `run` coverage.** `TestDiffHash_RunRefusesBeforeExecutingChild` covers both degenerate cases and asserts the child never ran. Without the preflight it fails - and instructively: the child's own side effect (`touch`) makes the delta non-empty, so the run then *succeeds* and records a marker.

**5 - composition coverage.** `TestDiffHash_WithTTL`, `TestDiffHash_AsRequiresChild` (set-time refusal, verify-time propagation, and exit-2 propagation from an unusable base), `TestDiffHash_WithStateDir` (including committing the marker and verifying the digest is undisturbed), plus `TestDiffHash_RebaseOntoMovedBase` for the rebase path.

**6 - mode-change claim corrected.** The README now says a `chmod` invalidates only when the path was not already in the delta, and states that markgate hashes content, never permission bits.

**7 - e2e header docstring updated.** It had silently not been updated: the string I edited did not exist in the file and the replacement was a no-op, which is exactly what the review caught.

**8 - strictness where the choice is made.** The strategy table gains a "Strictness" row naming `diff` as the least strict, the "when to use which" bullet says so and links to the limitation, and the `markgate init` template carries the same warning next to the example.

## Nits

- **Double `entries()` computation fixed.** `preflight` now runs only on the paths that return without hashing (no marker / kind changed), and is skipped entirely for deps-only gates whose hasher is never consulted. Measured on a 3,000-file repo, 20 runs each: **83.6 ms -> 42.1 ms per verify**.
- **Both non-discriminating e2e assertions fixed**: the missing-`--base` case now asserts the message names the flag (so removing the eager validation fails it), and the bare-status degrade block now has a second healthy gate whose row must still render.
- **Assertion count no longer hardcoded anywhere.** It lived in five prose copies with nothing tying it to the script and had already drifted by 14. CLAUDE.md and the skill now point at the summary line instead, and the script's header says why.
- Rebase path covered; the unresolvable-base test now asserts no marker was written; the flag tests assert message text as well as exit codes.

## Verification after the fixes

```text
go build ./...                 ok
go vet ./...                   VET-OK
go test ./... -race            ok (cli 114.9s, hasher 41.2s, config/duration/key/state ok)
golangci-lint run (v2.12.2)    0 issues.
bash .claude/scripts/e2e.sh    PASS: 121  FAIL: 0
```

Note on the linter version: the first local pass used golangci-lint 2.6.2 while CI's reviewdog action pulls 2.12.2, whose gosec flags `G602` on two slice indexings in the new test helpers. Caught by CI, fixed in e1e8a49, and re-verified locally against 2.12.2 itself. Nothing in the repo pins a golangci-lint version, so local and CI can disagree at any time.

Built-binary smoke re-run: subdirectory invocation now agrees with the root, `hash: git-tree` sees untracked files outside the cwd, the empty-delta warning prints while `set`/`verify` stay usable, and `markgate init` carries the strictness note.

