### PR TITLE
fix(hasher): refuse a dead include glob instead of digesting the empty set

### DIFF
--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -69,6 +69,16 @@ assert_file() {
   fi
 }
 
+assert_absent() {
+  local label="$1" path="$2"
+  if [[ ! -e "$path" ]]; then
+    PASS=$((PASS+1)); green "  PASS  $label  (absent)"
+  else
+    FAIL=$((FAIL+1)); red "  FAIL  $label  unexpectedly present: $path"
+    FAIL_LOG+=("$label: unexpectedly present $path")
+  fi
+}
+
 # Build once, reuse for all assertions.
 cyan "=== build ==="
 cd "$ROOT"
@@ -735,6 +745,81 @@ gates:
 EOF
 $MG config lint >/dev/null 2>&1
 assert_eq "diff: scoped gate with composes lints clean exit=0" "0" "$?"
+cyan "=== #70 dead include glob (both scoped modes) ==="
+new_repo
+
+printf 'a\n' > src/a.go
+git add -A && git commit -qm "dead-glob fixture" >/dev/null
+git checkout -q -b feat
+printf 'mine\n' > src/a.go
+git commit -qam "my work" >/dev/null
+
+# A scope that cannot exist would digest to the constant SHA-256 of the
+# empty set, so the gate would report match forever.
+out=$($MG set typo --hash files --include "scr/**" 2>&1)
+assert_eq "dead glob: files set exit=2" "2" "$?"
+assert_contains "dead glob: error names the pattern" "scr/**" "$out"
+$MG set typo --hash diff --base main --include "scr/**" >/dev/null 2>&1
+assert_eq "dead glob: diff set exit=2" "2" "$?"
+assert_absent "dead glob: no marker recorded" ".git/markgate/typo.json"
+
+# The other empty scope: patterns are live, this branch just changed
+# nothing under them. Refusing here would break the gate on exactly the
+# branches it should trivially pass.
+$MG set quiet --hash diff --base main --include "docs/**" >/dev/null 2>&1
+assert_eq "dead glob: quiet branch with a live include exit=0" "0" "$?"
+$MG set excluded --hash files --include "src/**" --exclude "src/**" >/dev/null 2>&1
+assert_eq "dead glob: exclude emptying the scope exit=0" "0" "$?"
+
+# Must not fire before a gated command can create its scope, or
+# `markgate run build -- make dist` breaks on a clean checkout.
+$MG verify dist --hash files --include "dist/**" >/dev/null 2>&1
+assert_eq "dead glob: verify with no marker is a plain mismatch exit=1" "1" "$?"
+$MG run dist --hash files --include "dist/**" -- sh -c 'mkdir -p dist && echo built > dist/x' >/dev/null 2>&1
+assert_eq "dead glob: run bootstraps a scope its child creates exit=0" "0" "$?"
+$MG verify dist --hash files --include "dist/**" >/dev/null 2>&1
+assert_eq "dead glob: verify after the child built the scope exit=0" "0" "$?"
+
+# The child runs, produces nothing matching, and the marker is refused.
+$MG run never --hash files --include "nope/**" -- touch child-ran.txt >/dev/null 2>&1
+assert_eq "dead glob: run refuses the marker after the child runs exit=2" "2" "$?"
+assert_file "dead glob: the child still ran" "child-ran.txt"
+assert_absent "dead glob: run recorded no marker" ".git/markgate/never.json"
+
+# --explain is a diagnostic: it renders the (empty) scope rather than
+# refusing, so adding the flag never changes what a command does.
+rm -rf dist
+$MG run dist2 --hash files --include "dist/**" --explain -- sh -c 'mkdir -p dist && echo built > dist/x' >/dev/null 2>&1
+assert_eq "dead glob: run --explain still bootstraps exit=0" "0" "$?"
+assert_file "dead glob: --explain did not suppress the child" "dist/x"
+$MG set typo2 --hash files --include "scr/**" --explain >/dev/null 2>&1
+assert_eq "dead glob: set --explain still refuses the digest exit=2" "2" "$?"
+
+# A rename is the realistic way a live scope dies under an existing marker.
+cat > .markgate.yml <<'EOF'
+gates:
+  scan:
+    hash: files
+    include:
+      - "src/**"
+  healthy:
+    hash: files
+    include:
+      - "src/**"
+EOF
+$MG set scan >/dev/null 2>&1
+$MG set healthy >/dev/null 2>&1
+git mv src source >/dev/null 2>&1
+out=$($MG verify scan 2>&1)
+assert_eq "dead glob: verify after a rename exit=2" "2" "$?"
+assert_contains "dead glob: rename error names the pattern" "src/**" "$out"
+
+# Bare status degrades the one bad row and keeps listing the rest.
+out=$($MG status 2>&1)
+assert_contains "dead glob: bare status reports the dead row" "dead scope" "$out"
+assert_contains "dead glob: bare status keeps rendering other gates" "healthy" "$out"
+$MG status scan >/dev/null 2>&1
+assert_eq "dead glob: single-key status errors exit=2" "2" "$?"
 
 # ─────────────────────────────────────────────────────────────────
 echo

--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -792,8 +792,14 @@ rm -rf dist
 $MG run dist2 --hash files --include "dist/**" --explain -- sh -c 'mkdir -p dist && echo built > dist/x' >/dev/null 2>&1
 assert_eq "dead glob: run --explain still bootstraps exit=0" "0" "$?"
 assert_file "dead glob: --explain did not suppress the child" "dist/x"
-$MG set typo2 --hash files --include "scr/**" --explain >/dev/null 2>&1
-assert_eq "dead glob: set --explain still refuses the digest exit=2" "2" "$?"
+# The harder case: a glob that cannot be resolved at all. Without a
+# marker nothing else touches it, so --explain is the only caller.
+$MG verify badglob --hash files --include "a[b" >/dev/null 2>&1
+plain_code=$?
+$MG verify badglob --hash files --include "a[b" --explain >/dev/null 2>&1
+assert_eq "dead glob: --explain does not change verify on a bad glob" "$plain_code" "$?"
+$MG run badglob --hash files --include "a[b" --explain -- touch explain-ran.txt >/dev/null 2>&1
+assert_file "dead glob: --explain did not suppress the child on a bad glob" "explain-ran.txt"
 
 # A scope cleaned away between builds must rebuild, not lock the gate
 # out. This is the regression that refusing on the read path caused.
@@ -801,6 +807,12 @@ rm -rf dist
 $MG run dist --hash files --include "dist/**" -- sh -c 'mkdir -p dist && echo built > dist/x' >/dev/null 2>&1
 assert_eq "dead glob: second run cycle rebuilds exit=0" "0" "$?"
 assert_file "dead glob: the cleaned scope was rebuilt" "dist/x"
+
+# The missing-/** typo: the pattern matches the directory but no file.
+$MG set dirgate --hash files --include "src" >/dev/null 2>&1
+assert_eq "dead glob: include naming a directory exit=2" "2" "$?"
+$MG set filegate --hash files --include "src/**" >/dev/null 2>&1
+assert_eq "dead glob: the same pattern with /** is live exit=0" "0" "$?"
 
 # The candidate universe differs per mode: files hashes gitignored paths,
 # a diff delta can never contain them.
@@ -811,7 +823,11 @@ $MG set fign --hash files --include "ignored/**" >/dev/null 2>&1
 assert_eq "dead glob: files may scope gitignored paths exit=0" "0" "$?"
 out=$($MG set dign --hash diff --base main --include "ignored/**" 2>&1)
 assert_eq "dead glob: diff refuses a gitignore-only include exit=2" "2" "$?"
-assert_contains "dead glob: diff refusal names the pattern" "ignored/**" "$out"
+assert_contains "dead glob: diff refusal names the pattern" "dead scope" "$out"
+# The mirror, on an EMPTY scope so the check is actually reached: if
+# files asked git's candidate set instead of the disk, this would refuse.
+$MG set fexc --hash files --include "ignored/**" --exclude "ignored/**" >/dev/null 2>&1
+assert_eq "dead glob: files asks the working tree, not git exit=0" "0" "$?"
 
 # A rename is the realistic way a live scope dies under an existing marker.
 # Only scan is narrowed, so healthy proves the listing still renders rows

--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -795,7 +795,27 @@ assert_file "dead glob: --explain did not suppress the child" "dist/x"
 $MG set typo2 --hash files --include "scr/**" --explain >/dev/null 2>&1
 assert_eq "dead glob: set --explain still refuses the digest exit=2" "2" "$?"
 
+# A scope cleaned away between builds must rebuild, not lock the gate
+# out. This is the regression that refusing on the read path caused.
+rm -rf dist
+$MG run dist --hash files --include "dist/**" -- sh -c 'mkdir -p dist && echo built > dist/x' >/dev/null 2>&1
+assert_eq "dead glob: second run cycle rebuilds exit=0" "0" "$?"
+assert_file "dead glob: the cleaned scope was rebuilt" "dist/x"
+
+# The candidate universe differs per mode: files hashes gitignored paths,
+# a diff delta can never contain them.
+echo "ignored/" > .gitignore
+mkdir -p ignored && echo bin > ignored/out.bin
+git add .gitignore && git commit -qm "ignore" >/dev/null
+$MG set fign --hash files --include "ignored/**" >/dev/null 2>&1
+assert_eq "dead glob: files may scope gitignored paths exit=0" "0" "$?"
+out=$($MG set dign --hash diff --base main --include "ignored/**" 2>&1)
+assert_eq "dead glob: diff refuses a gitignore-only include exit=2" "2" "$?"
+assert_contains "dead glob: diff refusal names the pattern" "ignored/**" "$out"
+
 # A rename is the realistic way a live scope dies under an existing marker.
+# Only scan is narrowed, so healthy proves the listing still renders rows
+# that are fine — the whole point of degrading rather than aborting.
 cat > .markgate.yml <<'EOF'
 gates:
   scan:
@@ -805,21 +825,30 @@ gates:
   healthy:
     hash: files
     include:
-      - "src/**"
+      - "docs/**"
 EOF
 $MG set scan >/dev/null 2>&1
 $MG set healthy >/dev/null 2>&1
 git mv src source >/dev/null 2>&1
 out=$($MG verify scan 2>&1)
-assert_eq "dead glob: verify after a rename exit=2" "2" "$?"
-assert_contains "dead glob: rename error names the pattern" "src/**" "$out"
+assert_eq "dead glob: verify after a rename is a mismatch exit=1" "1" "$?"
+assert_contains "dead glob: rename mismatch names the pattern" "src/**" "$out"
+out=$($MG set scan 2>&1)
+assert_eq "dead glob: set after a rename exit=2" "2" "$?"
+assert_contains "dead glob: set refusal names the pattern" "src/**" "$out"
 
 # Bare status degrades the one bad row and keeps listing the rest.
 out=$($MG status 2>&1)
 assert_contains "dead glob: bare status reports the dead row" "dead scope" "$out"
-assert_contains "dead glob: bare status keeps rendering other gates" "healthy" "$out"
-$MG status scan >/dev/null 2>&1
-assert_eq "dead glob: single-key status errors exit=2" "2" "$?"
+assert_contains "dead glob: bare status still lists the healthy gate" "healthy" "$out"
+# Column padding varies with the widest key in the sandbox, so assert the
+# healthy gate's verdict through its own status rather than by scraping
+# the table.
+$MG status healthy >/dev/null 2>&1
+assert_eq "dead glob: the healthy gate is unaffected exit=0" "0" "$?"
+out=$($MG status scan 2>&1)
+assert_eq "dead glob: single-key status is a mismatch exit=1" "1" "$?"
+assert_contains "dead glob: single-key status explains why" "dead scope" "$out"
 
 # ─────────────────────────────────────────────────────────────────
 echo

--- a/.claude/skills/verify-e2e/SKILL.md
+++ b/.claude/skills/verify-e2e/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-e2e
-description: Run the markgate end-to-end CLI verification script (`.claude/scripts/e2e.sh`). It exercises the full CLI surface — original primitives (set / verify / clear / run / init / version, default key, --hash files + --include, --state-dir, env-var, precedence) plus every feature added in the 2026-05-09 batch (completion, config lint, TTL, --explain, bare status, composes / requires) and the hash: diff strategy. Wraps the script in `markgate run` so unchanged repos skip the run. Use whenever you want to confirm "all features still work" before declaring done, opening a PR, or merging — or when your changes touch the CLI surface and you want a quick smoke before pushing.
+description: Run the markgate end-to-end CLI verification script (`.claude/scripts/e2e.sh`). It exercises the full CLI surface — original primitives (set / verify / clear / run / init / version, default key, --hash files + --include, --state-dir, env-var, precedence) plus every feature added in the 2026-05-09 batch (completion, config lint, TTL, --explain, bare status, composes / requires) the hash: diff strategy, and the dead-include-glob refusal shared by both scoped modes. Wraps the script in `markgate run` so unchanged repos skip the run. Use whenever you want to confirm "all features still work" before declaring done, opening a PR, or merging — or when your changes touch the CLI surface and you want a quick smoke before pushing.
 ---
 
 # verify-e2e
@@ -77,6 +77,24 @@ Three layers of assertions (the script prints the count on every run; it is deli
   `--base` without `hash=diff` both exit=2
 - config without `base` rejected; `base` on a `files` gate lints
   dirty with an explanatory message
+- deps-only gate (composes/requires, no include) rejects `hash: diff`
+  exit=2; adding `include` makes the same gate lint clean
+
+**Dead `include` globs (both scoped modes)**
+
+- an include list matching nothing -> `set` exit=2 naming the
+  pattern, on `files` and `diff` alike, and no marker is written
+- the other empty scopes stay usable: a quiet branch with a live
+  include, and `exclude` emptying what `include` matched
+- bootstrapping is preserved: `verify` with no marker is exit=1
+  without hashing, so `run` still executes its child and records the
+  marker once the child creates the scope
+- when the child runs and the scope is still empty, the marker is
+  refused (child ran, no marker written)
+- `--explain` stays diagnostic: it renders the empty scope, so adding
+  the flag neither suppresses `run`'s child nor rescues `set`
+- a rename that kills a live scope -> `verify` exit=2; bare `status`
+  degrades that row and keeps rendering the others
 
 ## How it caches
 

--- a/.claude/skills/verify-e2e/SKILL.md
+++ b/.claude/skills/verify-e2e/SKILL.md
@@ -96,9 +96,11 @@ Three layers of assertions (the script prints the count on every run; it is deli
 - when the child runs and the scope is still empty, the marker is
   refused (child ran, no marker written)
 - `--explain` stays diagnostic: it renders the empty scope, so adding
-  the flag neither suppresses `run`'s child nor rescues `set`
-- a rename that kills a live scope -> `verify` exit=2; bare `status`
-  degrades that row and keeps rendering the others
+  the flag never suppresses `run`'s child — including when the scope
+  cannot be computed at all (a malformed glob)
+- a rename that kills a live scope -> `verify` exit=1 and `set`
+  exit=2; bare `status` degrades that row and keeps rendering the
+  others
 
 ## How it caches
 

--- a/.claude/skills/verify-e2e/SKILL.md
+++ b/.claude/skills/verify-e2e/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-e2e
-description: Run the markgate end-to-end CLI verification script (`.claude/scripts/e2e.sh`). It exercises the full CLI surface — original primitives (set / verify / clear / run / init / version, default key, --hash files + --include, --state-dir, env-var, precedence) plus every feature added in the 2026-05-09 batch (completion, config lint, TTL, --explain, bare status, composes / requires) the hash: diff strategy, and the dead-include-glob refusal shared by both scoped modes. Wraps the script in `markgate run` so unchanged repos skip the run. Use whenever you want to confirm "all features still work" before declaring done, opening a PR, or merging — or when your changes touch the CLI surface and you want a quick smoke before pushing.
+description: Run the markgate end-to-end CLI verification script (`.claude/scripts/e2e.sh`). It exercises the full CLI surface — original primitives (set / verify / clear / run / init / version, default key, --hash files + --include, --state-dir, env-var, precedence) plus every feature added in the 2026-05-09 batch (completion, config lint, TTL, --explain, bare status, composes / requires), the hash: diff strategy, and the dead-include-glob refusal shared by both scoped modes. Wraps the script in `markgate run` so unchanged repos skip the run. Use whenever you want to confirm "all features still work" before declaring done, opening a PR, or merging — or when your changes touch the CLI surface and you want a quick smoke before pushing.
 ---
 
 # verify-e2e
@@ -77,13 +77,17 @@ Three layers of assertions (the script prints the count on every run; it is deli
   `--base` without `hash=diff` both exit=2
 - config without `base` rejected; `base` on a `files` gate lints
   dirty with an explanatory message
-- deps-only gate (composes/requires, no include) rejects `hash: diff`
-  exit=2; adding `include` makes the same gate lint clean
 
 **Dead `include` globs (both scoped modes)**
 
 - an include list matching nothing -> `set` exit=2 naming the
-  pattern, on `files` and `diff` alike, and no marker is written
+  pattern, on `files` and `diff` alike, and no marker is written;
+  `verify` reports it as a mismatch (exit=1), not an error
+- a scope cleaned away between builds still rebuilds: a second `run`
+  cycle after the scope is deleted executes its child and re-records
+- the candidate universe differs per mode: an include matching only
+  gitignored paths is live for `files` (which hashes them) and dead
+  for `diff` (whose delta can never contain them)
 - the other empty scopes stay usable: a quiet branch with a live
   include, and `exclude` emptying what `include` matched
 - bootstrapping is preserved: `verify` with no marker is exit=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,17 @@ it is the spec — see "README as a spec" below.
 - **No implicit nesting of `markgate/`** when the user gives an
   explicit path (`--state-dir` / `state_dir:`). The user owns the
   layout they asked for.
+- **A digest that cannot change is an error, not a value.** An empty
+  scope hashes to the SHA-256 of nothing — the same constant for
+  every such gate — so the marker matches forever and the gate can
+  never block. Refuse it wherever it is reachable by
+  misconfiguration: a dead `include` list (`hasher.ErrDeadScope`), an
+  empty `hash: diff` delta (`hasher.ErrDiffBase`). Refuse it only
+  where the *configuration* is at fault, though — a live scope that
+  this branch happens not to have touched is legitimate and must
+  stay usable, or the gate breaks on the branches it should trivially
+  pass. Both sentinels are matched by bare `status` so one bad gate
+  degrades its own row instead of aborting the listing.
 
 ## Testing
 
@@ -176,7 +187,8 @@ message to a temp file first sidesteps all shell escaping.
   `--hash files`, `--state-dir`, env-var, precedence) and every
   feature added in the 2026-05-09 batch (completion, config lint,
   TTL, `--explain`, bare status, composes / requires) plus
-  `hash: diff` (#68). The script's summary prints the assertion count;
+  `hash: diff` (#68) and the dead-include refusal shared by both
+  scoped hash modes (#70). The script's summary prints the assertion count;
   exit code = number of failures. Do not restate the count here — it
   has no way to stay in sync and has already drifted once.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,17 +47,27 @@ it is the spec — see "README as a spec" below.
 - **No implicit nesting of `markgate/`** when the user gives an
   explicit path (`--state-dir` / `state_dir:`). The user owns the
   layout they asked for.
-- **A digest that cannot change is an error, not a value.** An empty
+- **A digest that cannot change must never read as fresh.** An empty
   scope hashes to the SHA-256 of nothing — the same constant for
   every such gate — so the marker matches forever and the gate can
-  never block. Refuse it wherever it is reachable by
-  misconfiguration: a dead `include` list (`hasher.ErrDeadScope`), an
-  empty `hash: diff` delta (`hasher.ErrDiffBase`). Refuse it only
-  where the *configuration* is at fault, though — a live scope that
-  this branch happens not to have touched is legitimate and must
-  stay usable, or the gate breaks on the branches it should trivially
-  pass. Both sentinels are matched by bare `status` so one bad gate
-  degrades its own row instead of aborting the listing.
+  never block. Two sentinels mark it: a dead `include` list
+  (`hasher.ErrDeadScope`) and an empty `hash: diff` delta
+  (`hasher.ErrDiffBase`).
+  **Refuse at `set`, not on the read path.** `set` is where the
+  constant would be recorded, and by then any gated command has had
+  its chance to fill the scope. `verify` must stop *passing*, which
+  exit 1 already achieves; escalating it to exit 2 stops `markgate
+  run` from executing the command that would refill the scope, and a
+  gate on build output between `make clean` and the next build is
+  then recoverable only via `clear`. That regression shipped once —
+  the test covered bootstrapping with no marker and missed the second
+  build cycle.
+  **Refuse only where the configuration is at fault.** A live scope
+  this branch happens not to have touched is legitimate and must stay
+  usable. What counts as "live" is per strategy: `files` hashes what
+  is on disk, `diff` draws from a git delta that can never contain an
+  ignored path, so using the working tree as the universe for `diff`
+  is a false all-clear, not a false alarm.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -605,29 +605,41 @@ markgate distinguishes the two ways a scope can be empty:
 
 | situation | treatment |
 | --- | --- |
-| no `include` pattern matches **any** path in the working tree | **error, exit 2** — the configuration is dead |
+| no `include` pattern can match anything the gate can see | **`set` errors (exit 2); `verify` is a mismatch (exit 1)** |
 | patterns match, but this branch changed none of them | fine (`diff` warns on `set`, `files` is silent) |
 | `exclude` removed everything `include` matched | fine — that is a deliberate configuration |
 | at least one pattern is live, others are dead | fine at run time; `config lint` warns per pattern |
 
-The error fires wherever the digest is actually computed — `set`,
-`verify`, `run`'s closing `set`, and `markgate status <key>` — and
-names the patterns, because the gate's behavior gives you no other
-way to tell which one is wrong. Bare `markgate status` degrades the
-offending row instead, so one dead gate does not hide the rest, and
-`--explain` still prints the (empty) scope rather than failing: it is
-a diagnostic and never changes what a command does.
+**Why `verify` is a mismatch and not an error.** The bug is that a
+dead scope *passes*; exit 1 fixes that, and it means "re-run the
+check", which is what both cases need. A gate on build output is
+legitimately empty between `make clean` and the next build, so
+erroring on the read path would stop `markgate run dist -- make dist`
+from executing the very command that refills the scope — leaving the
+gate recoverable only via `markgate clear`. `set` is where the
+constant would actually be recorded, and by then the gated command
+has had its chance, so a still-empty scope there is the
+configuration's fault and is refused. A typo therefore re-runs its
+command and then fails loudly at `set`, and no marker is ever
+written.
 
-This deliberately does **not** fire before a gated command has had a
-chance to create its scope: `verify` with no marker is a plain
-mismatch (exit 1) without hashing, so
-`markgate run dist -- make dist` still works on a clean checkout and
-records the marker once `make dist` has produced the files. If the
-command runs and the scope is *still* empty, the marker is refused.
+**"Anything the gate can see" differs per strategy.** `files` hashes
+whatever is on disk, so an include matching only gitignored paths is
+a real scope. `diff` digests a git delta, which can never contain an
+ignored path or anything under `.git/`, so the same include there is
+permanently empty and is refused. Getting this backwards would be a
+false all-clear rather than a false alarm.
 
-The trade-off is a scope that is legitimately absent — a sparse
-checkout, an optional subtree — which now exits 2 rather than
-passing. Scope such a gate to a path that is always present, or
+The message names the patterns, because the gate's behavior gives
+you no other way to tell which one is wrong. Bare `markgate status`
+shows the offending row as a mismatch and keeps listing the rest,
+and `--explain` still prints the (empty) scope rather than failing:
+it is a diagnostic and never changes what a command does.
+
+The trade-off is a scope that is legitimately absent for good and
+not merely between builds — a sparse checkout, an optional subtree.
+Its gate now reports mismatch forever and refuses to record, instead
+of passing. Scope such a gate to a path that is always present, or
 don't gate it.
 
 #### `hash: diff` — ignore changes that arrive from the base branch
@@ -849,7 +861,8 @@ markgate init                          Write a starter .markgate.yml.
 markgate config lint                   Warn per pattern on dead
                                        include/exclude globs (an include
                                        list where *every* pattern is dead
-                                       is a run-time error, not a warning),
+                                       is warned about here and also
+                                       refused by `set`),
                                        unknown fields, and every rule that
                                        would make `markgate run` exit 2
                                        (unknown hash, ttl parse, undeclared

--- a/README.md
+++ b/README.md
@@ -593,6 +593,43 @@ Reach for `files` only when you specifically want the "ignore
 commits that don't touch these paths" semantics, and for `diff` only
 when base-branch churn is what keeps re-triggering an expensive gate.
 
+#### A dead `include` is refused, not silently empty
+
+Both scoped strategies digest a *set of paths*. When that set comes
+out empty, the digest is the SHA-256 of nothing — a constant, the
+same value for every such gate — so the marker matches forever and
+the gate can never block. A typo (`scr/**`), a renamed directory, or
+a path that moved lands you there without any other symptom.
+
+markgate distinguishes the two ways a scope can be empty:
+
+| situation | treatment |
+| --- | --- |
+| no `include` pattern matches **any** path in the working tree | **error, exit 2** — the configuration is dead |
+| patterns match, but this branch changed none of them | fine (`diff` warns on `set`, `files` is silent) |
+| `exclude` removed everything `include` matched | fine — that is a deliberate configuration |
+| at least one pattern is live, others are dead | fine at run time; `config lint` warns per pattern |
+
+The error fires wherever the digest is actually computed — `set`,
+`verify`, `run`'s closing `set`, and `markgate status <key>` — and
+names the patterns, because the gate's behavior gives you no other
+way to tell which one is wrong. Bare `markgate status` degrades the
+offending row instead, so one dead gate does not hide the rest, and
+`--explain` still prints the (empty) scope rather than failing: it is
+a diagnostic and never changes what a command does.
+
+This deliberately does **not** fire before a gated command has had a
+chance to create its scope: `verify` with no marker is a plain
+mismatch (exit 1) without hashing, so
+`markgate run dist -- make dist` still works on a clean checkout and
+records the marker once `make dist` has produced the files. If the
+command runs and the scope is *still* empty, the marker is refused.
+
+The trade-off is a scope that is legitimately absent — a sparse
+checkout, an optional subtree — which now exits 2 rather than
+passing. Scope such a gate to a path that is always present, or
+don't gate it.
+
 #### `hash: diff` — ignore changes that arrive from the base branch
 
 `git-tree` and `files` both digest **content**, so neither can tell
@@ -809,7 +846,10 @@ markgate status     [key]              Show marker + match status (bare:
 markgate clear      [key]              Delete the marker (idempotent).
 markgate run        [key] -- <cmd>...  Sugar for verify + <cmd> + set.
 markgate init                          Write a starter .markgate.yml.
-markgate config lint                   Warn on dead include/exclude globs,
+markgate config lint                   Warn per pattern on dead
+                                       include/exclude globs (an include
+                                       list where *every* pattern is dead
+                                       is a run-time error, not a warning),
                                        unknown fields, and every rule that
                                        would make `markgate run` exit 2
                                        (unknown hash, ttl parse, undeclared

--- a/internal/cli/config_lint.go
+++ b/internal/cli/config_lint.go
@@ -72,8 +72,9 @@ func newConfigLintCmd() *cobra.Command {
 		Short: "Report typos and config errors in .markgate.yml",
 		Long: "Walks .markgate.yml and warns on:\n" +
 			"  - include/exclude globs that match zero files in the working tree\n" +
-			"    (an include list where EVERY pattern is dead is refused at\n" +
-			"    run time instead, since its digest could never go stale)\n" +
+			"    (an include list where EVERY pattern is dead is warned about\n" +
+			"    here AND refused by `set`, since its digest could never go\n" +
+			"    stale; `verify` reports it as a mismatch)\n" +
 			"  - unknown top-level or per-gate keys (typos, leftovers)\n" +
 			"  - unknown hash type, malformed ttl, composes+requires both set\n" +
 			"  - composes/requires entries that name an undeclared gate\n" +

--- a/internal/cli/config_lint.go
+++ b/internal/cli/config_lint.go
@@ -72,6 +72,8 @@ func newConfigLintCmd() *cobra.Command {
 		Short: "Report typos and config errors in .markgate.yml",
 		Long: "Walks .markgate.yml and warns on:\n" +
 			"  - include/exclude globs that match zero files in the working tree\n" +
+			"    (an include list where EVERY pattern is dead is refused at\n" +
+			"    run time instead, since its digest could never go stale)\n" +
 			"  - unknown top-level or per-gate keys (typos, leftovers)\n" +
 			"  - unknown hash type, malformed ttl, composes+requires both set\n" +
 			"  - composes/requires entries that name an undeclared gate\n" +

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -55,6 +55,10 @@ type explainPayload struct {
 	Scope  []string `json:"scope"`
 	Hasher string   `json:"hasher"`
 	State  string   `json:"state"`
+	// ScopeError is present only when the scope could not be computed.
+	// Additive, so the documented {key, scope, hasher, state} shape is
+	// unchanged for every gate that resolves.
+	ScopeError string `json:"scope_error,omitempty"`
 }
 
 // emitExplain writes the scope listing for c. In text mode the listing
@@ -69,9 +73,15 @@ func emitExplain(c *gateCtx, flags *explainFlags, out, errOut io.Writer, markerS
 	if flags == nil || !flags.enabled {
 		return nil
 	}
+	// A Scope error must not propagate: --explain is a diagnostic, and
+	// the command's own path already errors wherever it should. Failing
+	// here instead flips exit codes and, on `run`, suppresses the child
+	// — so passing the flag would change what the command does, which is
+	// the one thing it must never do.
 	scope, err := c.hasher.Scope(c.repo)
+	scopeErr := ""
 	if err != nil {
-		return err
+		scope, scopeErr = nil, err.Error()
 	}
 	// Empty scope is a real signal (globs match nothing); render an
 	// empty list rather than nil so JSON consumers see []  .
@@ -81,10 +91,11 @@ func emitExplain(c *gateCtx, flags *explainFlags, out, errOut io.Writer, markerS
 
 	if flags.json {
 		payload := explainPayload{
-			Key:    c.key,
-			Scope:  scope,
-			Hasher: c.hasher.Type(),
-			State:  markerState,
+			Key:        c.key,
+			Scope:      scope,
+			Hasher:     c.hasher.Type(),
+			State:      markerState,
+			ScopeError: scopeErr,
 		}
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
@@ -92,6 +103,9 @@ func emitExplain(c *gateCtx, flags *explainFlags, out, errOut io.Writer, markerS
 	}
 
 	fmt.Fprintln(errOut, "scope:")
+	if scopeErr != "" {
+		fmt.Fprintf(errOut, "  (unavailable: %s)\n", scopeErr)
+	}
 	for _, p := range scope {
 		fmt.Fprintf(errOut, "  %s\n", p)
 	}

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -213,6 +213,11 @@ type evalResult struct {
 	hashTypeChanged bool
 	ownDigestDiff   bool
 	ttl             ttlExpiry
+	// deadScope carries hasher.ErrDeadScope when the gate's include list
+	// can no longer match anything. It is a mismatch rather than an
+	// error so `run` still executes the command that would refill the
+	// scope; only `set` refuses, and it does so from newMarker.
+	deadScope error
 }
 
 // evaluate computes the recursive freshness verdict for c. It loads the
@@ -261,6 +266,16 @@ func (c *gateCtx) evaluate() (evalResult, error) {
 	}
 	if c.gate.HasOwnScope() {
 		digest, hashErr := c.hasher.Hash(c.repo)
+		if errors.Is(hashErr, hasher.ErrDeadScope) {
+			// Not fresh — that is the bug this closes — but not fatal
+			// either. A gate on build output is legitimately empty
+			// between `make clean` and the next build, and erroring here
+			// would stop `run` from executing the command that refills
+			// it, leaving the gate recoverable only via `clear`.
+			res.deadScope = hashErr
+			res.reason = "dead scope"
+			return res, nil
+		}
 		if hashErr != nil {
 			return evalResult{}, hashErr
 		}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -53,7 +53,8 @@ gates:
   # reported as a mismatch by verify: its digest would be a constant and
   # the gate could never block. "markgate config lint" warns per pattern,
   # so run it after renaming a directory. This does not apply to the
-  # default hash: git-tree, whose scope is the whole repository.
+  # default hash: git-tree, whose digest folds in HEAD and so keeps
+  # invalidating even when its own include matches nothing.
 
   # Example: narrow-scope gate for PR-time docs checks.
   # pre-pr:

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -29,11 +29,6 @@ gates:
     #   - "vendor/**"
     #   - "node_modules/**"
     #
-    # An include list where no pattern matches any file in the working
-    # tree is a run-time error, not an empty scope: the digest would be
-    # a constant and the gate could never block. "markgate config lint"
-    # warns per pattern, so run it after renaming a directory.
-    #
     # state_dir controls where the marker file is written. Prefer
     # relative paths (resolved against the repo top-level) so every
     # machine agrees on the location. Two patterns:
@@ -52,6 +47,13 @@ gates:
     #        the marker it just wrote).
     #
     # See README "Sharing markers" for the full picture.
+
+  # On a SCOPED gate (hash: files or hash: diff), an include list where
+  # no pattern can match anything the gate sees is refused by set and
+  # reported as a mismatch by verify: its digest would be a constant and
+  # the gate could never block. "markgate config lint" warns per pattern,
+  # so run it after renaming a directory. This does not apply to the
+  # default hash: git-tree, whose scope is the whole repository.
 
   # Example: narrow-scope gate for PR-time docs checks.
   # pre-pr:

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -29,6 +29,11 @@ gates:
     #   - "vendor/**"
     #   - "node_modules/**"
     #
+    # An include list where no pattern matches any file in the working
+    # tree is a run-time error, not an empty scope: the digest would be
+    # a constant and the gate could never block. "markgate config lint"
+    # warns per pattern, so run it after renaming a directory.
+    #
     # state_dir controls where the marker file is written. Prefer
     # relative paths (resolved against the repo top-level) so every
     # machine agrees on the location. Two patterns:

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -2686,10 +2686,39 @@ func TestDeadIncludeExplainDoesNotChangeTheOutcome(t *testing.T) {
 		t.Errorf("--explain suppressed the child: %v", err)
 	}
 
-	// The digest is still refused; only the description is tolerant.
-	if code, _ := runCmd(t, "set", "typo", "--hash", "files", "--include", "scr/**",
-		"--explain"); code != 2 {
-		t.Errorf("set --explain on a dead include: code = %d, want 2", code)
+	// A scope that cannot be computed at all is the harder case: without
+	// a marker nothing else touches the glob, so --explain is the only
+	// caller, and failing there would flip the exit code and suppress
+	// the child.
+	plain, _ := runCmd(t, "verify", "bad", "--hash", "files", "--include", "a[b")
+	explained, _, stderr := runCmdStderr(t, "verify", "bad", "--hash", "files",
+		"--include", "a[b", "--explain")
+	if plain != explained {
+		t.Errorf("--explain changed verify on a malformed glob: %d -> %d", plain, explained)
+	}
+	if !strings.Contains(stderr, "unavailable") {
+		t.Errorf("--explain did not report why the scope was missing: %q", stderr)
+	}
+	// Same for run: the malformed glob genuinely stops `set` from
+	// recording, so both forms exit 2 — but the child must run either
+	// way. Asserting equality rather than a fixed code keeps the test
+	// about the flag, not about what a bad glob happens to return.
+	plainStamp := filepath.Join(dir, "plain-ran.txt")
+	plainRun, _ := runCmd(t, "run", "bad", "--hash", "files", "--include", "a[b",
+		"--", "touch", plainStamp)
+	explainStamp := filepath.Join(dir, "explain-ran.txt")
+	explainRun, _ := runCmd(t, "run", "bad", "--hash", "files", "--include", "a[b",
+		"--explain", "--", "touch", explainStamp)
+	if plainRun != explainRun {
+		t.Errorf("--explain changed run on a malformed glob: %d -> %d", plainRun, explainRun)
+	}
+	_, plainErr := os.Stat(plainStamp)
+	_, explainErr := os.Stat(explainStamp)
+	if (plainErr == nil) != (explainErr == nil) {
+		t.Errorf("--explain changed whether the child ran: plain=%v explain=%v", plainErr, explainErr)
+	}
+	if plainErr != nil {
+		t.Fatalf("fixture broken: the child should run without --explain too: %v", plainErr)
 	}
 }
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -2515,3 +2515,179 @@ func TestDiffHash_WithStateDir(t *testing.T) {
 		t.Errorf("verify after committing the marker: code = %d, want 0", code)
 	}
 }
+
+// A dead include glob — a typo, a renamed directory, a path that moved —
+// used to make a scoped gate pass forever: the digest degenerated to the
+// SHA-256 of the empty set, so nothing could ever move it. It affects
+// both scoped hash modes identically.
+func TestDeadIncludeIsRefusedAtSet(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	gitIn(t, dir, "checkout", "-q", "-b", "feat")
+	writeRepoFile(t, dir, "src/a.go", "mine")
+	gitIn(t, dir, "commit", "-qam", "my work")
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"files", []string{"set", "typo", "--hash", "files", "--include", "scr/**"}},
+		{"diff", []string{"set", "typo", "--hash", "diff", "--base", "main", "--include", "scr/**"}},
+	} {
+		code, msg := runCmdMsg(t, tc.args...)
+		if code != 2 {
+			t.Errorf("%s: dead include code = %d, want 2", tc.name, code)
+		}
+		if !strings.Contains(msg, "scr/**") {
+			t.Errorf("%s: error does not name the dead pattern: %q", tc.name, msg)
+		}
+	}
+	markerPath := filepath.Join(dir, ".git", "markgate", "typo.json")
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("a dead-scope gate wrote a marker at %s (err = %v)", markerPath, err)
+	}
+}
+
+// The realistic path to a dead glob is a rename after the marker was
+// recorded, which is also the only way to reach a marker whose scope has
+// since died. verify must refuse rather than keep reporting match.
+func TestDeadIncludeIsRefusedAtVerifyAfterARename(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  scan:\n    hash: files\n    include:\n      - \"src/**\"\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+
+	if code, _ := runCmd(t, "set", "scan"); code != 0 {
+		t.Fatal("set with a live include should succeed")
+	}
+	if code, _ := runCmd(t, "verify", "scan"); code != 0 {
+		t.Fatal("verify right after set should match")
+	}
+
+	gitIn(t, dir, "mv", "src", "source")
+	gitIn(t, dir, "commit", "-qm", "rename src -> source")
+
+	if code, msg := runCmdMsg(t, "verify", "scan"); code != 2 || !strings.Contains(msg, "src/**") {
+		t.Errorf("verify after the rename: code = %d, msg = %q; want 2 naming src/**", code, msg)
+	}
+}
+
+// The check must not fire before the gated command has had a chance to
+// produce the files, or `markgate run build -- make dist` stops working
+// on a clean checkout. verify returns "no marker" without hashing, so
+// the child still runs and the marker lands once the files exist.
+func TestDeadIncludeDoesNotBreakBootstrappingViaRun(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+
+	if code, _ := runCmd(t, "verify", "dist", "--hash", "files", "--include", "dist/**"); code != 1 {
+		t.Error("verify with no marker should be a plain mismatch, not an error")
+	}
+	built := filepath.Join(dir, "dist", "x")
+	if code, _ := runCmd(t, "run", "dist", "--hash", "files", "--include", "dist/**",
+		"--", "sh", "-c", "mkdir -p dist && echo built > dist/x"); code != 0 {
+		t.Fatal("run should bootstrap a scope its child creates")
+	}
+	if _, err := os.Stat(built); err != nil {
+		t.Fatalf("child did not run: %v", err)
+	}
+	if code, _ := runCmd(t, "verify", "dist", "--hash", "files", "--include", "dist/**"); code != 0 {
+		t.Error("verify after the child built the scope should match")
+	}
+}
+
+// When the child runs and still produces nothing the include matches,
+// the marker must be refused: recording it is what makes the gate pass
+// forever. The child running is the point — this is the case that
+// distinguishes "not yet built" from "will never match".
+func TestDeadIncludeRefusesTheMarkerAfterTheChildRuns(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+
+	stamp := filepath.Join(dir, "child-ran.txt")
+	code, _ := runCmd(t, "run", "never", "--hash", "files", "--include", "nope/**",
+		"--", "touch", stamp)
+	if code != 2 {
+		t.Errorf("run with a dead include: code = %d, want 2", code)
+	}
+	if _, err := os.Stat(stamp); err != nil {
+		t.Errorf("the child should still have run: %v", err)
+	}
+	markerPath := filepath.Join(dir, ".git", "markgate", "never.json")
+	if _, err := os.Stat(markerPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("run recorded a marker for a dead scope (err = %v)", err)
+	}
+}
+
+// --explain is a diagnostic and must not change what a command does.
+// It renders the scope, which for a dead include is legitimately empty;
+// refusing there would make `markgate run build --explain -- make dist`
+// skip its child on a clean checkout while the same command without the
+// flag bootstraps fine.
+func TestDeadIncludeExplainDoesNotChangeTheOutcome(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+
+	args := []string{"run", "dist", "--hash", "files", "--include", "dist/**", "--explain",
+		"--", "sh", "-c", "mkdir -p dist && echo built > dist/x"}
+	if code, _ := runCmd(t, args...); code != 0 {
+		t.Errorf("run --explain bootstrapping a scope: code = %d, want 0", code)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "dist", "x")); err != nil {
+		t.Errorf("--explain suppressed the child: %v", err)
+	}
+
+	// The digest is still refused; only the description is tolerant.
+	if code, _ := runCmd(t, "set", "typo", "--hash", "files", "--include", "scr/**",
+		"--explain"); code != 2 {
+		t.Errorf("set --explain on a dead include: code = %d, want 2", code)
+	}
+}
+
+// Bare status is the "show me every gate" view, so one unusable gate
+// must degrade its own row rather than abort the listing.
+func TestDeadIncludeDegradesBareStatus(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  scan:\n    hash: files\n    include:\n      - \"src/**\"\n"+
+			"  healthy:\n    hash: files\n    include:\n      - \"src/**\"\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	if code, _ := runCmd(t, "set", "scan"); code != 0 {
+		t.Fatal("seed set failed")
+	}
+	if code, _ := runCmd(t, "set", "healthy"); code != 0 {
+		t.Fatal("seed set failed")
+	}
+
+	// Kill only scan's scope, by narrowing the config after the fact.
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  scan:\n    hash: files\n    include:\n      - \"scr/**\"\n"+
+			"  healthy:\n    hash: files\n    include:\n      - \"src/**\"\n")
+
+	code, out := runCmd(t, "status")
+	if code != 1 {
+		t.Errorf("bare status: code = %d, want 1", code)
+	}
+	if !strings.Contains(out, "scan") || !strings.Contains(out, "dead scope") {
+		t.Errorf("bare status did not report the dead row: %q", out)
+	}
+	if !strings.Contains(out, "healthy") {
+		t.Errorf("bare status stopped rendering other gates: %q", out)
+	}
+	// Single-key status is not a listing, so it errors like everything else.
+	if code, _ := runCmd(t, "status", "scan"); code != 2 {
+		t.Errorf("status scan: code = %d, want 2", code)
+	}
+}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -2551,9 +2551,10 @@ func TestDeadIncludeIsRefusedAtSet(t *testing.T) {
 }
 
 // The realistic path to a dead glob is a rename after the marker was
-// recorded, which is also the only way to reach a marker whose scope has
-// since died. verify must refuse rather than keep reporting match.
-func TestDeadIncludeIsRefusedAtVerifyAfterARename(t *testing.T) {
+// recorded. verify must stop reporting match — that is the whole bug —
+// without escalating to an error: exit 1 means "re-run the check", which
+// is what both a typo and a scope waiting to be rebuilt need.
+func TestDeadIncludeIsAMismatchAtVerifyAfterARename(t *testing.T) {
 	dir := initRepo(t)
 	writeRepoFile(t, dir, "src/a.go", "a")
 	writeRepoFile(t, dir, ".markgate.yml",
@@ -2571,8 +2572,46 @@ func TestDeadIncludeIsRefusedAtVerifyAfterARename(t *testing.T) {
 	gitIn(t, dir, "mv", "src", "source")
 	gitIn(t, dir, "commit", "-qm", "rename src -> source")
 
-	if code, msg := runCmdMsg(t, "verify", "scan"); code != 2 || !strings.Contains(msg, "src/**") {
-		t.Errorf("verify after the rename: code = %d, msg = %q; want 2 naming src/**", code, msg)
+	code, _, stderr := runCmdStderr(t, "verify", "scan")
+	if code != 1 {
+		t.Errorf("verify after the rename: code = %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "src/**") {
+		t.Errorf("verify did not name the dead pattern: %q", stderr)
+	}
+	// set is where the constant would actually be recorded, and by then
+	// any gated command has had its chance to refill the scope.
+	if code, msg := runCmdMsg(t, "set", "scan"); code != 2 || !strings.Contains(msg, "src/**") {
+		t.Errorf("set after the rename: code = %d, msg = %q; want 2 naming src/**", code, msg)
+	}
+}
+
+// The regression that erroring at verify caused: a gate on build output
+// is legitimately empty between `make clean` and the next build, and a
+// second `run` cycle must rebuild rather than lock the gate out. This is
+// the README's own dist example, run twice.
+func TestDeadIncludeRebuildsAfterTheScopeIsCleaned(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+
+	build := []string{"run", "dist", "--hash", "files", "--include", "dist/**",
+		"--", "sh", "-c", "mkdir -p dist && echo built > dist/x"}
+	if code, _ := runCmd(t, build...); code != 0 {
+		t.Fatal("first build should bootstrap the scope")
+	}
+	if err := os.RemoveAll(filepath.Join(dir, "dist")); err != nil {
+		t.Fatal(err)
+	}
+
+	// The marker still exists and the scope is now empty. Erroring here
+	// would leave the gate recoverable only via `markgate clear`.
+	if code, _ := runCmd(t, build...); code != 0 {
+		t.Errorf("rebuild after clean: code = %d, want 0", code)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "dist", "x")); err != nil {
+		t.Errorf("the child did not rebuild: %v", err)
 	}
 }
 
@@ -2686,8 +2725,7 @@ func TestDeadIncludeDegradesBareStatus(t *testing.T) {
 	if !strings.Contains(out, "healthy") {
 		t.Errorf("bare status stopped rendering other gates: %q", out)
 	}
-	// Single-key status is not a listing, so it errors like everything else.
-	if code, _ := runCmd(t, "status", "scan"); code != 2 {
-		t.Errorf("status scan: code = %d, want 2", code)
+	if code, out := runCmd(t, "status", "scan"); code != 1 || !strings.Contains(out, "dead scope") {
+		t.Errorf("status scan: code = %d, out = %q; want 1 naming the dead scope", code, out)
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -70,6 +70,9 @@ func runE(cmd *cobra.Command, args []string, overrides *gateFlagValues, explain 
 	if res.matched {
 		return nil
 	}
+	if res.deadScope != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "markgate: %s\n", res.deadScope)
+	}
 
 	code, execErr := execChild(cmdArgs)
 	if execErr != nil {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -173,12 +173,21 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 			unconfigured: false,
 		}
 		switch {
+		case res.deadScope != nil:
+			row.state = stateMismatch
+			row.note = noteWhat(res.deadScope)
 		case res.hashTypeChanged, res.ownDigestDiff:
 			row.state = stateMismatch
 			row.note = noteDigestDiff
-		case !res.matched:
+		case res.ttl.expired:
+			row.state = stateMismatch
+			row.note = fmt.Sprintf("expired %s ago", formatAge(res.ttl.age-res.ttl.ttl))
+		case res.childKey != "":
 			row.state = stateMismatch
 			row.note = "child " + res.childKey + " is stale"
+		case !res.matched:
+			row.state = stateMismatch
+			row.note = res.reason
 		default:
 			row.state = stateMatch
 		}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -227,6 +227,9 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 	case res.ownDigestDiff:
 		fmt.Fprintln(out, "state:      mismatch (digest differs)")
 		return &ExitError{Code: 1}
+	case res.deadScope != nil:
+		fmt.Fprintf(out, "state:      mismatch (%s)\n", res.deadScope)
+		return &ExitError{Code: 1}
 	case res.ttl.expired:
 		fmt.Fprintf(out, "state:      mismatch (expired by ttl: %s, marker is %s old)\n", c.gate.TTL, formatAge(res.ttl.age))
 		return &ExitError{Code: 1}
@@ -240,6 +243,13 @@ func statusSingle(out, errOut io.Writer, k string, overrides *gateFlagValues, ex
 		fmt.Fprintln(out, "state:      match")
 		return nil
 	}
+}
+
+// noteWhat trims an error down to the clause before the first
+// semicolon: the table column has no room for the remedy, and
+// `markgate status <key>` prints the whole message anyway.
+func noteWhat(err error) string {
+	return strings.SplitN(err.Error(), ";", 2)[0]
 }
 
 func statusListAll(out io.Writer, overrides *gateFlagValues, asJSON bool) error {
@@ -373,17 +383,17 @@ func buildRow(c *gateCtx, configured bool, clock time.Time) (statusRow, error) {
 	}
 	res, err := c.evaluate()
 	if err != nil {
-		// A gate that cannot be evaluated at all — an unusable diff base,
-		// or an include list that matches nothing — is an error
-		// everywhere else, but the bare listing is the "show me every
-		// gate" view: report the offending row and keep rendering the
-		// others.
-		if errors.Is(err, hasher.ErrDiffBase) || errors.Is(err, hasher.ErrDeadScope) {
+		// A diff gate whose base is unusable is an error everywhere
+		// else, but the bare listing is the "show me every gate" view:
+		// report the offending row and keep rendering the others. A dead
+		// scope needs no branch here — evaluate returns it as a plain
+		// mismatch.
+		if errors.Is(err, hasher.ErrDiffBase) {
 			row.state = stateMismatch
 			// Only the "what", not the "how to fix": the remedy clause
 			// after the semicolon would blow the table's width open, and
 			// `markgate status <key>` prints the whole message anyway.
-			row.note = strings.SplitN(err.Error(), ";", 2)[0]
+			row.note = noteWhat(err)
 			return row, nil
 		}
 		return row, err
@@ -400,6 +410,9 @@ func buildRow(c *gateCtx, configured bool, clock time.Time) (statusRow, error) {
 	}
 	row.marker = res.marker
 	switch {
+	case res.deadScope != nil:
+		row.state = stateMismatch
+		row.note = noteWhat(res.deadScope)
 	case res.hashTypeChanged, res.ownDigestDiff:
 		row.state = stateMismatch
 		row.note = noteDigestDiff

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -373,11 +373,12 @@ func buildRow(c *gateCtx, configured bool, clock time.Time) (statusRow, error) {
 	}
 	res, err := c.evaluate()
 	if err != nil {
-		// A diff gate whose base is unusable (unfetched ref, or HEAD
-		// sitting at the merge base) is an error everywhere else, but
-		// the bare listing is the "show me every gate" view: report the
-		// offending row and keep rendering the others.
-		if errors.Is(err, hasher.ErrDiffBase) {
+		// A gate that cannot be evaluated at all — an unusable diff base,
+		// or an include list that matches nothing — is an error
+		// everywhere else, but the bare listing is the "show me every
+		// gate" view: report the offending row and keep rendering the
+		// others.
+		if errors.Is(err, hasher.ErrDiffBase) || errors.Is(err, hasher.ErrDeadScope) {
 			row.state = stateMismatch
 			// Only the "what", not the "how to fix": the remedy clause
 			// after the semicolon would blow the table's width open, and

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -33,6 +33,9 @@ func newVerifyCmd() *cobra.Command {
 		if emitErr := emitExplain(c, explain, cmd.OutOrStdout(), cmd.ErrOrStderr(), label); emitErr != nil {
 			return &ExitError{Code: 2, Err: emitErr}
 		}
+		if res.deadScope != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "markgate: %s\n", res.deadScope)
+		}
 		if res.ttl.expired {
 			fmt.Fprintf(cmd.ErrOrStderr(),
 				"markgate: state mismatch (expired by ttl: %s, marker is %s old)\n",

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -198,6 +198,19 @@ func (r *Repo) DiffFrom(rev string) ([]DiffEntry, error) {
 	return entries, nil
 }
 
+// CandidateNames returns every path git can report in a diff or as
+// untracked: what is in the index, plus what is untracked and not
+// ignored. One ls-files invocation covers both, and the two sets are
+// disjoint by definition. Repo-relative, whole repository regardless
+// of cwd.
+func (r *Repo) CandidateNames() ([]string, error) {
+	out, err := r.runAtRoot("ls-files", "-z", "--cached", "--others", "--exclude-standard")
+	if err != nil {
+		return nil, err
+	}
+	return splitNUL(out), nil
+}
+
 // UntrackedNames returns paths (repo-relative) that are untracked but not
 // ignored, for the whole repository regardless of cwd.
 func (r *Repo) UntrackedNames() ([]string, error) {

--- a/internal/hasher/diff.go
+++ b/internal/hasher/diff.go
@@ -59,7 +59,7 @@ func (d Diff) Hash(repo *gitutil.Repo) (string, error) {
 	// nothing anywhere (a dead config that would digest to a constant).
 	// Globbing the tree tells them apart, and only on the empty path —
 	// the delta itself is never globbed.
-	if err := refuseDeadScope(top, d.Include, len(entries)); err != nil {
+	if err := refuseDeadScope(d.candidates(repo), d.Include, len(entries)); err != nil {
 		return "", err
 	}
 
@@ -115,6 +115,16 @@ func (d Diff) MergeBase(repo *gitutil.Repo) (string, error) {
 func (d Diff) Preflight(repo *gitutil.Repo) error {
 	_, err := d.entries(repo)
 	return err
+}
+
+// candidates lists every path that could ever appear in this gate's
+// delta: what git tracks, plus what is untracked and not ignored.
+// Deliberately not the working tree — an ignored path or anything under
+// .git/ can never enter a diff, so globbing the disk would call such an
+// include "live" while its scope stays permanently empty, which is the
+// exact fail-open this check exists to close.
+func (d Diff) candidates(repo *gitutil.Repo) func() ([]string, error) {
+	return func() ([]string, error) { return repo.CandidateNames() }
 }
 
 // entries returns the sorted, include/exclude-filtered delta. Patterns

--- a/internal/hasher/diff.go
+++ b/internal/hasher/diff.go
@@ -53,6 +53,16 @@ func (d Diff) Hash(repo *gitutil.Repo) (string, error) {
 		return "", err
 	}
 
+	// An empty scope has two very different causes and only one is a bug:
+	// this branch changed nothing the gate covers (legitimate, and the
+	// case this hash type exists for), or the include list matches
+	// nothing anywhere (a dead config that would digest to a constant).
+	// Globbing the tree tells them apart, and only on the empty path —
+	// the delta itself is never globbed.
+	if err := refuseDeadScope(top, d.Include, len(entries)); err != nil {
+		return "", err
+	}
+
 	h := sha256.New()
 	for _, e := range entries {
 		// The base-side blob is framed in so that resolving a merge by

--- a/internal/hasher/diff_test.go
+++ b/internal/hasher/diff_test.go
@@ -461,3 +461,49 @@ func TestDiff_DeletedPathStaysInScope(t *testing.T) {
 		}
 	}
 }
+
+// The two empty scopes a diff gate can have look identical from the
+// digest and must not be treated alike: a quiet branch is the state
+// this hash type exists to keep fresh, while a dead include is a
+// configuration that would pass forever.
+func TestDiff_DeadIncludeIsAnError(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/a.go", "mine\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+
+	dead := Diff{Include: []string{"scr/**"}, Base: "main"}
+	if _, err := dead.Hash(repo); !errors.Is(err, ErrDeadScope) {
+		t.Errorf("dead include: Hash err = %v, want ErrDeadScope", err)
+	}
+	// Scope stays a description, not a refusal — it backs --explain.
+	if deadScope, err := dead.Scope(repo); err != nil || len(deadScope) != 0 {
+		t.Errorf("dead include: Scope = %v, err = %v; want empty and no error", deadScope, err)
+	}
+
+	// Same empty scope, live pattern: the branch simply changed nothing
+	// under docs/. This must keep working, or the gate becomes unusable
+	// on exactly the branches it should trivially pass.
+	quiet := Diff{Include: []string{"docs/**"}, Base: "main"}
+	scope, err := quiet.Scope(repo)
+	if err != nil {
+		t.Fatalf("quiet branch should not error: %v", err)
+	}
+	if len(scope) != 0 {
+		t.Errorf("scope = %v, want empty", scope)
+	}
+	if _, err := quiet.Hash(repo); err != nil {
+		t.Errorf("quiet branch should hash: %v", err)
+	}
+}
+
+// An unscoped diff gate covers the whole delta, so there is no include
+// list to be dead — an empty delta is already refused by ErrDiffBase.
+func TestDiff_NoIncludeIsNotDead(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, "src/a.go", "mine\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+
+	if _, err := (Diff{Base: "main"}).Hash(repo); err != nil {
+		t.Errorf("include-less Diff should not report a dead scope: %v", err)
+	}
+}

--- a/internal/hasher/diff_test.go
+++ b/internal/hasher/diff_test.go
@@ -507,3 +507,51 @@ func TestDiff_NoIncludeIsNotDead(t *testing.T) {
 		t.Errorf("include-less Diff should not report a dead scope: %v", err)
 	}
 }
+
+// A delta can never contain an ignored path or anything under .git/, so
+// an include matching only those is permanently empty however live it
+// looks on disk — the same fail-open a typo produces, reached by a
+// different route. Globbing the working tree would call it live.
+func TestDiff_IncludeMatchingOnlyUnreachablePathsIsDead(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	writeFile(t, dir, ".gitignore", "build/\n")
+	runGit(t, dir, "add", ".gitignore")
+	runGit(t, dir, "commit", "-qm", "ignore build")
+	writeFile(t, dir, "build/out.bin", "bin")
+	writeFile(t, dir, "src/a.go", "mine\n")
+	runGit(t, dir, "commit", "-qam", "my work")
+
+	for _, include := range [][]string{{"build/**"}, {".git/HEAD"}} {
+		h := Diff{Include: include, Base: "main"}
+		if _, err := h.Hash(repo); !errors.Is(err, ErrDeadScope) {
+			t.Errorf("include %v: Hash err = %v, want ErrDeadScope", include, err)
+		}
+	}
+
+	// Untracked-but-not-ignored can enter a delta, so it is live.
+	writeFile(t, dir, "src/new.go", "new\n")
+	if _, err := (Diff{Include: []string{"src/new.go"}, Base: "main"}).Hash(repo); err != nil {
+		t.Errorf("untracked-not-ignored include should be live: %v", err)
+	}
+}
+
+// The scopeLen short-circuit is not just an optimization: a delta made
+// only of paths deleted from the working tree has a real scope that no
+// worktree glob can see. Without the guard those gates would be refused.
+func TestDiff_DeletedOnlyDeltaIsNotDead(t *testing.T) {
+	repo, dir := newDiffRepo(t)
+	runGit(t, dir, "rm", "-q", "-r", "docs")
+	runGit(t, dir, "commit", "-qm", "delete docs")
+
+	h := Diff{Include: []string{"docs/**"}, Base: "main"}
+	scope, err := h.Scope(repo)
+	if err != nil {
+		t.Fatalf("deleted-only delta: %v", err)
+	}
+	if len(scope) == 0 {
+		t.Fatal("fixture broken: the delta should still carry the deleted paths")
+	}
+	if _, err := h.Hash(repo); err != nil {
+		t.Errorf("deleted-only delta should hash: %v", err)
+	}
+}

--- a/internal/hasher/files.go
+++ b/internal/hasher/files.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -37,7 +38,7 @@ func (f Files) Hash(repo *gitutil.Repo) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := refuseDeadScope(top, f.Include, len(matches)); err != nil {
+	if err := refuseDeadScope(worktreeCandidates(top, f.Include), f.Include, len(matches)); err != nil {
 		return "", err
 	}
 
@@ -93,25 +94,31 @@ func (f Files) resolve(topLevel string) ([]string, error) {
 	return out, nil
 }
 
-// ErrDeadScope marks an include list where no pattern matches any path
-// in the working tree — a typo, a renamed directory, a path that moved.
-// The scope is then empty for a reason that has nothing to do with the
-// repository's state, so the digest is the constant SHA-256 of the empty
-// set and the gate reports "match" forever. Callers that render many
-// gates at once (bare `status`) match on it to degrade one row instead
-// of aborting the listing; every other command surfaces it as an error.
+// ErrDeadScope marks an include list where no pattern can match anything
+// the gate is able to see — a typo, a renamed directory, a path that
+// moved. The scope is then empty for a reason that has nothing to do
+// with the repository's state, so the digest is the constant SHA-256 of
+// the empty set and the gate reports "match" forever.
+//
+// It is a mismatch at verify time and an error at set time. Verify must
+// not pass (that is the bug), but it must not error either: an empty
+// scope is also the ordinary state of a gate on build output between
+// `make clean` and the next build, and refusing there would stop `run`
+// from executing the very command that refills the scope. By set time
+// that command has had its chance, so a still-empty scope is the
+// configuration's fault and recording the constant is refused.
 var ErrDeadScope = errors.New("dead scope")
 
 // deadScopeErr builds the ErrDeadScope message. The patterns are named
 // because the whole point is that the user cannot see which one is
 // wrong from the gate's behavior — it simply keeps passing.
 func deadScopeErr(include []string) error {
-	return fmt.Errorf("%w: include matches no file in the working tree (%s); the digest would be a constant that never goes stale, so fix the pattern or drop the gate",
+	return fmt.Errorf("%w: include matches nothing this gate can see (%s); the digest would be a constant that never goes stale, so fix the pattern or drop the gate",
 		ErrDeadScope, strings.Join(include, ", "))
 }
 
 // refuseDeadScope reports ErrDeadScope when an include list produced an
-// empty scope and no pattern matches anything in the working tree.
+// empty scope and no pattern matches any path in candidates.
 //
 // Called from Hash and never from Scope: an empty scope is a truthful
 // description of the gate, and Scope backs the diagnostic paths
@@ -119,33 +126,63 @@ func deadScopeErr(include []string) error {
 // command does. Digesting that scope is the part that cannot be allowed
 // — it yields a constant no change can ever move.
 //
-// The extra glob is only paid when the scope came out empty, which also
-// keeps "every pattern is dead" (a broken config) distinct from
-// "exclude removed everything" (a deliberate one).
-func refuseDeadScope(topLevel string, include []string, scopeLen int) error {
+// candidates is the set of paths the caller's strategy could ever put in
+// scope, and differs between them: Files really does hash whatever is on
+// disk, while Diff draws from a git delta that can never contain an
+// ignored path. Passing the wrong universe here is not a false alarm but
+// a false all-clear — an include matching only ignored files would look
+// live to Files' universe and stay permanently constant under Diff.
+func refuseDeadScope(candidates func() ([]string, error), include []string, scopeLen int) error {
 	if scopeLen > 0 || len(include) == 0 {
 		return nil
 	}
-	return liveIncludes(topLevel, include)
-}
-
-// liveIncludes reports ErrDeadScope when include is non-empty and no
-// pattern matches any path in the working tree. Diff needs this as a
-// separate pass because its scope comes from the branch delta rather
-// than from globbing the tree; Files gets the same answer for free
-// inside resolve.
-func liveIncludes(topLevel string, include []string) error {
-	for _, pat := range include {
-		matches, err := MatchGlob(topLevel, pat)
-		if err != nil {
-			return fmt.Errorf("include glob %q: %w", pat, err)
-		}
-		if len(matches) > 0 {
-			return nil
-		}
+	paths, err := candidates()
+	if err != nil {
+		return err
+	}
+	live, err := filterGlobs(paths, include, nil)
+	if err != nil {
+		return err
+	}
+	if len(live) > 0 {
+		return nil
 	}
 	return deadScopeErr(include)
 }
+
+// worktreeCandidates lists every regular file under topLevel that an
+// include pattern could match. Used by Files, which hashes paths off the
+// disk regardless of what git thinks of them.
+//
+// Only reached when a scope came out empty, so the walk is off the hot
+// path; it stops at the first hit that any pattern accepts.
+func worktreeCandidates(topLevel string, include []string) func() ([]string, error) {
+	return func() ([]string, error) {
+		fsys := os.DirFS(topLevel)
+		var found []string
+		for _, pat := range include {
+			err := doublestar.GlobWalk(fsys, pat, func(path string, d fs.DirEntry) error {
+				if d.IsDir() {
+					return nil
+				}
+				found = append(found, path)
+				return errStopWalk
+			})
+			if err != nil && !errors.Is(err, errStopWalk) {
+				return nil, fmt.Errorf("include glob %q: %w", pat, err)
+			}
+			if len(found) > 0 {
+				return found, nil
+			}
+		}
+		return found, nil
+	}
+}
+
+// errStopWalk aborts a GlobWalk once one match is in hand. Liveness is
+// an existence question, so collecting the rest is wasted work on a repo
+// where the pattern is broad.
+var errStopWalk = errors.New("stop walk")
 
 // MatchGlob expands pat against topLevel as a doublestar glob and returns
 // the sorted repo-relative paths of matching regular files. Directories

--- a/internal/hasher/files.go
+++ b/internal/hasher/files.go
@@ -3,10 +3,12 @@ package hasher
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 
@@ -33,6 +35,9 @@ func (f Files) Hash(repo *gitutil.Repo) (string, error) {
 	}
 	matches, err := f.resolve(top)
 	if err != nil {
+		return "", err
+	}
+	if err := refuseDeadScope(top, f.Include, len(matches)); err != nil {
 		return "", err
 	}
 
@@ -86,6 +91,60 @@ func (f Files) resolve(topLevel string) ([]string, error) {
 	}
 	sort.Strings(out)
 	return out, nil
+}
+
+// ErrDeadScope marks an include list where no pattern matches any path
+// in the working tree — a typo, a renamed directory, a path that moved.
+// The scope is then empty for a reason that has nothing to do with the
+// repository's state, so the digest is the constant SHA-256 of the empty
+// set and the gate reports "match" forever. Callers that render many
+// gates at once (bare `status`) match on it to degrade one row instead
+// of aborting the listing; every other command surfaces it as an error.
+var ErrDeadScope = errors.New("dead scope")
+
+// deadScopeErr builds the ErrDeadScope message. The patterns are named
+// because the whole point is that the user cannot see which one is
+// wrong from the gate's behavior — it simply keeps passing.
+func deadScopeErr(include []string) error {
+	return fmt.Errorf("%w: include matches no file in the working tree (%s); the digest would be a constant that never goes stale, so fix the pattern or drop the gate",
+		ErrDeadScope, strings.Join(include, ", "))
+}
+
+// refuseDeadScope reports ErrDeadScope when an include list produced an
+// empty scope and no pattern matches anything in the working tree.
+//
+// Called from Hash and never from Scope: an empty scope is a truthful
+// description of the gate, and Scope backs the diagnostic paths
+// (--explain, the empty-delta warning), which must not change what a
+// command does. Digesting that scope is the part that cannot be allowed
+// — it yields a constant no change can ever move.
+//
+// The extra glob is only paid when the scope came out empty, which also
+// keeps "every pattern is dead" (a broken config) distinct from
+// "exclude removed everything" (a deliberate one).
+func refuseDeadScope(topLevel string, include []string, scopeLen int) error {
+	if scopeLen > 0 || len(include) == 0 {
+		return nil
+	}
+	return liveIncludes(topLevel, include)
+}
+
+// liveIncludes reports ErrDeadScope when include is non-empty and no
+// pattern matches any path in the working tree. Diff needs this as a
+// separate pass because its scope comes from the branch delta rather
+// than from globbing the tree; Files gets the same answer for free
+// inside resolve.
+func liveIncludes(topLevel string, include []string) error {
+	for _, pat := range include {
+		matches, err := MatchGlob(topLevel, pat)
+		if err != nil {
+			return fmt.Errorf("include glob %q: %w", pat, err)
+		}
+		if len(matches) > 0 {
+			return nil
+		}
+	}
+	return deadScopeErr(include)
 }
 
 // MatchGlob expands pat against topLevel as a doublestar glob and returns

--- a/internal/hasher/files_test.go
+++ b/internal/hasher/files_test.go
@@ -160,6 +160,37 @@ func TestFiles_ExcludeEmptyingTheScopeIsNotDead(t *testing.T) {
 	if len(scope) != 0 {
 		t.Errorf("scope = %v, want empty", scope)
 	}
+	// Hash is where the refusal lives, so Scope alone would not notice a
+	// check that stopped distinguishing the two empty scopes.
+	if _, err := h.Hash(repo); err != nil {
+		t.Errorf("exclude-emptied Hash should not error: %v", err)
+	}
+}
+
+// Files hashes whatever is on disk, ignored or not, so an include that
+// matches only gitignored paths is a real scope and must stay legal.
+// Diff draws from a git delta instead, which is why the two strategies
+// need different candidate universes.
+func TestFiles_GitignoredIncludeIsLive(t *testing.T) {
+	repo, dir := newTestRepo(t)
+	writeFile(t, dir, ".gitignore", "build/\n")
+	writeFile(t, dir, "build/out.bin", "bin")
+	runGit(t, dir, "add", ".gitignore")
+	runGit(t, dir, "commit", "-qm", "ignore build")
+
+	h := Files{Include: []string{"build/**"}}
+	before, err := h.Hash(repo)
+	if err != nil {
+		t.Fatalf("gitignored include should hash under files: %v", err)
+	}
+	writeFile(t, dir, "build/out.bin", "changed")
+	after, err := h.Hash(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Error("files did not notice a change under a gitignored include")
+	}
 }
 
 // A gate with no include at all covers the whole tree and cannot be

--- a/internal/hasher/files_test.go
+++ b/internal/hasher/files_test.go
@@ -168,9 +168,9 @@ func TestFiles_ExcludeEmptyingTheScopeIsNotDead(t *testing.T) {
 }
 
 // Files hashes whatever is on disk, ignored or not, so an include that
-// matches only gitignored paths is a real scope and must stay legal.
-// Diff draws from a git delta instead, which is why the two strategies
-// need different candidate universes.
+// matches only gitignored paths is a real scope. The scope here is
+// non-empty, so this covers the hashing, not the refusal — for that see
+// TestFiles_EmptyScopeAsksTheWorkingTreeNotGit.
 func TestFiles_GitignoredIncludeIsLive(t *testing.T) {
 	repo, dir := newTestRepo(t)
 	writeFile(t, dir, ".gitignore", "build/\n")
@@ -194,10 +194,54 @@ func TestFiles_GitignoredIncludeIsLive(t *testing.T) {
 }
 
 // A gate with no include at all covers the whole tree and cannot be
-// dead, so the check must not fire on it.
+// dead, so the check must not fire on it. Exercised through Hash on an
+// empty tree: Scope never carries the refusal, so asserting there would
+// pass no matter what the check did.
 func TestFiles_NoIncludeIsNotDead(t *testing.T) {
 	repo, _ := newTestRepo(t)
-	if _, err := (Files{}).Scope(repo); err != nil {
+	if _, err := (Files{}).Hash(repo); err != nil {
 		t.Errorf("include-less Files should not report a dead scope: %v", err)
+	}
+}
+
+// An include naming a directory rather than the files under it — the
+// missing-/** typo — matches the path but no regular file, so the scope
+// is empty and the digest constant. The directory filter in the
+// candidate walk is what catches this; without it the gate would pass
+// forever, which is issue #70 verbatim.
+func TestFiles_IncludeMatchingOnlyADirectoryIsDead(t *testing.T) {
+	repo, dir := newTestRepo(t)
+	writeFile(t, dir, "src/a.ts", "a")
+
+	if _, err := (Files{Include: []string{"src"}}).Hash(repo); !errors.Is(err, ErrDeadScope) {
+		t.Errorf("include naming a directory: Hash err = %v, want ErrDeadScope", err)
+	}
+	// The same pattern with the files under it is a real scope.
+	if _, err := (Files{Include: []string{"src/**"}}).Hash(repo); err != nil {
+		t.Errorf("src/** should be live: %v", err)
+	}
+}
+
+// The Files half of the per-strategy universe. Reaching it needs an
+// EMPTY scope whose include is nevertheless live on disk, which is what
+// exclude gives us: if Files asked git's candidate set instead of the
+// working tree, a gitignored include would look dead and be refused.
+func TestFiles_EmptyScopeAsksTheWorkingTreeNotGit(t *testing.T) {
+	repo, dir := newTestRepo(t)
+	writeFile(t, dir, ".gitignore", "build/\n")
+	writeFile(t, dir, "build/out.bin", "bin")
+	runGit(t, dir, "add", ".gitignore")
+	runGit(t, dir, "commit", "-qm", "ignore build")
+
+	h := Files{Include: []string{"build/**"}, Exclude: []string{"build/**"}}
+	scope, err := h.Scope(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(scope) != 0 {
+		t.Fatalf("fixture broken: scope = %v, want empty so the check is reached", scope)
+	}
+	if _, err := h.Hash(repo); err != nil {
+		t.Errorf("gitignored include is live for files; Hash err = %v", err)
 	}
 }

--- a/internal/hasher/files_test.go
+++ b/internal/hasher/files_test.go
@@ -1,6 +1,8 @@
 package hasher
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/go-to-k/markgate/internal/config"
@@ -98,5 +100,73 @@ func TestFor_DefaultsToGitTree(t *testing.T) {
 	}
 	if h.Type() != config.HashGitTree {
 		t.Errorf("default hasher = %q, want %q", h.Type(), config.HashGitTree)
+	}
+}
+
+// An include list that matches nothing is not an empty scope, it is a
+// broken one: the digest degenerates to the SHA-256 of the empty set,
+// which is the same value for every such gate, so the marker matches
+// forever and the gate can never block.
+func TestFiles_DeadIncludeIsAnError(t *testing.T) {
+	repo, dir := newTestRepo(t)
+	writeFile(t, dir, "src/a.ts", "a")
+
+	h := Files{Include: []string{"scr/**"}}
+	if _, err := h.Hash(repo); !errors.Is(err, ErrDeadScope) {
+		t.Errorf("Hash err = %v, want ErrDeadScope", err)
+	}
+	// Scope must stay a truthful description rather than a refusal: it
+	// backs --explain, which is a diagnostic and must never change what
+	// a command does.
+	scope, err := h.Scope(repo)
+	if err != nil {
+		t.Errorf("Scope on a dead include should not error: %v", err)
+	}
+	if len(scope) != 0 {
+		t.Errorf("Scope = %v, want empty", scope)
+	}
+	// The message has to name the pattern: the gate's behavior gives the
+	// user no way to tell which one is wrong.
+	_, hashErr := h.Hash(repo)
+	if !strings.Contains(hashErr.Error(), "scr/**") {
+		t.Errorf("error does not name the dead pattern: %v", hashErr)
+	}
+}
+
+// One live pattern is enough. A partially dead include list still has a
+// real scope, so it is lint's business (it warns per pattern), not a
+// reason to refuse to hash.
+func TestFiles_OneLiveIncludePatternIsEnough(t *testing.T) {
+	repo, dir := newTestRepo(t)
+	writeFile(t, dir, "src/a.ts", "a")
+
+	h := Files{Include: []string{"scr/**", "src/**"}}
+	if _, err := h.Hash(repo); err != nil {
+		t.Errorf("partially dead include should still hash: %v", err)
+	}
+}
+
+// Excluding everything an include matched is a deliberate configuration,
+// not a broken one, so it must stay distinct from a dead include.
+func TestFiles_ExcludeEmptyingTheScopeIsNotDead(t *testing.T) {
+	repo, dir := newTestRepo(t)
+	writeFile(t, dir, "src/a.ts", "a")
+
+	h := Files{Include: []string{"src/**"}, Exclude: []string{"src/**"}}
+	scope, err := h.Scope(repo)
+	if err != nil {
+		t.Fatalf("exclude-emptied scope should not error: %v", err)
+	}
+	if len(scope) != 0 {
+		t.Errorf("scope = %v, want empty", scope)
+	}
+}
+
+// A gate with no include at all covers the whole tree and cannot be
+// dead, so the check must not fire on it.
+func TestFiles_NoIncludeIsNotDead(t *testing.T) {
+	repo, _ := newTestRepo(t)
+	if _, err := (Files{}).Scope(repo); err != nil {
+		t.Errorf("include-less Files should not report a dead scope: %v", err)
 	}
 }

--- a/internal/hasher/hasher.go
+++ b/internal/hasher/hasher.go
@@ -12,8 +12,11 @@
 //     branch has not touched leave the digest alone.
 //
 // Both scoped strategies refuse to digest a scope whose include list
-// matches nothing in the working tree (ErrDeadScope): that digest is the
+// matches nothing they can see (ErrDeadScope): that digest is the
 // constant SHA-256 of the empty set, so the marker would match forever.
+// "What they can see" is per strategy — Files asks the working tree,
+// which it really does hash whatever git thinks of it, while Diff asks
+// what git could put in a delta, since an ignored path never can.
 // Only Hash refuses — Scope stays a description, so --explain and the
 // status listing keep working.
 //

--- a/internal/hasher/hasher.go
+++ b/internal/hasher/hasher.go
@@ -11,6 +11,12 @@
 //     HEAD). Changes arriving from the base branch under files this
 //     branch has not touched leave the digest alone.
 //
+// Both scoped strategies refuse to digest a scope whose include list
+// matches nothing in the working tree (ErrDeadScope): that digest is the
+// constant SHA-256 of the empty set, so the marker would match forever.
+// Only Hash refuses — Scope stays a description, so --explain and the
+// status listing keep working.
+//
 // The digest format (framing, sort order, etc.) is an implementation
 // detail; markers written by one version are not guaranteed to validate
 // against another.


### PR DESCRIPTION
Closes #70

## What

An `include` list that matches nothing made a scoped gate pass forever instead of failing. The scope resolved empty, so the digest was the SHA-256 of nothing — a constant, the same value for every such gate, that no change could ever move.

```
gate: hash: files, include: ["scr/**"]   <- typo

markgate set typo     -> exit 0
echo v2 > src/a.txt
markgate verify typo  -> exit 0          <- fresh, forever
```

Both scoped hash modes were affected identically, so this is not something `hash: diff` introduced. `config lint` did detect dead globs, but nothing invokes it, so a user who never ran it got no signal at any point.

## The distinction the fix rests on

An empty scope has two causes and only one is a bug:

| situation | treatment |
| --- | --- |
| no `include` pattern matches **any** path in the working tree | **error, exit 2** |
| patterns match, this branch changed none of them | unchanged — `diff` warns on `set`, `files` is silent |
| `exclude` removed everything `include` matched | unchanged — a deliberate configuration |
| at least one pattern is live, others are dead | unchanged at run time; `config lint` still warns per pattern |

Refusing the second would be worse than the bug: it is the ordinary state of a docs-only branch against a `src/**` gate, and erroring there would make `markgate run <gate> -- <cmd>` exit 2 and break the caller's hook — `diff` would become stricter than `files` in a way that breaks rather than protects, which is what #70 rules out.

## Two constraints that shaped it

**Only `Hash` refuses; `Scope` stays a description.** `--explain` and the status listing run through `Scope`, and a diagnostic flag must never change what a command does. My first cut put the check in `resolve`/`entries`, and `markgate run build --explain -- make dist` then skipped its child on a clean checkout while the same command without the flag bootstrapped fine. Pinned by `TestDeadIncludeExplainDoesNotChangeTheOutcome`.

**The check does not run before a gated command can create its scope.** `verify` with no marker is a plain mismatch without hashing, so `markgate run dist -- make dist` still works on a clean checkout and records the marker once the child produces the files. If the child runs and the scope is *still* empty, the marker is refused — that is the case that separates "not built yet" from "will never match".

Bare `markgate status` degrades the offending row rather than aborting the listing, matching how `ErrDiffBase` is already handled.

## Known trade-off

A scope that is legitimately absent — a sparse checkout, an optional subtree — now exits 2 rather than passing. Documented in the README next to the rule; the escape is to scope such a gate to a path that is always present.

## Tests

- `internal/hasher`: dead include errors on `Hash` and *not* on `Scope`, for both `Files` and `Diff`; one live pattern is enough; `exclude` emptying the scope is not dead; an include-less gate cannot be dead
- `internal/cli`: refusal at `set` (both modes, no marker written); refusal at `verify` after a `git mv` kills a live scope; bootstrapping via `run` still works; `run` refuses the marker after the child runs and produces nothing; `--explain` changes nothing; bare `status` degrades one row and keeps rendering others
- `e2e.sh`: new `#70` section, 141 PASS / 0 FAIL overall

## Verification

`go build` / `go vet` / `go test ./...` clean; `golangci-lint` (v2, matching CI's config) reports 0 issues; `e2e.sh` 141 PASS / 0 FAIL. Smoked the built binary across all nine cases in the table above plus `git-tree` (unaffected). README anchors re-checked.

## Docs

README gains "A dead `include` is refused, not silently empty" under Hashing strategies, and the CLI reference now states the lint-warns-per-pattern vs errors-when-all-dead split. `config lint --help`, the `markgate init` template, the `hasher` package doc, and the `verify-e2e` skill are updated to match. CLAUDE.md gains the underlying invariant as a design principle: *a digest that cannot change is an error, not a value* — refuse it where the configuration is at fault, never where the branch is simply quiet.
