### PR TITLE
fix(config): reject hash: diff on a deps-only gate instead of discarding it

### DIFF
--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -700,6 +700,42 @@ out=$($MG config lint 2>&1)
 assert_eq "diff: base on a files gate lints dirty exit=1" "1" "$?"
 assert_contains "diff: lint explains base misuse" "base is only valid with hash=diff" "$out"
 
+# The mirror case: a deps-only gate discards hash/base instead, so it is
+# the same config error seen from the other side (#71). The unresolvable
+# base is deliberate — nothing may resolve it, which is the point.
+cat > .markgate.yml <<'EOF'
+gates:
+  child:
+    hash: files
+    include:
+      - "src/**"
+  parent:
+    hash: diff
+    base: origin/never-resolves
+    composes: [child]
+EOF
+out=$($MG set parent 2>&1)
+assert_eq "diff: deps-only gate rejects hash=diff exit=2" "2" "$?"
+assert_contains "diff: deps-only rejection names the scope" "requires its own scope" "$out"
+
+# Adding include gives the same gate its own scope back, so the rule is
+# about scope rather than about having children at all.
+cat > .markgate.yml <<'EOF'
+gates:
+  child:
+    hash: files
+    include:
+      - "src/**"
+  parent:
+    hash: diff
+    base: main
+    include:
+      - "src/**"
+    composes: [child]
+EOF
+$MG config lint >/dev/null 2>&1
+assert_eq "diff: scoped gate with composes lints clean exit=0" "0" "$?"
+
 # ─────────────────────────────────────────────────────────────────
 echo
 cyan "=== summary ==="

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Per-gate fields:
 | field | purpose |
 | --- | --- |
 | `hash` | `git-tree` (default), `files`, or `diff` |
-| `include` | glob list; required for `hash: files`, optional for `hash: diff` (omitted = the branch's whole delta) |
+| `include` | glob list; required for `hash: files`, optional for `hash: diff` (omitted = the branch's whole delta) except on a gate with `composes`/`requires`, where omitting it would make the gate [deps-only](#gate-dependencies-composes-vs-requires) and discard the hash |
 | `exclude` | glob list |
 | `base` | ref a `hash: diff` gate measures its delta from (e.g. `origin/main`); required there, rejected everywhere else — see [Hashing strategies](#hashing-strategies-git-tree-vs-files-vs-diff) |
 | `state_dir` | optional override of marker storage location — see [Sharing markers](#sharing-markers-across-machines-ci--teammates) |
@@ -766,6 +766,14 @@ almost always stale.
 A `markgate set <parent>` on a deps-only gate still records a
 marker, so `markgate clear <parent>` keeps working as the user
 expects.
+
+Because a deps-only gate never consults a hasher, `hash: diff` on
+one is a config error: its `base:` would be silently discarded, and
+a gate whose ref never has to resolve is exactly the kind of
+misconfiguration that reads as working. Add `include:` if you want
+the gate to have its own delta as well as children, or drop `hash:`
+and `base:`. `hash: git-tree` stays legal there — it is the default
+and carries no scope configuration to discard.
 
 #### Which one should I use?
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Per-gate fields:
 | field | purpose |
 | --- | --- |
 | `hash` | `git-tree` (default), `files`, or `diff` |
-| `include` | glob list; required for `hash: files`, optional for `hash: diff` (omitted = the branch's whole delta) except on a gate with `composes`/`requires`, where omitting it would make the gate [deps-only](#gate-dependencies-composes-vs-requires) and discard the hash |
+| `include` | glob list; required for `hash: files`, optional for `hash: diff` (omitted = the branch's whole delta) except on a gate with `composes`/`requires`, where omitting it would make the gate [deps-only](#gate-dependencies-composes-vs-requires) — that combination is rejected rather than silently ignoring `hash`/`base` |
 | `exclude` | glob list |
 | `base` | ref a `hash: diff` gate measures its delta from (e.g. `origin/main`); required there, rejected everywhere else — see [Hashing strategies](#hashing-strategies-git-tree-vs-files-vs-diff) |
 | `state_dir` | optional override of marker storage location — see [Sharing markers](#sharing-markers-across-machines-ci--teammates) |
@@ -926,8 +926,11 @@ so one-off scopes don't need a `.markgate.yml`:
 ```
 
 Flag syntax is identical across hash types. With `--hash files`,
-`--include` is required; with `--hash diff`, `--base` is. Example — exclude `vendor/` without any
-config file:
+`--include` is required; with `--hash diff`, `--base` is — and
+`--include` too, if the gate carries `composes`/`requires`, since
+without it the gate would be
+[deps-only](#gate-dependencies-composes-vs-requires) and never consult
+a hasher. Example — exclude `vendor/` without any config file:
 
 ```sh
 markgate run --exclude 'vendor/**' -- pnpm build

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -423,6 +423,11 @@ func validateGate(g config.Gate) error {
 		}
 		return nil
 	case config.HashDiff:
+		// Mirrors config.validateGate: a deps-only gate never consults a
+		// hasher, so hash and base would be silently discarded.
+		if !g.HasOwnScope() {
+			return fmt.Errorf("hash=diff requires its own scope; add --include, or drop --hash/--base (composes/requires without include makes the gate deps-only)")
+		}
 		if g.Base == "" {
 			return fmt.Errorf("hash=diff requires --base or a base: in config")
 		}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -2076,6 +2076,42 @@ func TestDiffHash_BaseOnNonDiffGateIsAConfigError(t *testing.T) {
 	}
 }
 
+// A gate with composes/requires and no include is deps-only, so it
+// never consults a hasher and would discard hash: diff and base:
+// entirely — including a base ref that does not resolve. That is the
+// same silent no-op TestDiffHash_BaseOnNonDiffGateIsAConfigError
+// prevents, seen from the other side, so it carries the same severity.
+func TestDiffHash_DepsOnlyGateRejectsDiff(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  child:\n    hash: files\n    include:\n      - \"src/**\"\n"+
+			"  parent:\n    hash: diff\n    base: origin/does-not-exist-at-all\n    composes: [child]\n")
+	if code, msg := runCmdMsg(t, "set", "parent"); code != 2 || !strings.Contains(msg, "requires its own scope") {
+		t.Errorf("set on a deps-only diff gate: code = %d, msg = %q", code, msg)
+	}
+	if code, out := runCmd(t, "config", "lint"); code != 1 || !strings.Contains(out, "hash=diff requires its own scope") {
+		t.Errorf("lint: code = %d, out = %q", code, out)
+	}
+	// The rule is about own scope, not about having children: adding
+	// include makes the same gate legal again.
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  child:\n    hash: files\n    include:\n      - \"src/**\"\n"+
+			"  parent:\n    hash: diff\n    base: main\n    include:\n      - \"src/**\"\n    composes: [child]\n")
+	if code, out := runCmd(t, "config", "lint"); code != 0 {
+		t.Errorf("diff gate with include + composes should lint clean: code = %d, out = %q", code, out)
+	}
+
+	// Same rule on the flag path, which bypasses config validation.
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  child:\n    hash: files\n    include:\n      - \"src/**\"\n"+
+			"  parent:\n    composes: [child]\n")
+	if code, msg := runCmdMsg(t, "set", "parent", "--hash", "diff", "--base", "main"); code != 2 ||
+		!strings.Contains(msg, "requires its own scope") {
+		t.Errorf("--hash diff on a deps-only gate: code = %d, msg = %q", code, msg)
+	}
+}
+
 func TestDiffHash_Flags(t *testing.T) {
 	dir := initRepo(t)
 	writeRepoFile(t, dir, "src/a.go", "a\n")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,6 +168,15 @@ func validateGate(c *Config, name string, g Gate) []Finding {
 			})
 		}
 	case HashDiff:
+		// Checked before base: a gate that cannot be a diff gate at all
+		// should say so, rather than send the user to add a base ref
+		// that would still be discarded.
+		if !g.HasOwnScope() {
+			out = append(out, Finding{
+				Path:    fmt.Sprintf("gates.%s", name),
+				Message: fmt.Sprintf("gates.%s: hash=diff requires its own scope; add include, or drop hash and base (composes/requires without include makes the gate deps-only)", name),
+			})
+		}
 		if g.Base == "" {
 			out = append(out, Finding{
 				Path:    fmt.Sprintf("gates.%s", name),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -97,6 +98,23 @@ func TestLoad_DiffRejectedOnDepsOnlyGate(t *testing.T) {
 		if _, err := Load(dir); err == nil {
 			t.Errorf("want error for hash=diff on a deps-only gate: %q", body)
 		}
+	}
+}
+
+// The scope check must come BEFORE the base requirement. A gate that
+// cannot be a diff gate at all should say so, rather than send the user
+// to add a base ref that the same gate would still discard. Ordering is
+// invisible to a gate that supplies a base, so this case omits it.
+func TestLoad_DepsOnlyDiffReportsScopeBeforeBase(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir,
+		"gates:\n  child:\n    hash: files\n    include:\n      - \"src/**\"\n  x:\n    hash: diff\n    composes: [child]\n")
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("want an error for a deps-only diff gate with no base")
+	}
+	if !strings.Contains(err.Error(), "requires its own scope") {
+		t.Errorf("Load reported %q; want the scope problem first, not the base ref", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -83,6 +83,51 @@ func TestLoad_BaseRejectedOnNonDiffGate(t *testing.T) {
 	}
 }
 
+// A deps-only gate never consults a hasher, so hash: diff and base:
+// on one are discarded — the same silent no-op that
+// TestLoad_BaseRejectedOnNonDiffGate exists to prevent, seen from the
+// other side.
+func TestLoad_DiffRejectedOnDepsOnlyGate(t *testing.T) {
+	for _, body := range []string{
+		"gates:\n  child:\n    hash: files\n    include:\n      - \"src/**\"\n  x:\n    hash: diff\n    base: main\n    composes: [child]\n",
+		"gates:\n  child:\n    hash: files\n    include:\n      - \"src/**\"\n  x:\n    hash: diff\n    base: main\n    requires: [child]\n",
+	} {
+		dir := t.TempDir()
+		writeConfig(t, dir, body)
+		if _, err := Load(dir); err == nil {
+			t.Errorf("want error for hash=diff on a deps-only gate: %q", body)
+		}
+	}
+}
+
+// The rule is about own scope, not about having children: a diff gate
+// that declares include alongside composes keeps its own digest and
+// must stay legal.
+func TestLoad_DiffWithIncludeAndDepsOK(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir,
+		"gates:\n  child:\n    hash: files\n    include:\n      - \"src/**\"\n  x:\n    hash: diff\n    base: main\n    include:\n      - \"src/**\"\n    composes: [child]\n")
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g := c.Gate("x"); !g.HasOwnScope() {
+		t.Error("diff gate with include + composes should keep its own scope")
+	}
+}
+
+// git-tree is the default and needs no scope config, so writing it
+// explicitly on a deps-only gate stays legal — the rule targets config
+// that would be discarded, not config that is merely redundant.
+func TestLoad_ExplicitGitTreeOnDepsOnlyGateOK(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir,
+		"gates:\n  child:\n    hash: files\n    include:\n      - \"src/**\"\n  x:\n    hash: git-tree\n    composes: [child]\n")
+	if _, err := Load(dir); err != nil {
+		t.Errorf("explicit git-tree on a deps-only gate should load: %v", err)
+	}
+}
+
 func TestLoad_UnknownHash(t *testing.T) {
 	dir := t.TempDir()
 	writeConfig(t, dir, "gates:\n  x:\n    hash: bogus\n")


### PR DESCRIPTION
Closes #71

## What

A gate with `composes`/`requires` and no `include` is deps-only (`HasOwnScope() == false`), so it never consults a hasher. On a `hash: diff` gate that silently discarded both `hash:` and `base:` — including a base ref that nothing ever had to resolve:

```yaml
gates:
  child:
    hash: files
    include: ["src/**"]
  parent:
    hash: diff
    base: origin/does-not-exist-at-all
    composes: [child]
```

```
markgate config lint   -> exit 0, no finding
markgate set parent    -> "marker saved: parent", exit 0
markgate status parent -> kind: deps-only
```

Now:

```
markgate config lint   -> exit 1, gates.parent: hash=diff requires its own scope; add include,
                          or drop hash and base (composes/requires without include makes the
                          gate deps-only)
markgate set parent    -> exit 2, same message
```

## Design decisions

**Config error, not a lint finding.** `base:` on a non-diff gate is already fatal (#69) specifically so it cannot be a silent no-op. This is the same mistake seen from the other side and carries the same severity — it would be odd for one to be fatal and the other invisible. Putting it in `config.Validate` also means it is enforced at Load by every command, rather than only when someone remembers to run `config lint`; lint inherits it for free since it already sources `Validate`.

**Checked before the base requirement.** A gate that cannot be a diff gate at all should say so, rather than send the user to add a `base:` that would still be discarded.

**Explicit `hash: git-tree` on a deps-only gate stays legal.** It is the default and carries no scope configuration to discard, so rejecting it would be flagging redundancy rather than a mistake. `hash: files` cannot reach this state at all, since it already requires a non-empty `include`.

**The rule is about own scope, not about having children.** A diff gate that declares `include` alongside `composes` keeps its own digest and stays legal — covered by a test and an e2e assertion.

Mirrored in the CLI `validateGate` so a `--hash diff` override cannot construct the same gate; `--hash diff --base X --include Y` on a deps-only gate is still accepted, because the include gives it a scope.

## Tests

- `TestLoad_DiffRejectedOnDepsOnlyGate` — both `composes` and `requires` spellings
- `TestLoad_DiffWithIncludeAndDepsOK` / `TestLoad_ExplicitGitTreeOnDepsOnlyGateOK` — the two cases that must stay legal
- `TestDiffHash_DepsOnlyGateRejectsDiff` — `set` exit 2 with the message, `config lint` exit 1, the include-restores-legality case, and the flag-override path
- `e2e.sh`: 3 new assertions (124 PASS / 0 FAIL)

## Verification

`go build` / `go vet` / `go test ./...` clean; `golangci-lint` (v2, matching CI's config) reports 0 issues; `e2e.sh` 124 PASS / 0 FAIL. Smoked the built binary across the issue's repro, the flag-override path with and without `--include`, a plain deps-only gate, a `diff` + `include` + `composes` gate, and an explicit `git-tree` deps-only gate.

## Docs

README gains the rule in the deps-only paragraph under [Gate dependencies](README.md#gate-dependencies-composes-vs-requires) and a qualifier on the `include` field-table row (which previously said `include` is simply optional for `hash: diff`). All in-file `](#...)` anchors re-checked.
