### PR TITLE
chore: stop the main-branch guard blocking file writes

### DIFF
--- a/.claude/hooks/guard-main-branch.sh
+++ b/.claude/hooks/guard-main-branch.sh
@@ -29,8 +29,50 @@ command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
 # word boundary after the verb keeps read-only lookalikes out
 # (`git merge-tree`), and anchoring the left side keeps `mygit commit`
 # and `git log --grep commit` out.
+# Heredoc bodies are data, not commands: the outer shell never executes
+# them, so a script that merely CONTAINS `git commit` -- e2e.sh seeds
+# sandbox repos and has eight of them -- must not be mistaken for one
+# that runs it. Excised before matching, keeping the line that opens the
+# heredoc since it can carry a real command before the `<<`.
+#
+# Quoted strings deliberately get no such treatment: `bash -c "git
+# commit -m x"` is a real commit, so stripping quoted regions would turn
+# a block into a miss. The asymmetry is the point -- a heredoc body
+# cannot be a command, a quoted string can.
+strip_heredocs() {
+  awk '
+    inbody {
+      body = $0
+      sub(/^[[:space:]]+/, "", body)
+      if (body == delim) { inbody = 0 }
+      next
+    }
+    {
+      print
+      line = $0
+      while (match(line, /<<-?[[:space:]]*("[^"]+"|'"'"'[^'"'"']+'"'"'|[A-Za-z_][A-Za-z0-9_]*)/)) {
+        d = substr(line, RSTART, RLENGTH)
+        sub(/^<<-?[[:space:]]*/, "", d)
+        gsub(/["'"'"']/, "", d)
+        delim = d
+        inbody = 1
+        line = substr(line, RSTART + RLENGTH)
+      }
+    }
+  '
+}
+
+# Matched anywhere in the command, not only at the start: these arrive
+# inside a compound far more often than alone
+# (`git add -A && git commit ...`), and a prefix-only match let exactly
+# that through once. The global-option run covers `git -C <dir> commit`
+# and `git -c k=v commit`, which is how the mistake reaches a repo the
+# shell is not sitting in -- the situation that caused it. Requiring a
+# word boundary after the verb keeps read-only lookalikes out
+# (`git merge-tree`), and anchoring the left side keeps `mygit commit`
+# and `git log --grep commit` out.
 git_write_verb='(^|[^[:alnum:]_./-])git(( +-[cC] +[^ ]+)|( +--[a-z][a-z-]*(=[^ ]+)?)|( +-[a-zA-Z]))* +(commit|push|merge|rebase)([[:space:]]|$)'
-if ! printf '%s' "$command" | grep -Eq "$git_write_verb"; then
+if ! printf '%s' "$command" | strip_heredocs | grep -Eq "$git_write_verb"; then
   exit 0
 fi
 

--- a/.claude/hooks/guard-main-branch.test.sh
+++ b/.claude/hooks/guard-main-branch.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Test matrix for guard-main-branch.sh.
+#
+# The hook has failed twice in both directions: it missed `git add -A &&
+# git commit` (a prefix-only match, #80) and it blocked writing a file
+# that merely contained a git command (a heredoc body, #81). Both are
+# silent -- a miss lets a commit onto main, a false positive trains the
+# reader to route around the guard -- so the matrix asserts BOTH
+# directions rather than only the case that last went wrong.
+#
+# Usage: bash .claude/hooks/guard-main-branch.test.sh
+# Exit code = number of failures.
+
+set -u
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/guard-main-branch.sh"
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+REPO="$SANDBOX/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q -b main
+git -C "$REPO" config user.email t@e
+git -C "$REPO" config user.name T
+: > "$REPO/seed"
+git -C "$REPO" add -A
+git -C "$REPO" -c commit.gpgsign=false commit -qm init
+git -C "$REPO" branch -q feat
+
+PASS=0
+FAIL=0
+
+# The verb is assembled rather than written, so this file does not trip
+# the very hook it tests when an agent edits it from main.
+V="com""mit"
+
+# want=2 means "must refuse", want=0 means "must allow".
+check() {
+  local label="$1" want="$2" cmd="$3"
+  local payload
+  payload=$(CMD="$cmd" python3 -c 'import json,os;print(json.dumps({"tool_input":{"command":os.environ["CMD"]}}))')
+  printf '%s' "$payload" | CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1)); printf '  PASS  %s\n' "$label"
+  else
+    FAIL=$((FAIL+1)); printf '  FAIL  %s (want exit %s, got %s)\n' "$label" "$want" "$got"
+  fi
+}
+
+git -C "$REPO" checkout -q main
+echo "=== on main: writes must be refused ==="
+check "plain"                       2 "git $V -m x"
+check "compound (the #80 miss)"     2 "git add -A && git $V -m x"
+check "git -C <dir>"                2 "git -C /repo $V -m x"
+check "git -c k=v"                  2 "git -c user.name=x $V"
+check "extra spaces"                2 "git   $V"
+check "push / merge / rebase"       2 "git push && git merge main && git rebase -i"
+# A quoted string CAN be a real command, so it must stay refused. This is
+# the case that makes stripping quotes -- unlike heredoc bodies -- unsafe.
+check "real commit inside quotes"   2 "bash -c \"git $V -m x\""
+check "real commit after a heredoc" 2 "$(printf 'cat > f <<%sEOF%s\nhi\nEOF\ngit %s -m x' "'" "'" "$V")"
+check "real commit USING a heredoc" 2 "$(printf 'git %s -F - <<%sEOF%s\nmsg\nEOF' "$V" "'" "'")"
+
+echo "=== on main: non-writes must be allowed ==="
+check "writing a script that contains one (the #81 false positive)" 0 \
+  "$(printf 'cat > e2e.sh <<%sEOF%s\nnew_repo() {\n  git init -q\n  git add . && git %s -qm init\n}\nEOF' "'" "'" "$V")"
+check "heredoc, double-quoted delimiter" 0 "$(printf 'cat > f <<"SH"\ngit %s -m x\nSH' "$V")"
+check "heredoc, bare delimiter"          0 "$(printf 'cat > f <<SH\ngit %s -m x\nSH' "$V")"
+check "heredoc, <<- form"                0 "$(printf 'cat > f <<-SH\n\tgit %s -m x\n\tSH' "$V")"
+check "two heredocs in one command"      0 "$(printf 'cat > a <<%sA%s\ngit %s x\nA\ncat > b <<%sB%s\ngit push\nB' "'" "'" "$V" "'" "'")"
+check "git merge-tree (read-only)"       0 "git merge-tree a b"
+check "git log --grep"                   0 "git log --grep $V"
+check "not git at all"                   0 "mygit $V; git-foo $V; echo done"
+
+echo "=== on a feature branch: everything allowed ==="
+git -C "$REPO" checkout -q feat
+check "plain"    0 "git $V -m x"
+check "compound" 0 "git add -A && git $V -m x"
+check "push"     0 "git push"
+
+echo
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+exit "$FAIL"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,21 @@ message to a temp file first sidesteps all shell escaping.
   prefix-only match let exactly that through once. Global options are
   matched too (`git -C <dir> commit`), since operating on the repo
   from another cwd is how the mistake happens in the first place.
+  Heredoc bodies are excised first, so writing a script that merely
+  *contains* a git command is not mistaken for running one —
+  `scripts/e2e.sh` has eight of them. Quoted strings deliberately are
+  not excised: `bash -c "git commit"` is a real commit, so a heredoc
+  body (which the shell can never execute) and a quoted string (which
+  it can) are not the same case.
+- `hooks/guard-main-branch.test.sh` is the matrix for the above. Run
+  it after touching that hook: `bash
+  .claude/hooks/guard-main-branch.test.sh` (exit code = failures).
+  It asserts **both** directions, because the hook has failed in both
+  — once missing a real commit, once blocking a file write — and each
+  failure is silent in its own way: a miss puts a commit on `main`, a
+  false positive teaches the reader to route around the guard. Adding
+  a case to only the direction that last broke is how the other one
+  comes back.
 - `hooks/e2e-pre-merge.sh` is a PreToolUse hook on Bash: before any
   `gh pr merge ...` it runs `.claude/scripts/e2e.sh` (the full
   black-box CLI smoke), wrapped in `markgate run` so unchanged


### PR DESCRIPTION
Closes #81

## Problem

#80 made the guard match the git verb anywhere in the command, fixing the miss that put a commit on `main`. But the command text includes **heredoc bodies**, so writing a script that merely *contains* a git command became indistinguishable from running one:

```sh
cat > .claude/scripts/e2e.sh <<'EOF'
  git add . && git commit -qm init      # seeds a sandbox repo
EOF
```

`scripts/e2e.sh` has **eight** of those, so any session rewriting it from `main` was blocked. Hit three times within an hour of #80 merging — including once while trying to *measure* the problem.

## Fix

Heredoc bodies are excised before matching. The line that **opens** the heredoc is kept, since it can carry a real command before the `<<` — `git commit -F - <<'EOF'` still refuses.

**Quoted strings deliberately get no such treatment.** `bash -c "git commit -m x"` is a real commit, so stripping quoted regions would turn a block into a miss. A heredoc body cannot be executed by the outer shell; a quoted string can. That asymmetry is the whole fix — "strip anything that looks like data" would have been wrong.

## A test matrix, checked in

`guard-main-branch.test.sh`, 20 cases, asserting **both** directions. The hook has now failed in both — missing a real commit (#80), blocking a file write (#81) — and each failure is silent in its own way: a miss puts a commit on `main`; a false positive teaches the reader to route around the guard, which is how guards stop being read at all. A matrix that only grows in the direction that last broke is how the other one comes back.

Verified by mutation:

| regression | failing checks |
|---|---|
| revert to the prefix-only match (#80's bug) | 2 |
| drop the heredoc strip (#81's bug) | 5 |
| also strip quoted strings | 1 — the `bash -c` case |

## Note on the reporting

I initially judged two occurrences "too few to file". That was wrong, and I said so on #81: the rate was 2 out of 2 opportunities, the mechanism was already understood rather than awaiting more samples, and #74 / #75 / #77 were each filed off a single observation in the same session. The real reason was reluctance to flag a problem with a change I had just authored.