### PR TITLE
chore: pin golangci-lint so `make lint` cannot silently do nothing

### DIFF
--- a/.claude/skills/audit-before-done/SKILL.md
+++ b/.claude/skills/audit-before-done/SKILL.md
@@ -104,7 +104,7 @@ Before pushing or marking done, run:
 
 ```sh
 go test ./...
-make lint        # golangci-lint run, mirrors CI
+make lint        # pinned golangci-lint via `go run`, mirrors CI
 ```
 
 `make lint` catches — in descending order of this session's hit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,8 @@ jobs:
           filter_mode: nofilter
           golangci_lint_flags: "--config=.golangci.yml"
           fail_level: error
+          # Keep in step with GOLANGCI_LINT_VERSION in the Makefile. The
+          # action otherwise floats, so CI and `make lint` can disagree
+          # about which linters even exist — the point of running lint
+          # locally is that it predicts this job.
+          golangci_lint_version: "v2.12.2"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,10 @@ go test ./...         # full test suite (CLI tests spawn real git repos)
 go vet ./...          # basic misuse check
 make lint             # golangci-lint with govet shadow + gocritic +
                       # staticcheck + gosec + etc. Mirrors CI.
+                      # Runs a pinned version via `go run`, so it needs
+                      # no local install and cannot drift from
+                      # .golangci.yml (which is v2-format: a v1 binary
+                      # exits with a config error and lints nothing).
 ```
 
 Before reporting a task complete, run `go test ./... && make lint`.

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,15 @@ test_view:
 	go tool cover -func=cover.out
 	go tool cover -html=cover.out -o cover.html
 
+# Pinned rather than "whatever is on $PATH": .golangci.yml is v2-format,
+# so a v1 binary exits with a config error and lints nothing. That failure
+# reads like a repo problem, not "your lint did not run", which is the
+# wrong way for this to fail given CLAUDE.md requires it before pushing.
+# Keep in step with golangci_lint_version in .github/workflows/ci.yml.
+GOLANGCI_LINT_VERSION := v2.12.2
+
 lint:
-	golangci-lint run
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
 
 run:
 	go mod tidy


### PR DESCRIPTION
Closes #74

## Problem

`.golangci.yml` is v2-format, but the Makefile ran whatever `golangci-lint` was on `$PATH`. On a machine with v1 that exits with a config error and lints nothing:

```
$ make lint
Error: you are using a configuration file for golangci-lint v2 with golangci-lint v1: please use golangci-lint v2
make: *** [lint] Error 3
```

Nothing broken ships — CI lints correctly — but [CLAUDE.md](CLAUDE.md) and the `audit-before-done` skill both tell a contributor (or a Claude session) that running `make lint` means the CI lint has been mirrored locally, and on a v1 machine that is false. The failure is quiet in the direction that matters: the message is about *configuration*, which reads like a repo problem rather than "your lint did not run", so the natural response is to move on — and the audit step CLAUDE.md leans on has then contributed nothing.

Found while working #70/#71: I only noticed because the error text mentioned v2, and had to install v2 into a scratch `GOBIN` to get a real result.

## Fix

Option 2 from the issue. `make lint` runs a pinned version through `go run`, so it needs no local install and cannot drift from `.golangci.yml`. This matches how the repo already dogfoods markgate itself through `go run ./cmd/markgate` rather than an installed binary.

CI is pinned to the same version. `reviewdog/action-golangci-lint@v2` otherwise floats its golangci-lint, so the two could disagree about which linters even exist once both are on v2 — and the point of running lint locally is that it predicts the CI job. The issue asked whether CI should pin at the same time; it should.

The version literal appears in two places, each naming the other. A single source of truth would need machinery not worth it for one string, so the duplication is explicit rather than hidden.

## Verification

`make lint` → `0 issues` (previously: exit 3, nothing linted). `go build` / `go vet` / `go test ./...` clean; `e2e.sh` 157 PASS / 0 FAIL. No code change — Makefile, CI workflow, and the two docs that make the claim.