### PR TITLE
chore: gitignore the throwaway worktrees created for subagent runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ dist/
 cover.out.tmp
 cover.html
 /markgate
+
+# Throwaway git worktrees created for isolated subagent runs.
+# They are real repositories, so a stray `git add -A` commits them as
+# gitlinks; that has happened.
+.claude/worktrees/


### PR DESCRIPTION
The harness creates isolated subagent worktrees under `.claude/worktrees/`. They are real git repositories, so a stray `git add -A` in the outer repo stages one as a gitlink:

```
warning: adding embedded git repository: .claude/worktrees/agent-<id>
A  .claude/worktrees/agent-<id>
```

That happened while working #70/#71 — caught and amended out before it reached main, but only because the warning was noticed. Ignoring the directory removes the hazard rather than relying on catching it each time.

One line plus a comment saying why; no behavior change.