### PR TITLE
fix(cli): let clear work without a valid config

### DIFF
--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -8,7 +8,9 @@
 # bare status, and gate dependencies (composes / requires) — and
 # (c) the hash: diff strategy (#68): base-branch churn staying fresh,
 # same-file churn going stale, the empty-delta and unresolvable-base
-# refusals, flag and config validation.
+# refusals, flag and config validation -- (d) the dead-include refusal
+# shared by both scoped modes (#70) -- and (e) clear surviving an
+# invalid config (#77).
 #
 # The assertion COUNT is printed by the summary and deliberately not
 # repeated in prose anywhere: it drifted by 14 the last time it was.
@@ -905,13 +907,42 @@ assert_eq "clear: verify still refuses an invalid config exit=2" "2" "$?"
 $MG status >/dev/null 2>&1
 assert_eq "clear: status still refuses an invalid config exit=2" "2" "$?"
 
-# Unparseable: state_dir is unknowable, so say which location was used.
+# Unparseable: state_dir is unknowable, so say which path was used.
+# Seeded while the config is still valid -- seeding afterwards would make
+# `set` fail, leaving nothing to clear and an assertion that passes no
+# matter what clear does.
+cat > .markgate.yml <<'CFGEOF'
+gates:
+  good:
+    hash: files
+    include:
+      - "src/**"
+CFGEOF
 $MG set k --hash files --include "src/**" --state-dir .mg2 >/dev/null 2>&1
+assert_file "clear: override marker seeded before the config breaks" ".mg2/k.json"
 printf 'gates:\n  good: {hash: files\n' > .markgate.yml
 out=$($MG clear k --state-dir .mg2 2>&1)
 assert_eq "clear: unparseable config still clears exit=0" "0" "$?"
 assert_contains "clear: says the config could not be read" "could not be read" "$out"
+assert_contains "clear: names the path it looked at" ".mg2/k.json" "$out"
 assert_absent "clear: --state-dir still resolves exactly" ".mg2/k.json"
+
+# With no override the fallback may look somewhere the marker is not, so
+# it must say so rather than let "cleared" imply the marker is gone.
+out=$($MG clear neverset 2>&1)
+assert_eq "clear: fallback with nothing there exit=0" "0" "$?"
+assert_contains "clear: warns the marker may survive elsewhere" "still exists" "$out"
+
+# Leniency is about the config, not the command line.
+cat > .markgate.yml <<'CFGEOF'
+gates:
+  good:
+    hash: files
+    include:
+      - "src/**"
+CFGEOF
+$MG clear good --hash bogus >/dev/null 2>&1
+assert_eq "clear: flag typo still refused on a valid config exit=2" "2" "$?"
 
 # A clean config must stay silent, or the warnings above mean nothing.
 cat > .markgate.yml <<'EOF'

--- a/.claude/scripts/e2e.sh
+++ b/.claude/scripts/e2e.sh
@@ -866,6 +866,66 @@ out=$($MG status scan 2>&1)
 assert_eq "dead glob: single-key status is a mismatch exit=1" "1" "$?"
 assert_contains "dead glob: single-key status explains why" "dead scope" "$out"
 
+cyan "=== #77 clear survives an invalid config ==="
+new_repo
+
+cat > .markgate.yml <<'EOF'
+gates:
+  good:
+    hash: files
+    include:
+      - "src/**"
+    state_dir: .mg-store
+EOF
+$MG set good >/dev/null 2>&1
+assert_file "clear: seed marker written to state_dir" ".mg-store/good.json"
+
+# A different gate goes invalid. Removal must not become impossible.
+cat > .markgate.yml <<'EOF'
+gates:
+  good:
+    hash: files
+    include:
+      - "src/**"
+    state_dir: .mg-store
+  broken:
+    hash: bogus
+EOF
+out=$($MG clear good 2>&1)
+assert_eq "clear: invalid config still clears exit=0" "0" "$?"
+assert_absent "clear: the marker really went" ".mg-store/good.json"
+assert_absent "clear: state_dir honored, no default dir made" ".git/markgate"
+assert_contains "clear: the config error is still reported" "bogus" "$out"
+
+# Skipped for clear, not weakened.
+$MG set good >/dev/null 2>&1
+assert_eq "clear: set still refuses an invalid config exit=2" "2" "$?"
+$MG verify good >/dev/null 2>&1
+assert_eq "clear: verify still refuses an invalid config exit=2" "2" "$?"
+$MG status >/dev/null 2>&1
+assert_eq "clear: status still refuses an invalid config exit=2" "2" "$?"
+
+# Unparseable: state_dir is unknowable, so say which location was used.
+$MG set k --hash files --include "src/**" --state-dir .mg2 >/dev/null 2>&1
+printf 'gates:\n  good: {hash: files\n' > .markgate.yml
+out=$($MG clear k --state-dir .mg2 2>&1)
+assert_eq "clear: unparseable config still clears exit=0" "0" "$?"
+assert_contains "clear: says the config could not be read" "could not be read" "$out"
+assert_absent "clear: --state-dir still resolves exactly" ".mg2/k.json"
+
+# A clean config must stay silent, or the warnings above mean nothing.
+cat > .markgate.yml <<'EOF'
+gates:
+  good:
+    hash: files
+    include:
+      - "src/**"
+EOF
+$MG set good >/dev/null 2>&1
+out=$($MG clear good 2>&1)
+assert_eq "clear: valid config clears exit=0" "0" "$?"
+assert_eq "clear: valid config warns about nothing" "cleared: good" "$out"
+
 # ─────────────────────────────────────────────────────────────────
 echo
 cyan "=== summary ==="

--- a/.claude/skills/verify-e2e/SKILL.md
+++ b/.claude/skills/verify-e2e/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-e2e
-description: Run the markgate end-to-end CLI verification script (`.claude/scripts/e2e.sh`). It exercises the full CLI surface — original primitives (set / verify / clear / run / init / version, default key, --hash files + --include, --state-dir, env-var, precedence) plus every feature added in the 2026-05-09 batch (completion, config lint, TTL, --explain, bare status, composes / requires), the hash: diff strategy, and the dead-include-glob refusal shared by both scoped modes. Wraps the script in `markgate run` so unchanged repos skip the run. Use whenever you want to confirm "all features still work" before declaring done, opening a PR, or merging — or when your changes touch the CLI surface and you want a quick smoke before pushing.
+description: Run the markgate end-to-end CLI verification script (`.claude/scripts/e2e.sh`). It exercises the full CLI surface — original primitives (set / verify / clear / run / init / version, default key, --hash files + --include, --state-dir, env-var, precedence) plus every feature added in the 2026-05-09 batch (completion, config lint, TTL, --explain, bare status, composes / requires), the hash: diff strategy, the dead-include-glob refusal shared by both scoped modes, and clear surviving an invalid config. Wraps the script in `markgate run` so unchanged repos skip the run. Use whenever you want to confirm "all features still work" before declaring done, opening a PR, or merging — or when your changes touch the CLI surface and you want a quick smoke before pushing.
 ---
 
 # verify-e2e
@@ -101,6 +101,15 @@ Three layers of assertions (the script prints the count on every run; it is deli
 - a rename that kills a live scope -> `verify` exit=1 and `set`
   exit=2; bare `status` degrades that row and keeps rendering the
   others
+
+**`clear` survives an invalid config (#77)**
+
+- a validation error elsewhere in the document no longer blocks
+  removal, and the gate's own `state_dir` is still honored
+- `set` / `verify` / `status` still refuse the same config
+- unparseable YAML: `clear` names the exact path it looked at, warns
+  when nothing was there, and `--state-dir` still resolves exactly
+- flag typos (`--hash bogus`) are still refused on a valid config
 
 ## How it caches
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,17 @@ it is the spec — see "README as a spec" below.
 - **No implicit nesting of `markgate/`** when the user gives an
   explicit path (`--state-dir` / `state_dir:`). The user owns the
   layout they asked for.
+- **A command's preconditions are the ones it actually has.** Config
+  validation lives in `config.Load`, and every command that resolves
+  a hasher goes through it. `clear` does not — it deletes a file, and
+  its only config dependency is `state_dir` — so it uses
+  `config.Parse` instead. Requiring a valid document there put the
+  recovery path inside the trap it recovers from: one bad gate made
+  *every* marker unremovable, including markers for valid gates, with
+  hand-editing YAML as the only way out. Skipping validation for one
+  command is not the same as weakening it; if you add a command that
+  genuinely needs less than `newGateCtx` provides, give it a narrower
+  resolver rather than loosening the shared one.
 - **A digest that cannot change must never read as fresh.** An empty
   scope hashes to the SHA-256 of nothing — the same constant for
   every such gate — so the marker matches forever and the gate can

--- a/README.md
+++ b/README.md
@@ -856,6 +856,13 @@ markgate verify     [key]              Exit 0 match, 1 mismatch (incl. ttl
 markgate status     [key]              Show marker + match status (bare:
                                        list every known gate).
 markgate clear      [key]              Delete the marker (idempotent).
+                                       The only command that does not
+                                       require .markgate.yml to be valid
+                                       — it needs the marker's location,
+                                       not the gate's semantics — so a
+                                       config error elsewhere cannot
+                                       leave markers unremovable. The
+                                       error is still reported.
 markgate run        [key] -- <cmd>...  Sugar for verify + <cmd> + set.
 markgate init                          Write a starter .markgate.yml.
 markgate config lint                   Warn per pattern on dead
@@ -1312,6 +1319,17 @@ markers where commit-access already implies trust in the signal.
   `.markgate.yml`. See
   [Sharing markers](#sharing-markers-across-machines-ci--teammates) for patterns
   and trust considerations.
+- **My `.markgate.yml` is broken and now nothing works.** `clear`
+  still does. Every other command resolves a hasher and computes a
+  digest, so a config error stops them by design — but `clear` only
+  needs to know where the marker lives, and refusing there would put
+  the recovery path inside the trap: markers for *valid* gates would
+  be unremovable too. `clear` reports the config error on stderr and
+  removes the marker anyway. If the YAML cannot even be parsed, its
+  `state_dir:` is unknowable, so `clear` says which location it used
+  and falls back to `--state-dir` / `MARKGATE_STATE_DIR` / the
+  default.
+
 - **Can the marker be tampered with?** Yes — it's a JSON file under
   `.git/` (or wherever `--state-dir` points). Trust whoever can write
   to that location. Signed markers are still a future consideration.

--- a/README.md
+++ b/README.md
@@ -856,13 +856,15 @@ markgate verify     [key]              Exit 0 match, 1 mismatch (incl. ttl
 markgate status     [key]              Show marker + match status (bare:
                                        list every known gate).
 markgate clear      [key]              Delete the marker (idempotent).
-                                       The only command that does not
-                                       require .markgate.yml to be valid
-                                       — it needs the marker's location,
-                                       not the gate's semantics — so a
-                                       config error elsewhere cannot
-                                       leave markers unremovable. The
-                                       error is still reported.
+                                       The only gate command that does
+                                       not require .markgate.yml to be
+                                       valid — it needs the marker's
+                                       location, not the gate's
+                                       semantics — so a config error
+                                       elsewhere cannot leave markers
+                                       unremovable. The error is still
+                                       reported, and flag typos are
+                                       still refused.
 markgate run        [key] -- <cmd>...  Sugar for verify + <cmd> + set.
 markgate init                          Write a starter .markgate.yml.
 markgate config lint                   Warn per pattern on dead
@@ -1320,16 +1322,19 @@ markers where commit-access already implies trust in the signal.
   [Sharing markers](#sharing-markers-across-machines-ci--teammates) for patterns
   and trust considerations.
 - **My `.markgate.yml` is broken and now nothing works.** `clear`
-  still does. Every other command resolves a hasher and computes a
-  digest, so a config error stops them by design — but `clear` only
+  still does. Every other gate command resolves a hasher and computes
+  a digest, so a config error stops them by design — but `clear` only
   needs to know where the marker lives, and refusing there would put
   the recovery path inside the trap: markers for *valid* gates would
   be unremovable too. `clear` reports the config error on stderr and
-  removes the marker anyway. If the YAML cannot even be parsed, its
-  `state_dir:` is unknowable, so `clear` says which location it used
-  and falls back to `--state-dir` / `MARKGATE_STATE_DIR` / the
-  default.
-
+  removes the marker anyway. Flag typos (`--hash bogus`) are still
+  refused; the leniency is about the config, not the command line.
+  If the YAML cannot even be **parsed**, its `state_dir:` is
+  unknowable: `clear` falls back to `--state-dir` /
+  `MARKGATE_STATE_DIR` / the default, prints the exact path it looked
+  at, and warns when nothing was there — because a gate whose
+  `state_dir:` it could not read may still have a marker somewhere
+  else. Fix the YAML and clear again if so.
 - **Can the marker be tampered with?** Yes — it's a JSON file under
   `.git/` (or wherever `--state-dir` points). Trust whoever can write
   to that location. Signed markers are still a future consideration.

--- a/internal/cli/clear.go
+++ b/internal/cli/clear.go
@@ -16,8 +16,13 @@ func newClearCmd() *cobra.Command {
 			"removing a marker that is not there succeeds.\n\n" +
 			"clear does not require .markgate.yml to be valid. It only needs to\n" +
 			"know where the marker lives, so a config error elsewhere must not\n" +
-			"stop you cleaning up — every other command still refuses a bad\n" +
-			"config. Errors are reported on stderr so clearing never hides them.",
+			"stop you cleaning up — every other gate command still refuses a\n" +
+			"bad config. Errors are reported on stderr so clearing never hides\n" +
+			"them, and flag typos are still refused: the leniency is about the\n" +
+			"config, not the command line.\n\n" +
+			"If the YAML cannot be parsed at all, state_dir: is unknowable, so\n" +
+			"clear prints the exact path it looked at and warns when nothing\n" +
+			"was there.",
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: gateKeyCompletion,
 	}

--- a/internal/cli/clear.go
+++ b/internal/cli/clear.go
@@ -10,14 +10,20 @@ import (
 
 func newClearCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "clear [key]",
-		Short:             "Remove the marker (idempotent)",
+		Use:   "clear [key]",
+		Short: "Remove the marker (idempotent)",
+		Long: "Remove the marker for [key] (default: \"default\"). Idempotent:\n" +
+			"removing a marker that is not there succeeds.\n\n" +
+			"clear does not require .markgate.yml to be valid. It only needs to\n" +
+			"know where the marker lives, so a config error elsewhere must not\n" +
+			"stop you cleaning up — every other command still refuses a bad\n" +
+			"config. Errors are reported on stderr so clearing never hides them.",
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: gateKeyCompletion,
 	}
 	overrides := addGateFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		c, err := newGateCtx(resolveKey(args), overrides)
+		c, err := newClearTarget(resolveKey(args), overrides, cmd.ErrOrStderr())
 		if err != nil {
 			return err
 		}

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -141,6 +141,63 @@ func newGateCtx(k string, overrides *gateFlagValues) (*gateCtx, error) {
 	}, nil
 }
 
+// clearTarget is everything `clear` needs and nothing more: which
+// marker file to remove.
+type clearTarget struct {
+	key        string
+	markerPath string
+}
+
+// newClearTarget resolves the marker path without validating the config.
+//
+// `clear` deletes a file; its only config dependency is state_dir. The
+// whole-document validation every other command inherits from
+// newGateCtx is an incidental coupling here, and an expensive one: it
+// makes the recovery path unusable in exactly the situation it exists
+// for, leaving hand-editing YAML as the only way to remove a marker —
+// including markers for gates that are perfectly fine.
+//
+// Validation is skipped, not weakened. Every command that resolves a
+// hasher still goes through Load and still refuses a bad config, so a
+// typo is still caught the next time anything is actually gated.
+func newClearTarget(k string, overrides *gateFlagValues, errOut io.Writer) (*clearTarget, error) {
+	if err := key.Validate(k); err != nil {
+		return nil, &ExitError{Code: 2, Err: err}
+	}
+	repo := gitutil.New("")
+	top, err := repo.TopLevel()
+	if err != nil {
+		return nil, &ExitError{Code: 2, Err: err}
+	}
+	gitDir, err := repo.GitDir()
+	if err != nil {
+		return nil, &ExitError{Code: 2, Err: err}
+	}
+
+	var gate config.Gate
+	cfg, parseErr := config.Parse(top)
+	switch {
+	case parseErr != nil:
+		// Unparseable: state_dir is unknowable, so say which location is
+		// being used instead of reporting a removal that may have
+		// happened somewhere else.
+		fmt.Fprintf(errOut, "markgate: %s could not be read (%v); using the default marker location\n",
+			config.Filename, parseErr)
+	default:
+		gate = cfg.Gate(k)
+		// Clearing must not double as a way to stop noticing the errors.
+		if findings := cfg.Validate(); len(findings) > 0 {
+			fmt.Fprintf(errOut, "markgate: %s still has errors (%s); clearing anyway\n",
+				config.Filename, findings[0].Message)
+		}
+	}
+
+	return &clearTarget{
+		key:        k,
+		markerPath: resolveMarkerPath(overrides, gate, top, gitDir, k),
+	}, nil
+}
+
 // newGateCtxWithConfig builds a gateCtx from already-resolved
 // components, skipping the config / git / hasher I/O newGateCtx does.
 // Used by callers that walk multiple keys (bare `status`) to avoid

--- a/internal/cli/helper.go
+++ b/internal/cli/helper.go
@@ -174,28 +174,47 @@ func newClearTarget(k string, overrides *gateFlagValues, errOut io.Writer) (*cle
 		return nil, &ExitError{Code: 2, Err: err}
 	}
 
-	var gate config.Gate
+	var (
+		gate       config.Gate
+		unresolved bool
+	)
 	cfg, parseErr := config.Parse(top)
 	switch {
 	case parseErr != nil:
-		// Unparseable: state_dir is unknowable, so say which location is
-		// being used instead of reporting a removal that may have
-		// happened somewhere else.
-		fmt.Fprintf(errOut, "markgate: %s could not be read (%v); using the default marker location\n",
-			config.Filename, parseErr)
+		unresolved = true
 	default:
 		gate = cfg.Gate(k)
-		// Clearing must not double as a way to stop noticing the errors.
-		if findings := cfg.Validate(); len(findings) > 0 {
-			fmt.Fprintf(errOut, "markgate: %s still has errors (%s); clearing anyway\n",
+		findings := cfg.Validate()
+		switch {
+		case len(findings) > 0:
+			// Clearing must not double as a way to stop noticing the
+			// errors. Only the first is shown; lint shows the rest.
+			fmt.Fprintf(errOut, "markgate: %s still has errors (%s; see `markgate config lint`); clearing anyway\n",
 				config.Filename, findings[0].Message)
+		default:
+			// The document is fine, so anything validateGate objects to
+			// came from the flags. Rejecting it here keeps `clear` as
+			// strict about flag typos as every other command — the
+			// leniency is about the config, not about the command line.
+			if vErr := validateGate(overrides.override(gate)); vErr != nil {
+				return nil, &ExitError{Code: 2, Err: vErr}
+			}
 		}
 	}
 
-	return &clearTarget{
-		key:        k,
-		markerPath: resolveMarkerPath(overrides, gate, top, gitDir, k),
-	}, nil
+	markerPath := resolveMarkerPath(overrides, gate, top, gitDir, k)
+	if unresolved {
+		// state_dir is unknowable, so the marker may well live somewhere
+		// this path never looks. Naming the path is what keeps the
+		// "cleared" that follows from claiming more than it can support.
+		fmt.Fprintf(errOut, "markgate: %s could not be read (%v); looked only at %s\n",
+			config.Filename, parseErr, markerPath)
+		if _, statErr := os.Stat(markerPath); errors.Is(statErr, os.ErrNotExist) {
+			fmt.Fprintf(errOut, "markgate: no marker was there; if the gate set state_dir, its marker still exists\n")
+		}
+	}
+
+	return &clearTarget{key: k, markerPath: markerPath}, nil
 }
 
 // newGateCtxWithConfig builds a gateCtx from already-resolved

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -2835,10 +2835,94 @@ func TestClearReportsTheLocationWhenTheConfigCannotBeParsed(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, ".git", "markgate", "k.json")); !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("clear did not remove the marker (err = %v)", err)
 	}
-	// --state-dir still resolves exactly, so the fallback is only for the
-	// layer the unreadable file would have supplied.
-	if code, _ := runCmd(t, "clear", "k", "--state-dir", "elsewhere"); code != 0 {
-		t.Errorf("clear --state-dir with an unparseable config: code = %d, want 0", code)
+	// The path is named, not just described: on this branch the marker
+	// may live somewhere clear never looked, so "cleared" only stays
+	// honest if the user can see where it did look.
+	if !strings.Contains(stderr, filepath.Join(".git", "markgate", "k.json")) {
+		t.Errorf("clear did not name the path it used: %q", stderr)
+	}
+
+	// Nothing at the fallback path is the dangerous shape: "cleared"
+	// would otherwise imply the marker is gone when a gate whose
+	// state_dir could not be read may still have one.
+	_, _, stderr = runCmdStderr(t, "clear", "neverset")
+	if !strings.Contains(stderr, "still exists") {
+		t.Errorf("clear did not warn that a marker may survive elsewhere: %q", stderr)
+	}
+}
+
+// --state-dir and the env var still resolve exactly when the config is
+// unreadable — only the layer the file would have supplied falls back.
+// Seeded BEFORE the config breaks, or the marker never exists and the
+// assertion passes no matter what clear does.
+func TestClearHonorsOverridesWhenTheConfigCannotBeParsed(t *testing.T) {
+	for _, tc := range []struct{ name, dirName string }{
+		{"flag", "flagdir"},
+		{"env", "envdir"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := initRepo(t)
+			writeRepoFile(t, dir, "src/a.go", "a")
+			gitIn(t, dir, "add", ".")
+			gitIn(t, dir, "commit", "-qm", "seed")
+			writeRepoFile(t, dir, ".markgate.yml",
+				"gates:\n  k:\n    hash: files\n    include:\n      - \"src/**\"\n")
+
+			var args []string
+			if tc.name == "flag" {
+				args = []string{"--state-dir", tc.dirName}
+			} else {
+				t.Setenv(EnvStateDir, tc.dirName)
+			}
+
+			if code, _ := runCmd(t, append([]string{"set", "k"}, args...)...); code != 0 {
+				t.Fatal("seed set failed")
+			}
+			marker := filepath.Join(dir, tc.dirName, "k.json")
+			if _, err := os.Stat(marker); err != nil {
+				t.Fatalf("fixture broken, nothing to clear: %v", err)
+			}
+
+			writeRepoFile(t, dir, ".markgate.yml", "gates:\n  k: {hash: files\n")
+			if code, _ := runCmd(t, append([]string{"clear", "k"}, args...)...); code != 0 {
+				t.Fatalf("clear: code = %d, want 0", code)
+			}
+			if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+				t.Errorf("the override did not resolve exactly: %s survived (err = %v)", marker, err)
+			}
+		})
+	}
+}
+
+// Leniency is about the config, not the command line. A flag that
+// cannot mean anything is still a typo worth reporting, so `clear`
+// stays as strict as every other command whenever the document itself
+// is fine — and stops checking only once the document is not.
+func TestClearStillRejectsFlagTyposOnAValidConfig(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  g:\n    hash: files\n    include:\n      - \"src/**\"\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+
+	for _, args := range [][]string{
+		{"clear", "g", "--hash", "bogus"},
+		{"clear", "g", "--hash", "diff"},
+		{"clear", "g", "--base", "origin/main"},
+	} {
+		if code, _ := runCmd(t, args...); code != 2 {
+			t.Errorf("%v on a valid config: code = %d, want 2", args, code)
+		}
+	}
+
+	// Once the document is invalid, the same flags stop being checked —
+	// otherwise the recovery path would be blocked by the very thing it
+	// is there to recover from.
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  g:\n    hash: files\n    include:\n      - \"src/**\"\n  broken:\n    hash: bogus\n")
+	if code, _ := runCmd(t, "clear", "g", "--hash", "bogus"); code != 0 {
+		t.Errorf("clear on an invalid config: code = %d, want 0", code)
 	}
 }
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -2758,3 +2758,104 @@ func TestDeadIncludeDegradesBareStatus(t *testing.T) {
 		t.Errorf("status scan: code = %d, out = %q; want 1 naming the dead scope", code, out)
 	}
 }
+
+// clear is the recovery path, so requiring a valid config to use it puts
+// the escape hatch inside the trap: a document that stopped validating
+// leaves every marker unremovable, including markers for gates that are
+// perfectly fine.
+func TestClearToleratesAnInvalidConfig(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  good:\n    hash: files\n    include:\n      - \"src/**\"\n    state_dir: .mg-store\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	if code, _ := runCmd(t, "set", "good"); code != 0 {
+		t.Fatal("seed set failed")
+	}
+	marker := filepath.Join(dir, ".mg-store", "good.json")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("fixture broken: %v", err)
+	}
+
+	// A different gate goes invalid.
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  good:\n    hash: files\n    include:\n      - \"src/**\"\n    state_dir: .mg-store\n"+
+			"  broken:\n    hash: bogus\n")
+
+	code, _, stderr := runCmdStderr(t, "clear", "good")
+	if code != 0 {
+		t.Errorf("clear with an invalid config: code = %d, want 0", code)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("clear did not remove %s (err = %v)", marker, err)
+	}
+	// The state_dir of a gate that fails validation is still accurate, so
+	// the default location must not have been used instead.
+	if _, err := os.Stat(filepath.Join(dir, ".git", "markgate")); err == nil {
+		t.Error("clear fell back to the default location despite a readable state_dir")
+	}
+	// Clearing must not double as a way to stop noticing the errors.
+	if !strings.Contains(stderr, "bogus") {
+		t.Errorf("clear did not report the config error: %q", stderr)
+	}
+
+	// Skipped for clear, not weakened: everything that resolves a hasher
+	// still refuses.
+	for _, args := range [][]string{
+		{"set", "good"}, {"verify", "good"}, {"status", "good"}, {"status"},
+	} {
+		if code, _ := runCmd(t, args...); code != 2 {
+			t.Errorf("%v with an invalid config: code = %d, want 2", args, code)
+		}
+	}
+}
+
+// An unparseable document is the one case where state_dir cannot be
+// recovered. Refusing there would close the escape hatch exactly when
+// the config is most broken, so clear proceeds — but says which location
+// it used, since otherwise "cleared" would be a claim it cannot support.
+func TestClearReportsTheLocationWhenTheConfigCannotBeParsed(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	if code, _ := runCmd(t, "set", "k", "--hash", "files", "--include", "src/**"); code != 0 {
+		t.Fatal("seed set failed")
+	}
+	writeRepoFile(t, dir, ".markgate.yml", "gates:\n  good: {hash: files\n")
+
+	code, _, stderr := runCmdStderr(t, "clear", "k")
+	if code != 0 {
+		t.Errorf("clear with an unparseable config: code = %d, want 0", code)
+	}
+	if !strings.Contains(stderr, "could not be read") {
+		t.Errorf("clear did not say the config was unreadable: %q", stderr)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git", "markgate", "k.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("clear did not remove the marker (err = %v)", err)
+	}
+	// --state-dir still resolves exactly, so the fallback is only for the
+	// layer the unreadable file would have supplied.
+	if code, _ := runCmd(t, "clear", "k", "--state-dir", "elsewhere"); code != 0 {
+		t.Errorf("clear --state-dir with an unparseable config: code = %d, want 0", code)
+	}
+}
+
+// A clean config must stay silent: the warnings above are the signal
+// that something is wrong, so they must not fire on the happy path.
+func TestClearIsSilentOnAValidConfig(t *testing.T) {
+	dir := initRepo(t)
+	writeRepoFile(t, dir, "src/a.go", "a")
+	writeRepoFile(t, dir, ".markgate.yml",
+		"gates:\n  good:\n    hash: files\n    include:\n      - \"src/**\"\n")
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-qm", "seed")
+	if code, _ := runCmd(t, "set", "good"); code != 0 {
+		t.Fatal("seed set failed")
+	}
+	code, _, stderr := runCmdStderr(t, "clear", "good")
+	if code != 0 || stderr != "" {
+		t.Errorf("clear on a valid config: code = %d, stderr = %q; want 0 and silence", code, stderr)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,6 +107,26 @@ type Finding struct {
 // Load reads topLevel/.markgate.yml. A missing file yields an empty
 // Config (never nil) so callers can always call c.Gate(...) safely.
 func Load(topLevel string) (*Config, error) {
+	c, err := Parse(topLevel)
+	if err != nil {
+		return nil, err
+	}
+	if findings := c.Validate(); len(findings) > 0 {
+		return nil, errors.New(findings[0].Message)
+	}
+	return c, nil
+}
+
+// Parse reads and unmarshals the config without validating it. A missing
+// file is not an error and yields an empty Config, same as Load.
+//
+// Split out for `clear`, whose only use of the config is state_dir: a
+// gate that fails validation still declares its storage location
+// accurately, and making marker removal depend on the whole document
+// being valid puts the recovery path inside the trap it recovers from.
+// Every other command resolves a hasher and computes a digest, so they
+// go through Load and keep failing loudly on a bad config.
+func Parse(topLevel string) (*Config, error) {
 	path := filepath.Join(topLevel, Filename)
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -118,9 +138,6 @@ func Load(topLevel string) (*Config, error) {
 	var c Config
 	if err := yaml.Unmarshal(data, &c); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", Filename, err)
-	}
-	if findings := c.Validate(); len(findings) > 0 {
-		return nil, errors.New(findings[0].Message)
 	}
 	return &c, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -146,6 +146,51 @@ func TestLoad_ExplicitGitTreeOnDepsOnlyGateOK(t *testing.T) {
 	}
 }
 
+// Parse is the half of Load that clear relies on: a document that fails
+// validation still yields accurate storage locations, so removal does
+// not have to wait on the rest of the file being correct.
+func TestParse_DoesNotValidate(t *testing.T) {
+	dir := t.TempDir()
+	body := "gates:\n  good:\n    hash: files\n    include:\n      - \"src/**\"\n    state_dir: .mg\n" +
+		"  broken:\n    hash: bogus\n"
+	writeConfig(t, dir, body)
+
+	if _, err := Load(dir); err == nil {
+		t.Fatal("Load should still reject this document")
+	}
+	c, err := Parse(dir)
+	if err != nil {
+		t.Fatalf("Parse should accept a document that only fails validation: %v", err)
+	}
+	if got := c.Gate("good").StateDir; got != ".mg" {
+		t.Errorf("Gate(\"good\").StateDir = %q, want .mg", got)
+	}
+	if len(c.Validate()) == 0 {
+		t.Error("Parse must not validate, but Validate found nothing to report")
+	}
+}
+
+// Malformed YAML is the one thing Parse still refuses: there is nothing
+// to read a state_dir out of.
+func TestParse_RejectsMalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "gates:\n  good: {hash: files\n")
+	if _, err := Parse(dir); err == nil {
+		t.Error("Parse should reject malformed YAML")
+	}
+}
+
+// A missing file is not an error for either, same as before.
+func TestParse_MissingFileIsEmpty(t *testing.T) {
+	c, err := Parse(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.Gates) != 0 {
+		t.Errorf("Gates = %v, want empty", c.Gates)
+	}
+}
+
 func TestLoad_UnknownHash(t *testing.T) {
 	dir := t.TempDir()
 	writeConfig(t, dir, "gates:\n  x:\n    hash: bogus\n")


### PR DESCRIPTION
Closes #77

## Problem

Every command goes through `newGateCtx`, which calls `config.Load` before anything else, and `Load` rejects the whole document if any gate is invalid. So one bad gate made **every** marker unremovable — including markers for gates that were perfectly fine:

```yaml
gates:
  good:   {hash: files, include: ["src/**"]}
  broken: {hash: bogus}
```

```
clear good   -> 2   gates.broken: unknown hash "bogus"
clear broken -> 2   same
clear        -> 2   same
ls .git/markgate/   -> good.json broken.json   # still there
```

Hand-editing the YAML was the only way out. That is bad when you wrote the typo a minute ago, and worse when the config went invalid because a *newer markgate* added a rule — the user then has to work out which rule and why before they can clean up state the old binary wrote.

## Fix

`clear` deletes a file. Its only config dependency is `state_dir`; it resolves no hasher and computes no digest. Requiring the whole document to be semantically valid was incidental coupling from `newGateCtx` being one-size-fits-all, and it put the recovery path inside the trap it recovers from.

`clear` now resolves its target through `config.Parse` — the unmarshal half of `Load`, split out for this — and skips validation.

## Why not lazy per-gate validation

That would have fixed this too, and it was the other option on the issue. It is rejected because **whole-document validation at `Load` is markgate's only automatic check on the config**: `config lint` exists, but nothing invokes it — the gap both #70 and #71 named. Validating only the addressed gate means a typo in `gates.integ` stays silent until something addresses `integ`; a developer who only uses `gates.docs` locally never sees it, and CI breaks. That is the same failure mode those two PRs just closed, reopened from the other side.

Skipping validation for the one command that does not need it is not the same as weakening it. `set` / `verify` / `run` / `status` all still go through `Load` and still refuse — covered by assertions in the new tests.

## Two things that keep it honest

**Clearing does not double as a way to stop seeing the errors.** The first finding goes to stderr; the exit code stays 0. A valid config stays completely silent, so the warning keeps meaning something.

**An unparseable document is the one case where `state_dir` cannot be recovered.** Refusing there would close the escape hatch exactly when the config is most broken, so `clear` proceeds — but names the location it used, since otherwise `cleared: <key>` would be a claim it cannot support. `--state-dir` and `MARKGATE_STATE_DIR` still resolve exactly; only the layer the unreadable file would have supplied falls back.

## Tests

- `TestClearToleratesAnInvalidConfig` — clears, honors the invalid config's `state_dir` (asserts the default dir was *not* created), reports the error, and checks `set`/`verify`/`status`/bare `status` still exit 2
- `TestClearReportsTheLocationWhenTheConfigCannotBeParsed` — unparseable YAML, plus `--state-dir` still exact
- `TestClearIsSilentOnAValidConfig` — the happy path stays quiet
- `TestParse_DoesNotValidate` / `_RejectsMalformedYAML` / `_MissingFileIsEmpty`
- `e2e.sh`: new `#77` section — 170 PASS / 0 FAIL overall

Mutation-tested; all five caught, including reverting `clear` to `config.Load` (the original bug), making `Parse` validate, dropping the stderr report, ignoring `state_dir`, and making `Load` stop validating.

## Verification

`go build` / `go vet` / `go test ./...` clean; `make lint` → 0 issues; `e2e.sh` 170 PASS / 0 FAIL. `clear --help` states the behavior; README gains a CLI-reference note and an FAQ entry; CLAUDE.md gains the underlying principle — *a command's preconditions are the ones it actually has*.