### PR TITLE
chore: record what this session kept paying for — audit lessons, and that merging is not shipping

### DIFF
--- a/.claude/skills/audit-before-done/SKILL.md
+++ b/.claude/skills/audit-before-done/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-before-done
-description: Pre-push / pre-done-declaration discipline for markgate. Covers implementation anti-patterns (no churn, no silent deletion), a widened proactive audit (grep every introduced name, check --help output, smoke the built binary, run make lint — go vet is not enough), and the post-merge manual smoke pattern. Use whenever you're about to say "done", mark a task complete, push a branch, create a PR, or ask for merge. Companion to `iterate-design`, which covers the pre-code design phase.
+description: Pre-push / pre-done-declaration discipline for markgate. Covers implementation anti-patterns (no churn, no silent deletion), a widened proactive audit (grep every introduced name, check --help output, smoke the built binary, mutation-test every check you add, run make lint — go vet is not enough), why a self-audit is not a review, and the post-merge manual smoke pattern. Use whenever you're about to say "done", mark a task complete, push a branch, create a PR, or ask for merge. Companion to `iterate-design`, which covers the pre-code design phase.
 ---
 
 # audit-before-done
@@ -85,11 +85,55 @@ lens:
 - Cross-check claims that point at other sections: if the Why
   section says "four passes, one change", are all four passes
   actually wired up, or is one of them aspirational?
+- **Delete each check you added and confirm a test fails.** A suite
+  that stays green without your check is not protecting it. Over one
+  session that was true of eight checks, one of which reintroduced
+  the very bug its PR closed while `go test ./...` and the e2e smoke
+  both stayed green. Do it on a copy
+  (`git archive HEAD | tar -x -C /tmp/...`), never the worktree.
+  The same pass catches assertions that never reach the code they
+  name — a test calling `Scope` when the check lives in `Hash`, an
+  exit-code assertion on a flag the command does not register, a
+  fixture seeded *after* the precondition broke so the file never
+  existed. Three separate cases in that session, all invisible until
+  the mutation. Mutate in both directions when the change has one:
+  a guard that must fire, and must not fire on the legitimate case.
 
 Report the result — "no gaps after N checks" or "one stale link,
 fixing" — in the same message that announces completion. If the
 user then finds something the audit missed, that's a signal the
 checklist above needs a new entry.
+
+## A self-audit is not a review
+
+Phase 4 is a *self*-audit, and it keeps growing because self-audits
+keep coming back clean while something is still wrong. Over one
+session it reported "no gaps" five times; an independent reviewer
+found a real defect all five, including a blocker that broke the
+exact workflow the README recommends.
+
+So for anything that changes behavior, get an independent review
+before asking for merge — a subagent with `isolation: "worktree"`,
+briefed to *verify claims by running things* rather than read the
+diff, and told the author judged its own work. Hand it the failure
+modes to hunt, not a summary of what you did.
+
+Two things make the difference, and neither is available to you on
+your own work:
+
+- It re-derives your claims instead of checking them off. Numbers in
+  a PR body are claims: a "142ms -> 58ms" in that session came from
+  a different fixture and did not reproduce.
+- It has no stake in the design holding, so it probes the case you
+  had already decided was fine. That is where the blocker was — a
+  scope that empties out *after* a marker exists, which the
+  bootstrapping test covered only in the no-marker half.
+
+The bar for filing what it finds does not move because you wrote the
+code. Having just authored something is a reason to file, not to
+wait for more occurrences — "only twice so far" was used to defer a
+report in that session and was wrong on the numbers (twice out of
+two opportunities, mechanism already understood).
 
 ## Mirror what CI runs, locally
 
@@ -112,6 +156,13 @@ rate — shadow declarations, unused variables, unchecked errors,
 and format-string mismatches. If you only ran `go test && go vet`
 and `make lint` is still unproven, the CI run is the audit, which
 is too late.
+
+CI also validates the **PR title**
+(`amannn/action-semantic-pull-request`): the type comes from a fixed
+list, and the scope from an allowlist of `internal/` package names
+(`cli`, `config`, `gitutil`, `hasher`, `key`, `state`, plus `deps`
+and `run`). A change under `.claude/` has no matching scope — use
+no scope rather than inventing one. `chore(hooks):` fails.
 
 ## Post-merge: manual smoke
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,35 @@ detection, ineffassign, unused-variable, format-string checks, and
 more that `go vet` alone misses. If only `go vet` passed, CI is your
 audit — which is too late.
 
+## Releasing (merging to main is not shipping)
+
+`tagpr` keeps a release PR open against `main` ("Release for vX.Y.Z"),
+accumulating every merge into a CHANGELOG entry. **Merging that PR is
+what ships**: it tags the merge commit, and `.github/actions/release`
+then builds the cross-platform archives, attaches them plus
+`checksums.txt`, takes the GitHub release out of draft, and updates
+the Homebrew tap.
+
+Until that happens the work does not exist for anyone consuming
+markgate — a downstream repo pinned to a released version sees
+nothing. So **a task that exists because a consumer needs a behavior
+is not done at merge; it is done at release.** Treat the release PR
+as part of the task, not as unrelated repo upkeep. (That framing
+error is exactly how a release got classified out-of-session once:
+by its mechanism — "it's a tagpr PR" — rather than by the goal.)
+
+Version: patch by default. The `Lint PR` workflow adds
+`minor-release` for a `feat:` title, and `.tagpr` reads
+`minorLabels` / `majorLabels`, so a new feature bumps the minor
+automatically. Nothing to do by hand unless you want to override.
+
+After merging the release PR, confirm it actually shipped rather than
+assuming: the workflow can succeed while the release is still a draft
+with no assets. Check `isDraft: false` and a non-empty asset list,
+then download the built archive and smoke it — that is the only test
+of the artifact users receive, and it is a different artifact from
+the one `go test` and `e2e.sh` exercise.
+
 ## Style
 
 - **No comments that describe *what* the code does.** Identifier names


### PR DESCRIPTION
Both are things Phase 4 already gestured at and neither caught.

## Mutation-test every check you add

Eight checks over one session survived deletion with `go test ./...` **and** `e2e.sh` fully green — including one whose removal reintroduced the exact bug its PR closed (#70's dead-include fail-open, via the directory filter in the candidate walk).

The same pass catches assertions that never reach the code they name. Three separate cases in that session:

| test | why it asserted nothing |
|---|---|
| called `Scope` | the check lives in `Hash` |
| asserted exit 2 on `set --explain` | `set` never registered `--explain`, so 2 came from *unknown flag* |
| `assert_absent` on an override marker | seeded *after* the config broke, so `set` failed and the file never existed |

All three passed on `main` too. Mutation testing surfaced each in seconds.

## A self-audit is not a review

Phase 4 says *"don't settle for 'no gaps' from a superficial check"* and then asks you to widen your own lens. Empirically that is not what worked: over that session the self-audit reported "no gaps" **five times**, and an independent reviewer found a real defect **all five**, including a blocker that broke the exact workflow the README recommends.

What made the difference was not a longer checklist. It was a reader who:

- **re-derived the claims** rather than checking them off — a "142ms → 58ms" in a PR body came from a different fixture and did not reproduce;
- **had no stake in the design holding**, so it probed the case already judged fine. That is where the blocker was: a scope that empties out *after* a marker exists, which the bootstrapping test covered only in the no-marker half.

Neither is available to you on your own work, which is why this is a section rather than another bullet.

It also records that the bar for filing does not move because you wrote the code — *"only twice so far"* was used to defer a report in that session and was wrong on the numbers (twice out of two opportunities, mechanism already understood).

## Plus one cheap thing

CI validates the PR **title**, and its scope allowlist is `internal/` package names. A `.claude/` change takes no scope — `chore(hooks):` fails. Cost one red check to learn.

No behavior change; docs only. The hook test matrix still passes.