### PR TITLE
chore: make the main-branch guard match compound commands

### DIFF
--- a/.claude/hooks/guard-main-branch.sh
+++ b/.claude/hooks/guard-main-branch.sh
@@ -20,10 +20,19 @@ set -u
 input=$(cat)
 command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
 
-case "$command" in
-  "git commit"*|"git push"*|"git merge"*|"git rebase"*) ;;
-  *) exit 0 ;;
-esac
+# Matched anywhere in the command, not only at the start: these arrive
+# inside a compound far more often than alone
+# (`git add -A && git commit ...`), and a prefix-only match let exactly
+# that through once. The global-option run covers `git -C <dir> commit`
+# and `git -c k=v commit`, which is how the mistake reaches a repo the
+# shell is not sitting in -- the situation that caused it. Requiring a
+# word boundary after the verb keeps read-only lookalikes out
+# (`git merge-tree`), and anchoring the left side keeps `mygit commit`
+# and `git log --grep commit` out.
+git_write_verb='(^|[^[:alnum:]_./-])git(( +-[cC] +[^ ]+)|( +--[a-z][a-z-]*(=[^ ]+)?)|( +-[a-zA-Z]))* +(commit|push|merge|rebase)([[:space:]]|$)'
+if ! printf '%s' "$command" | grep -Eq "$git_write_verb"; then
+  exit 0
+fi
 
 cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,12 @@ message to a temp file first sidesteps all shell escaping.
   mistake, which the project's branch-protection rule catches at
   push time but only after the commit has already landed locally
   (expensive to unwind). Exits 2 with a message pointing at the fix
-  (`git checkout -b <feature-branch>`).
+  (`git checkout -b <feature-branch>`). Matches the verb anywhere in
+  the command, not just at the start: these almost always arrive
+  inside a compound (`git add -A && git commit ...`), and a
+  prefix-only match let exactly that through once. Global options are
+  matched too (`git -C <dir> commit`), since operating on the repo
+  from another cwd is how the mistake happens in the first place.
 - `hooks/e2e-pre-merge.sh` is a PreToolUse hook on Bash: before any
   `gh pr merge ...` it runs `.claude/scripts/e2e.sh` (the full
   black-box CLI smoke), wrapped in `markgate run` so unchanged


### PR DESCRIPTION
## Problem

`guard-main-branch.sh` matched `"git commit"*` as a **prefix**, so it only fired when the command *started* with the verb. In practice they arrive inside a compound far more often:

```sh
git add -A && git status --short && cat > msg <<EOF
...
EOF
git commit -F msg && git push -u origin <branch>
```

That is the shape that slipped through while working #77 and put a commit on `main` — exactly the mistake this hook exists to prevent. The push was rejected by branch protection so unwinding was cheap (`git branch <name>`, `git branch -f main origin/main`), but that is luck rather than design: the hook's stated job is to catch it *before* the commit lands.

## Fix

Match the verb anywhere in the command. A required trailing space (or end of string) keeps read-only lookalikes out — `git merge-tree`, which is how you ask whether two refs would conflict, was previously caught by the `git merge`* prefix and is now correctly ignored.

## Verification

Driven directly with the hook's stdin contract:

| command | on a feature branch | on `main` |
|---|---|---|
| `git commit -m x` | 0 | **2** |
| `git add -A && git commit -m x` | 0 | **2** |
| the heredoc compound above | 0 | **2** |
| `git push` | 0 | **2** |
| `git merge-tree a b c` | 0 | 0 *(was 2 — false positive)* |
| `git status`, `echo done` | 0 | 0 |

No behavior change on feature branches. CLAUDE.md's description of the hook updated to say it matches anywhere and why.